### PR TITLE
feat: meal templates with favorites quick-add

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Schautrack is built to stay out of your way. Log calories and macros, set goals,
 ## Features
 
 - Log calories and macros (protein, carbs, fat, fiber, sugar)
+- Meal templates with a favorites Quick-Add bar — log recurring meals with one tap
 - Daily goals with color-coded progress tracking
 - AI-powered nutrition estimation from food photos (OpenAI, Claude, or Ollama)
 - Barcode scanning via OpenFoodFacts

--- a/client/src/api/templates.ts
+++ b/client/src/api/templates.ts
@@ -1,0 +1,39 @@
+import { api } from './client';
+import type { MealTemplate, MealTemplateInput } from '@/types';
+
+export function listTemplates(favoritesOnly = false) {
+  const qs = favoritesOnly ? '?favorites=true' : '';
+  return api<{ ok: boolean; templates: MealTemplate[] }>(`/api/templates${qs}`);
+}
+
+export function createTemplate(data: MealTemplateInput) {
+  return api<{ ok: boolean; id: number }>('/templates', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export function updateTemplate(id: number, data: MealTemplateInput) {
+  return api<{ ok: boolean }>(`/templates/${id}/update`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteTemplate(id: number) {
+  return api<{ ok: boolean }>(`/templates/${id}/delete`, { method: 'POST' });
+}
+
+export function toggleTemplateFavorite(id: number, isFavorite?: boolean) {
+  return api<{ ok: boolean; is_favorite: boolean }>(`/templates/${id}/favorite`, {
+    method: 'POST',
+    body: isFavorite === undefined ? undefined : JSON.stringify({ is_favorite: isFavorite }),
+  });
+}
+
+export function applyTemplate(id: number, day?: string) {
+  const qs = day ? `?day=${encodeURIComponent(day)}` : '';
+  return api<{ ok: boolean; count: number; day: string }>(`/templates/${id}/apply${qs}`, {
+    method: 'POST',
+  });
+}

--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -68,6 +68,9 @@ export default function Header() {
               <Link to="/dashboard" onClick={() => setMenuOpen(false)} className={navClass('/dashboard')}>
                 Dashboard
               </Link>
+              <Link to="/templates" onClick={() => setMenuOpen(false)} className={navClass('/templates')}>
+                Templates
+              </Link>
               <Link to="/settings" onClick={() => setMenuOpen(false)} className={cn(navClass('/settings'), 'relative')}>
                 Settings
                 {pendingLinkRequests > 0 && (

--- a/client/src/hooks/useSSE.ts
+++ b/client/src/hooks/useSSE.ts
@@ -55,6 +55,10 @@ export function useSSE() {
         queryClient.invalidateQueries({ queryKey: ['note'] });
       });
 
+      source.addEventListener('template-change', () => {
+        queryClient.invalidateQueries({ queryKey: ['templates'] });
+      });
+
       source.onopen = () => {
         retryDelayRef.current = 2000;
       };

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -12,6 +12,8 @@ import EntryList from './EntryList';
 import WeightRow from './WeightRow';
 import TodoList from './TodoList';
 import NoteEditor from './NoteEditor';
+import FavoritesBar from './FavoritesBar';
+import SaveTodayAsTemplateButton from './SaveTodayAsTemplateButton';
 
 export default function Dashboard() {
   const { user, isLoading: authLoading } = useRequireAuth();
@@ -111,6 +113,8 @@ export default function Dashboard() {
         todayStr={dashboard.todayStr}
       />
 
+      {canEdit && <FavoritesBar selectedDate={selectedDate} canEdit={canEdit} />}
+
       {canEdit && (
         <EntryForm
           selectedDate={selectedDate}
@@ -153,9 +157,17 @@ export default function Dashboard() {
       )}
 
       <div className="rounded-xl border-2 border-border bg-card overflow-hidden">
-        <div className="px-4 py-3 border-b-2 border-border flex items-center justify-between">
+        <div className="px-4 py-3 border-b-2 border-border flex items-center justify-between gap-2 flex-wrap">
           <h3 className="text-sm font-medium text-muted-foreground">Entries</h3>
-          <span className="text-sm text-muted-foreground">{selectedDate} &mdash; {currentLabel}</span>
+          <div className="flex items-center gap-3">
+            {canEdit && (
+              <SaveTodayAsTemplateButton
+                entries={dayData?.entries || []}
+                selectedDate={selectedDate}
+              />
+            )}
+            <span className="text-sm text-muted-foreground">{selectedDate} &mdash; {currentLabel}</span>
+          </div>
         </div>
 
         <EntryList

--- a/client/src/pages/Dashboard/EntryList.tsx
+++ b/client/src/pages/Dashboard/EntryList.tsx
@@ -5,6 +5,19 @@ import { useQueryClient } from '@tanstack/react-query';
 import { MACRO_LABELS } from '@/lib/macros';
 import { cn } from '@/lib/utils';
 import { useToastStore } from '@/stores/toastStore';
+import TemplateEditor from '../Templates/TemplateEditor';
+
+function entryToEditorItem(entry: Entry) {
+  return {
+    entry_name: entry.name || '',
+    amount: entry.amount === 0 ? '' : String(entry.amount),
+    protein_g: entry.macros?.protein != null ? String(entry.macros.protein) : '',
+    carbs_g: entry.macros?.carbs != null ? String(entry.macros.carbs) : '',
+    fat_g: entry.macros?.fat != null ? String(entry.macros.fat) : '',
+    fiber_g: entry.macros?.fiber != null ? String(entry.macros.fiber) : '',
+    sugar_g: entry.macros?.sugar != null ? String(entry.macros.sugar) : '',
+  };
+}
 
 const MACRO_STYLES: Record<string, { bg: string; border: string; label: string }> = {
   kcal:    { bg: 'bg-macro-kcal/10',    border: 'border-macro-kcal/20',    label: 'text-macro-kcal/70' },
@@ -60,7 +73,9 @@ function EntryRow({ entry, canEdit, enabledMacros, caloriesEnabled, autoCalcCalo
 }) {
   const [editing, setEditing] = useState<string | null>(null);
   const [editValue, setEditValue] = useState('');
+  const [saveAsTemplate, setSaveAsTemplate] = useState(false);
   const addToast = useToastStore((s) => s.addToast);
+  const queryClient = useQueryClient();
 
   const handleEdit = (field: string, currentValue: string | number | null) => {
     if (!canEdit) return;
@@ -129,11 +144,23 @@ function EntryRow({ entry, canEdit, enabledMacros, caloriesEnabled, autoCalcCalo
         </span>
         <span className="text-xs text-muted-foreground tabular-nums shrink-0 opacity-85">{entry.time}</span>
         {canEdit && (
-          <button type="button" className="size-7 flex items-center justify-center rounded-[10px] border border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors cursor-pointer shrink-0" onClick={handleDelete} title="Delete">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M18 6L6 18" /><path d="M6 6l12 12" />
-            </svg>
-          </button>
+          <>
+            <button
+              type="button"
+              className="size-7 flex items-center justify-center rounded-[10px] border border-[#f59e0b]/30 bg-[#f59e0b]/10 text-[#f59e0b] hover:bg-[#f59e0b]/20 transition-colors cursor-pointer shrink-0"
+              onClick={() => setSaveAsTemplate(true)}
+              title="Save as template"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+              </svg>
+            </button>
+            <button type="button" className="size-7 flex items-center justify-center rounded-[10px] border border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors cursor-pointer shrink-0" onClick={handleDelete} title="Delete">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 6L6 18" /><path d="M6 6l12 12" />
+              </svg>
+            </button>
+          </>
         )}
       </div>
 
@@ -177,6 +204,20 @@ function EntryRow({ entry, canEdit, enabledMacros, caloriesEnabled, autoCalcCalo
             );
           })}
         </div>
+      )}
+
+      {saveAsTemplate && (
+        <TemplateEditor
+          isOpen
+          template={null}
+          presetItems={[entryToEditorItem(entry)]}
+          presetName={entry.name || ''}
+          onClose={() => setSaveAsTemplate(false)}
+          onSaved={() => {
+            queryClient.invalidateQueries({ queryKey: ['templates'] });
+            setSaveAsTemplate(false);
+          }}
+        />
       )}
     </div>
   );

--- a/client/src/pages/Dashboard/FavoritesBar.tsx
+++ b/client/src/pages/Dashboard/FavoritesBar.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { applyTemplate, listTemplates } from '@/api/templates';
+import { useToastStore } from '@/stores/toastStore';
+
+interface Props {
+  selectedDate: string;
+  canEdit: boolean;
+}
+
+export default function FavoritesBar({ selectedDate, canEdit }: Props) {
+  const addToast = useToastStore((s) => s.addToast);
+  const queryClient = useQueryClient();
+  const [pendingId, setPendingId] = useState<number | null>(null);
+
+  const { data } = useQuery({
+    queryKey: ['templates'],
+    queryFn: () => listTemplates(false),
+    enabled: canEdit,
+  });
+
+  const applyMutation = useMutation({
+    mutationFn: (id: number) => applyTemplate(id, selectedDate),
+    onMutate: (id) => setPendingId(id),
+    onSettled: () => setPendingId(null),
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+      queryClient.invalidateQueries({ queryKey: ['day-entries'] });
+      addToast('success', `Added ${res.count} entr${res.count === 1 ? 'y' : 'ies'}`);
+    },
+    onError: (err: Error) => addToast('error', err.message || 'Failed to apply'),
+  });
+
+  if (!canEdit) return null;
+
+  const favorites = (data?.templates ?? []).filter((t) => t.is_favorite);
+  const hasTemplates = (data?.templates ?? []).length > 0;
+
+  // If there are no templates at all, don't render the bar (avoid noise on empty setups).
+  if (!hasTemplates) return null;
+
+  return (
+    <div className="rounded-xl border-2 border-border bg-card overflow-hidden">
+      <div className="px-4 py-2 border-b-2 border-border flex items-center justify-between">
+        <h3 className="text-sm font-medium text-muted-foreground">Quick add</h3>
+        <Link to="/templates" className="text-xs text-muted-foreground hover:text-foreground">
+          Manage
+        </Link>
+      </div>
+      <div className="px-4 py-3 flex flex-wrap gap-2">
+        {favorites.length === 0 ? (
+          <span className="text-xs text-muted-foreground">
+            Star a template to pin it here.
+          </span>
+        ) : (
+          favorites.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => applyMutation.mutate(t.id)}
+              disabled={pendingId === t.id || !selectedDate}
+              title={`Add ${t.items.length} entr${t.items.length === 1 ? 'y' : 'ies'} to ${selectedDate}`}
+              className="inline-flex items-center gap-1.5 rounded-full border border-[#f59e0b]/40 bg-[#f59e0b]/[0.07] px-3 py-1 text-xs text-foreground hover:bg-[#f59e0b]/[0.13] hover:border-[#f59e0b]/70 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-colors"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="#f59e0b" stroke="#f59e0b" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+              </svg>
+              <span className="truncate max-w-[160px]">{t.name}</span>
+              {pendingId === t.id && <span className="text-muted-foreground">…</span>}
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Dashboard/SaveTodayAsTemplateButton.tsx
+++ b/client/src/pages/Dashboard/SaveTodayAsTemplateButton.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import TemplateEditor from '../Templates/TemplateEditor';
+import type { Entry } from '@/types';
+
+interface Props {
+  entries: Entry[];
+  selectedDate: string;
+}
+
+function entriesToPreset(entries: Entry[]) {
+  return entries.map((e) => ({
+    entry_name: e.name || '',
+    amount: e.amount === 0 ? '' : String(e.amount),
+    protein_g: e.macros?.protein != null ? String(e.macros.protein) : '',
+    carbs_g: e.macros?.carbs != null ? String(e.macros.carbs) : '',
+    fat_g: e.macros?.fat != null ? String(e.macros.fat) : '',
+    fiber_g: e.macros?.fiber != null ? String(e.macros.fiber) : '',
+    sugar_g: e.macros?.sugar != null ? String(e.macros.sugar) : '',
+  }));
+}
+
+export default function SaveTodayAsTemplateButton({ entries, selectedDate }: Props) {
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+
+  const disabled = entries.length === 0;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={disabled}
+        title={disabled ? 'Track entries first, then save them as a template' : 'Save these entries as a reusable template'}
+        className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+      >
+        Save as template
+      </button>
+      {open && (
+        <TemplateEditor
+          isOpen
+          template={null}
+          presetItems={entriesToPreset(entries)}
+          presetName={`Entries from ${selectedDate}`}
+          onClose={() => setOpen(false)}
+          onSaved={() => {
+            queryClient.invalidateQueries({ queryKey: ['templates'] });
+            setOpen(false);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/client/src/pages/Templates/TemplateEditor.tsx
+++ b/client/src/pages/Templates/TemplateEditor.tsx
@@ -1,0 +1,313 @@
+import { useEffect, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { createTemplate, updateTemplate } from '@/api/templates';
+import { Button } from '@/components/ui/Button';
+import { useToastStore } from '@/stores/toastStore';
+import type { MealTemplate, MealTemplateItemInput } from '@/types';
+
+interface EditorItem {
+  entry_name: string;
+  amount: string;
+  protein_g: string;
+  carbs_g: string;
+  fat_g: string;
+  fiber_g: string;
+  sugar_g: string;
+}
+
+const EMPTY_ITEM: EditorItem = {
+  entry_name: '',
+  amount: '',
+  protein_g: '',
+  carbs_g: '',
+  fat_g: '',
+  fiber_g: '',
+  sugar_g: '',
+};
+
+function toEditorItem(it: {
+  entry_name?: string | null;
+  amount: number;
+  protein_g?: number | null;
+  carbs_g?: number | null;
+  fat_g?: number | null;
+  fiber_g?: number | null;
+  sugar_g?: number | null;
+}): EditorItem {
+  const toStr = (n: number | null | undefined) => (n == null ? '' : String(n));
+  return {
+    entry_name: it.entry_name || '',
+    amount: it.amount === 0 ? '' : String(it.amount),
+    protein_g: toStr(it.protein_g),
+    carbs_g: toStr(it.carbs_g),
+    fat_g: toStr(it.fat_g),
+    fiber_g: toStr(it.fiber_g),
+    sugar_g: toStr(it.sugar_g),
+  };
+}
+
+function parseOptionalInt(raw: string): number | null {
+  const t = raw.trim();
+  if (t === '') return null;
+  const n = Number(t);
+  if (!Number.isFinite(n) || Math.round(n) !== n) return NaN;
+  return n;
+}
+
+interface Props {
+  isOpen: boolean;
+  template: MealTemplate | null;
+  presetItems?: EditorItem[];
+  presetName?: string;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export default function TemplateEditor({
+  isOpen,
+  template,
+  presetItems,
+  presetName,
+  onClose,
+  onSaved,
+}: Props) {
+  const addToast = useToastStore((s) => s.addToast);
+  const isEdit = !!template;
+
+  const [name, setName] = useState('');
+  const [isFavorite, setIsFavorite] = useState(false);
+  const [items, setItems] = useState<EditorItem[]>([{ ...EMPTY_ITEM }]);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (template) {
+      setName(template.name);
+      setIsFavorite(template.is_favorite);
+      setItems(template.items.length > 0 ? template.items.map(toEditorItem) : [{ ...EMPTY_ITEM }]);
+    } else {
+      setName(presetName ?? '');
+      setIsFavorite(false);
+      setItems(presetItems && presetItems.length > 0 ? presetItems : [{ ...EMPTY_ITEM }]);
+    }
+  }, [isOpen, template, presetName, presetItems]);
+
+  const setItem = (idx: number, patch: Partial<EditorItem>) => {
+    setItems((current) => current.map((it, i) => (i === idx ? { ...it, ...patch } : it)));
+  };
+
+  const addItem = () => setItems((current) => [...current, { ...EMPTY_ITEM }]);
+  const removeItem = (idx: number) =>
+    setItems((current) => (current.length <= 1 ? current : current.filter((_, i) => i !== idx)));
+
+  const handleSave = async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      addToast('error', 'Name is required');
+      return;
+    }
+
+    const payloadItems: MealTemplateItemInput[] = [];
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      const amountRaw = it.amount.trim();
+      const amount = amountRaw === '' ? 0 : Number(amountRaw);
+      if (amountRaw !== '' && (!Number.isFinite(amount) || Math.round(amount) !== amount)) {
+        addToast('error', `Item ${i + 1}: calories must be a whole number`);
+        return;
+      }
+
+      const macros: Record<string, number | null | undefined> = {};
+      const keys = ['protein_g', 'carbs_g', 'fat_g', 'fiber_g', 'sugar_g'] as const;
+      for (const k of keys) {
+        const parsed = parseOptionalInt(it[k]);
+        if (Number.isNaN(parsed)) {
+          addToast('error', `Item ${i + 1}: ${k} must be a whole number`);
+          return;
+        }
+        macros[k] = parsed === null ? undefined : parsed;
+      }
+
+      const hasContent =
+        amount !== 0 ||
+        it.entry_name.trim() !== '' ||
+        Object.values(macros).some((v) => v != null);
+      if (!hasContent) continue;
+
+      payloadItems.push({
+        entry_name: it.entry_name.trim() || null,
+        amount,
+        ...macros,
+      });
+    }
+
+    if (payloadItems.length === 0) {
+      addToast('error', 'Add at least one item with a name, calories, or macros');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const payload = { name: trimmedName, is_favorite: isFavorite, items: payloadItems };
+      if (isEdit && template) {
+        await updateTemplate(template.id, payload);
+        addToast('success', 'Template updated');
+      } else {
+        await createTemplate(payload);
+        addToast('success', 'Template created');
+      }
+      onSaved();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to save';
+      addToast('error', msg);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Content
+          className="fixed z-50 inset-x-3 top-1/2 -translate-y-1/2 mx-auto max-w-lg max-h-[90vh] overflow-y-auto rounded-xl border-2 border-border bg-card"
+          aria-describedby={undefined}
+        >
+          <div className="flex items-center justify-between px-4 py-3 border-b-2 border-border">
+            <Dialog.Title className="text-sm font-semibold text-foreground">
+              {isEdit ? 'Edit template' : 'New template'}
+            </Dialog.Title>
+            <Dialog.Close
+              className="size-8 flex items-center justify-center rounded-md border border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 cursor-pointer"
+              aria-label="Close"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 6L6 18" /><path d="M6 6l12 12" />
+              </svg>
+            </Dialog.Close>
+          </div>
+
+          <div className="flex flex-col gap-3 px-4 py-4">
+            <div className="flex flex-col gap-1">
+              <label htmlFor="template-name" className="text-xs font-medium text-muted-foreground">
+                Name
+              </label>
+              <input
+                id="template-name"
+                type="text"
+                className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Breakfast, post-workout, etc."
+                maxLength={100}
+              />
+            </div>
+
+            <label className="flex items-center gap-2 text-sm text-foreground cursor-pointer">
+              <input
+                type="checkbox"
+                checked={isFavorite}
+                onChange={(e) => setIsFavorite(e.target.checked)}
+                className="size-4 accent-[#f59e0b]"
+              />
+              Show in Dashboard Quick-Add
+            </label>
+
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium text-muted-foreground">Items</span>
+                <Button size="sm" variant="ghost" onClick={addItem} disabled={items.length >= 50}>
+                  + Add item
+                </Button>
+              </div>
+              {items.map((it, idx) => (
+                <div
+                  key={idx}
+                  className="rounded-md border border-border bg-card/40 px-3 py-2 flex flex-col gap-2"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-xs text-muted-foreground">Item {idx + 1}</span>
+                    {items.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => removeItem(idx)}
+                        className="text-xs text-destructive hover:underline cursor-pointer"
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </div>
+                  <input
+                    type="text"
+                    className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                    placeholder="Name (e.g. Oatmeal)"
+                    value={it.entry_name}
+                    maxLength={120}
+                    onChange={(e) => setItem(idx, { entry_name: e.target.value })}
+                  />
+                  <div className="grid grid-cols-3 gap-2">
+                    <input
+                      type="text"
+                      inputMode="tel"
+                      className="rounded-md border border-input bg-background px-2 py-2 text-sm text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                      placeholder="kcal"
+                      value={it.amount}
+                      onChange={(e) => setItem(idx, { amount: e.target.value })}
+                    />
+                    <input
+                      type="text"
+                      inputMode="tel"
+                      className="rounded-md border border-input bg-background px-2 py-2 text-sm text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                      placeholder="P (g)"
+                      value={it.protein_g}
+                      onChange={(e) => setItem(idx, { protein_g: e.target.value })}
+                    />
+                    <input
+                      type="text"
+                      inputMode="tel"
+                      className="rounded-md border border-input bg-background px-2 py-2 text-sm text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                      placeholder="C (g)"
+                      value={it.carbs_g}
+                      onChange={(e) => setItem(idx, { carbs_g: e.target.value })}
+                    />
+                    <input
+                      type="text"
+                      inputMode="tel"
+                      className="rounded-md border border-input bg-background px-2 py-2 text-sm text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                      placeholder="F (g)"
+                      value={it.fat_g}
+                      onChange={(e) => setItem(idx, { fat_g: e.target.value })}
+                    />
+                    <input
+                      type="text"
+                      inputMode="tel"
+                      className="rounded-md border border-input bg-background px-2 py-2 text-sm text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                      placeholder="Fi (g)"
+                      value={it.fiber_g}
+                      onChange={(e) => setItem(idx, { fiber_g: e.target.value })}
+                    />
+                    <input
+                      type="text"
+                      inputMode="tel"
+                      className="rounded-md border border-input bg-background px-2 py-2 text-sm text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                      placeholder="S (g)"
+                      value={it.sugar_g}
+                      onChange={(e) => setItem(idx, { sugar_g: e.target.value })}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-end gap-2 px-4 py-3 border-t-2 border-border bg-card/60">
+            <Button variant="ghost" onClick={onClose}>Cancel</Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving…' : isEdit ? 'Save' : 'Create'}
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/client/src/pages/Templates/Templates.tsx
+++ b/client/src/pages/Templates/Templates.tsx
@@ -1,0 +1,189 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRequireAuth } from '@/hooks/useAuth';
+import {
+  applyTemplate,
+  deleteTemplate,
+  listTemplates,
+  toggleTemplateFavorite,
+} from '@/api/templates';
+import { useDashboardStore } from '@/stores/dashboardStore';
+import { useToastStore } from '@/stores/toastStore';
+import { Button } from '@/components/ui/Button';
+import type { MealTemplate } from '@/types';
+import TemplateEditor from './TemplateEditor';
+
+export default function Templates() {
+  const { user, isLoading: authLoading } = useRequireAuth();
+  const addToast = useToastStore((s) => s.addToast);
+  const selectedDate = useDashboardStore((s) => s.selectedDate);
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['templates'],
+    queryFn: () => listTemplates(false),
+    enabled: !!user,
+  });
+
+  const [editing, setEditing] = useState<MealTemplate | null>(null);
+  const [creatingNew, setCreatingNew] = useState(false);
+  const [pendingId, setPendingId] = useState<number | null>(null);
+
+  const favoriteMutation = useMutation({
+    mutationFn: (t: MealTemplate) => toggleTemplateFavorite(t.id, !t.is_favorite),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['templates'] }),
+    onError: (err: Error) => addToast('error', err.message || 'Failed to update'),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteTemplate(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['templates'] });
+      addToast('success', 'Template deleted');
+    },
+    onError: (err: Error) => addToast('error', err.message || 'Failed to delete'),
+  });
+
+  const applyMutation = useMutation({
+    mutationFn: ({ id, day }: { id: number; day: string }) => applyTemplate(id, day),
+    onMutate: ({ id }) => setPendingId(id),
+    onSettled: () => setPendingId(null),
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+      queryClient.invalidateQueries({ queryKey: ['day-entries'] });
+      addToast('success', `Added ${res.count} entr${res.count === 1 ? 'y' : 'ies'}`);
+    },
+    onError: (err: Error) => addToast('error', err.message || 'Failed to apply'),
+  });
+
+  if (authLoading || isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="size-6 rounded-full border-2 border-primary border-t-transparent animate-spin" />
+      </div>
+    );
+  }
+
+  const templates = data?.templates ?? [];
+  const targetDay = selectedDate || '';
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold text-foreground">Meal templates</h1>
+        <Button onClick={() => setCreatingNew(true)}>New template</Button>
+      </div>
+
+      {templates.length === 0 ? (
+        <div className="rounded-xl border-2 border-dashed border-border bg-card/40 p-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            No templates yet. Save recurring meals and combinations to log them with one tap.
+          </p>
+          <div className="mt-4">
+            <Button onClick={() => setCreatingNew(true)}>Create your first template</Button>
+          </div>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {templates.map((t) => (
+            <li
+              key={t.id}
+              className="rounded-xl border-2 border-border bg-card overflow-hidden"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-3">
+                <div className="flex items-center gap-2 min-w-0">
+                  <button
+                    type="button"
+                    onClick={() => favoriteMutation.mutate(t)}
+                    className="size-8 shrink-0 flex items-center justify-center rounded-md hover:bg-white/5 transition-colors cursor-pointer"
+                    title={t.is_favorite ? 'Unstar' : 'Star as favorite'}
+                    aria-label={t.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
+                  >
+                    <svg
+                      width="18"
+                      height="18"
+                      viewBox="0 0 24 24"
+                      fill={t.is_favorite ? '#f59e0b' : 'none'}
+                      stroke={t.is_favorite ? '#f59e0b' : 'currentColor'}
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+                    </svg>
+                  </button>
+                  <div className="flex flex-col min-w-0">
+                    <span className="text-sm font-medium text-foreground truncate">{t.name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {t.items.length} item{t.items.length === 1 ? '' : 's'}
+                      {' · '}
+                      {t.items.reduce((sum, it) => sum + (it.amount || 0), 0)} kcal
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    onClick={() => applyMutation.mutate({ id: t.id, day: targetDay })}
+                    disabled={pendingId === t.id || !targetDay}
+                    title={targetDay ? `Apply to ${targetDay}` : 'Open dashboard to pick a day'}
+                  >
+                    {pendingId === t.id ? 'Applying…' : 'Apply'}
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={() => setEditing(t)}>
+                    Edit
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={() => {
+                      if (window.confirm(`Delete "${t.name}"?`)) {
+                        deleteMutation.mutate(t.id);
+                      }
+                    }}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </div>
+              {t.items.length > 0 && (
+                <ul className="border-t border-border px-4 py-2 flex flex-col gap-1">
+                  {t.items.map((it) => (
+                    <li
+                      key={it.id}
+                      className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground"
+                    >
+                      <span className="text-foreground">{it.entry_name || '—'}</span>
+                      <span>{it.amount} kcal</span>
+                      {it.protein_g != null && <span>P {it.protein_g}g</span>}
+                      {it.carbs_g != null && <span>C {it.carbs_g}g</span>}
+                      {it.fat_g != null && <span>F {it.fat_g}g</span>}
+                      {it.fiber_g != null && <span>Fi {it.fiber_g}g</span>}
+                      {it.sugar_g != null && <span>S {it.sugar_g}g</span>}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {(creatingNew || editing) && (
+        <TemplateEditor
+          isOpen
+          template={editing}
+          onClose={() => {
+            setEditing(null);
+            setCreatingNew(false);
+          }}
+          onSaved={() => {
+            queryClient.invalidateQueries({ queryKey: ['templates'] });
+            setEditing(null);
+            setCreatingNew(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -9,6 +9,7 @@ import ResetPassword from '@/pages/ResetPassword/ResetPassword';
 import VerifyEmail from '@/pages/VerifyEmail/VerifyEmail';
 import Dashboard from '@/pages/Dashboard/Dashboard';
 import Settings from '@/pages/Settings/Settings';
+import Templates from '@/pages/Templates/Templates';
 import Admin from '@/pages/Admin/Admin';
 import Privacy from '@/pages/Legal/Privacy';
 import Terms from '@/pages/Legal/Terms';
@@ -41,6 +42,7 @@ export default function AppRouter() {
         <Route path="/reset-password" element={<GuestRoute><ResetPassword /></GuestRoute>} />
         <Route path="/verify-email" element={<VerifyEmail />} />
         <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
+        <Route path="/templates" element={<ProtectedRoute><Templates /></ProtectedRoute>} />
         <Route path="/settings" element={<ProtectedRoute><Settings /></ProtectedRoute>} />
         <Route path="/admin" element={<ProtectedRoute><Admin /></ProtectedRoute>} />
         <Route path="/delete" element={<ProtectedRoute><DeleteAccount /></ProtectedRoute>} />

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -168,3 +168,43 @@ export interface InviteCode {
   expires_at: string | null;
   created_at: string;
 }
+
+export interface MealTemplateItem {
+  id: number;
+  template_id: number;
+  entry_name: string | null;
+  amount: number;
+  protein_g?: number | null;
+  carbs_g?: number | null;
+  fat_g?: number | null;
+  fiber_g?: number | null;
+  sugar_g?: number | null;
+  sort_order: number;
+}
+
+export interface MealTemplate {
+  id: number;
+  user_id: number;
+  name: string;
+  is_favorite: boolean;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+  items: MealTemplateItem[];
+}
+
+export interface MealTemplateItemInput {
+  entry_name?: string | null;
+  amount: number;
+  protein_g?: number | null;
+  carbs_g?: number | null;
+  fat_g?: number | null;
+  fiber_g?: number | null;
+  sugar_g?: number | null;
+}
+
+export interface MealTemplateInput {
+  name: string;
+  is_favorite: boolean;
+  items: MealTemplateItemInput[];
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -189,6 +189,15 @@ func main() {
 	r.With(middleware.RequireLogin, middleware.RequireLinkAuth(pool)).Get("/api/notes/day", notesHandler.Get)
 	r.With(middleware.RequireLogin, session.CsrfProtection).Post("/api/notes", notesHandler.Save)
 
+	// Meal template routes
+	mealTemplatesHandler := &handler.MealTemplatesHandler{Pool: pool, Broker: sseBroker}
+	r.With(middleware.RequireLogin).Get("/api/templates", mealTemplatesHandler.List)
+	r.With(middleware.RequireLogin, session.CsrfProtection).Post("/templates", mealTemplatesHandler.Create)
+	r.With(middleware.RequireLogin, session.CsrfProtection).Post("/templates/{id}/update", mealTemplatesHandler.Update)
+	r.With(middleware.RequireLogin, session.CsrfProtection).Post("/templates/{id}/delete", mealTemplatesHandler.Delete)
+	r.With(middleware.RequireLogin, session.CsrfProtection).Post("/templates/{id}/favorite", mealTemplatesHandler.ToggleFavorite)
+	r.With(middleware.RequireLogin, session.CsrfProtection).Post("/templates/{id}/apply", mealTemplatesHandler.Apply)
+
 	// AI estimation
 	aiHandler := &handler.AIHandler{Pool: pool, Cfg: cfg, Settings: settingsCache}
 	r.With(strictLimiter.Middleware, middleware.RequireLogin).Post("/api/ai/estimate", aiHandler.Estimate)

--- a/e2e/fixtures/helpers.ts
+++ b/e2e/fixtures/helpers.ts
@@ -135,6 +135,7 @@ export function createIsolatedUser(specName: string, opts: { features?: boolean 
   psql(`DELETE FROM todos WHERE user_id = ${id}`);
   psql(`DELETE FROM daily_notes WHERE user_id = ${id}`);
   psql(`DELETE FROM ai_usage WHERE user_id = ${id}`);
+  psql(`DELETE FROM meal_templates WHERE user_id = ${id}`);
 
   if (features) {
     psql(`UPDATE users SET

--- a/e2e/meal-templates.spec.ts
+++ b/e2e/meal-templates.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+import { psql, createIsolatedUser, loginUser } from './fixtures/helpers';
+
+let user: { email: string; password: string; id: string };
+
+test.describe('Meal templates', () => {
+  test.beforeAll(() => {
+    user = createIsolatedUser('meal-templates');
+  });
+
+  test.beforeEach(() => {
+    psql(`DELETE FROM meal_templates WHERE user_id = ${user.id}`);
+    psql(`DELETE FROM calorie_entries WHERE user_id = ${user.id}`);
+  });
+
+  test('create template, star it, apply from Dashboard, delete', async ({ browser }) => {
+    const { context: ctx, page } = await loginUser(browser, user.email, user.password);
+
+    // Create template via the Templates page
+    await page.goto('/templates');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.getByRole('heading', { name: 'Meal templates' })).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('button', { name: 'New template' }).click();
+    await page.locator('input#template-name').fill('Breakfast combo');
+    await page.getByLabel('Show in Dashboard Quick-Add').check();
+
+    // First item (pre-filled row)
+    const inputs = page.locator('input[placeholder="Name (e.g. Oatmeal)"]');
+    await inputs.nth(0).fill('Oatmeal');
+    const kcalInputs = page.locator('input[placeholder="kcal"]');
+    await kcalInputs.nth(0).fill('300');
+
+    // Add a second item
+    await page.getByRole('button', { name: '+ Add item' }).click();
+    await inputs.nth(1).fill('Banana');
+    await kcalInputs.nth(1).fill('110');
+
+    await page.getByRole('button', { name: 'Create' }).click();
+    await expect(page.getByText('Template created')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Breakfast combo')).toBeVisible({ timeout: 5000 });
+
+    // Switch to Dashboard and confirm favorites chip
+    await page.goto('/dashboard');
+    await page.waitForLoadState('domcontentloaded');
+    const chip = page.getByRole('button', { name: /Breakfast combo/ });
+    await expect(chip).toBeVisible({ timeout: 10000 });
+
+    // Apply via chip — expect 2 new entries
+    await chip.click();
+    await expect(page.getByText('Added 2 entries')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: 'Oatmeal' })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: 'Banana' })).toBeVisible({ timeout: 5000 });
+
+    // Unstar in the Templates page → chip disappears
+    await page.goto('/templates');
+    await page.waitForLoadState('domcontentloaded');
+    await page.getByRole('button', { name: 'Remove from favorites' }).click();
+
+    await page.goto('/dashboard');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.getByRole('button', { name: /Breakfast combo/ })).not.toBeVisible({ timeout: 5000 });
+
+    // Delete template
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.goto('/templates');
+    await page.waitForLoadState('domcontentloaded');
+    await page.getByRole('button', { name: 'Delete' }).click();
+    await expect(page.getByText('Template deleted')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Breakfast combo')).not.toBeVisible({ timeout: 5000 });
+
+    await ctx.close();
+  });
+
+  test('validation: template needs at least one item', async ({ browser }) => {
+    const { context: ctx, page } = await loginUser(browser, user.email, user.password);
+    await page.goto('/templates');
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.getByRole('button', { name: /New template|Create your first template/ }).click();
+    await page.locator('input#template-name').fill('Empty');
+    await page.getByRole('button', { name: 'Create' }).click();
+    await expect(
+      page.getByText(/at least one item|name, calories, or macros/i),
+    ).toBeVisible({ timeout: 5000 });
+
+    await ctx.close();
+  });
+});

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -480,6 +480,62 @@ func ensureDailyNotesSchema(ctx context.Context, pool *pgxpool.Pool) error {
 	})
 }
 
+func ensureMealTemplateSchema(ctx context.Context, pool *pgxpool.Pool) error {
+	return withTransaction(ctx, pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			CREATE TABLE IF NOT EXISTS meal_templates (
+				id          SERIAL PRIMARY KEY,
+				user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+				name        TEXT    NOT NULL,
+				is_favorite BOOLEAN NOT NULL DEFAULT FALSE,
+				sort_order  INTEGER NOT NULL DEFAULT 0,
+				created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+				updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+			);
+			CREATE INDEX IF NOT EXISTS meal_templates_user_idx ON meal_templates (user_id, sort_order, created_at DESC);
+			CREATE INDEX IF NOT EXISTS meal_templates_fav_idx ON meal_templates (user_id, sort_order) WHERE is_favorite;
+			DO $$ BEGIN
+				ALTER TABLE meal_templates ADD CONSTRAINT meal_templates_name_length CHECK (char_length(name) BETWEEN 1 AND 100);
+			EXCEPTION WHEN duplicate_object THEN NULL;
+			END $$;
+
+			CREATE TABLE IF NOT EXISTS meal_template_items (
+				id          SERIAL PRIMARY KEY,
+				template_id INTEGER NOT NULL REFERENCES meal_templates(id) ON DELETE CASCADE,
+				entry_name  TEXT,
+				amount      INTEGER NOT NULL,
+				protein_g   INTEGER,
+				carbs_g     INTEGER,
+				fat_g       INTEGER,
+				fiber_g     INTEGER,
+				sugar_g     INTEGER,
+				sort_order  INTEGER NOT NULL DEFAULT 0
+			);
+			CREATE INDEX IF NOT EXISTS meal_template_items_template_idx ON meal_template_items (template_id, sort_order);
+			DO $$ BEGIN
+				ALTER TABLE meal_template_items ADD CONSTRAINT meal_template_items_amount_range CHECK (amount BETWEEN -9999 AND 9999);
+			EXCEPTION WHEN duplicate_object THEN NULL;
+			END $$`)
+		if err != nil {
+			return err
+		}
+
+		// Macro range CHECK constraints, idempotent.
+		macros := []string{"protein_g", "carbs_g", "fat_g", "fiber_g", "sugar_g"}
+		for _, col := range macros {
+			_, err = tx.Exec(ctx, fmt.Sprintf(`
+				DO $$ BEGIN
+					ALTER TABLE meal_template_items ADD CONSTRAINT meal_template_items_%s_range CHECK (%s IS NULL OR (%s >= 0 AND %s <= 999));
+				EXCEPTION WHEN duplicate_object THEN NULL;
+				END $$`, col, col, col, col))
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 // InitSchemaWithRetry runs all migrations with exponential backoff.
 func InitSchemaWithRetry(ctx context.Context, pool *pgxpool.Pool, maxRetries int) error {
 	if maxRetries == 0 {
@@ -531,6 +587,7 @@ func runAllMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 		{"ai_keys", ensureAIKeysSchema},
 		{"ai_usage", ensureAIUsageSchema},
 		{"macros", ensureMacroSchema},
+		{"meal_templates", ensureMealTemplateSchema},
 	}
 
 	results := make(chan migrationResult, len(migrations))

--- a/internal/handler/meal_template.go
+++ b/internal/handler/meal_template.go
@@ -1,0 +1,450 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"schautrack/internal/middleware"
+	"schautrack/internal/model"
+	"schautrack/internal/service"
+	"schautrack/internal/sse"
+)
+
+// MealTemplatesHandler holds deps for meal-template routes.
+type MealTemplatesHandler struct {
+	Pool   *pgxpool.Pool
+	Broker *sse.Broker
+}
+
+// templateItemBody is the wire format for an item in a create/update request.
+type templateItemBody struct {
+	EntryName *string `json:"entry_name"`
+	Amount    int     `json:"amount"`
+	ProteinG  *int    `json:"protein_g"`
+	CarbsG    *int    `json:"carbs_g"`
+	FatG      *int    `json:"fat_g"`
+	FiberG    *int    `json:"fiber_g"`
+	SugarG    *int    `json:"sugar_g"`
+}
+
+// templateWriteBody is the wire format for create/update.
+type templateWriteBody struct {
+	Name       string             `json:"name"`
+	IsFavorite bool               `json:"is_favorite"`
+	Items      []templateItemBody `json:"items"`
+}
+
+func itemBodyToInput(b templateItemBody) service.MealTemplateItemInput {
+	in := service.MealTemplateItemInput{
+		Amount: b.Amount,
+		Macros: map[string]int{},
+	}
+	if b.EntryName != nil {
+		in.EntryName = *b.EntryName
+	}
+	if b.ProteinG != nil {
+		in.Macros["protein"] = *b.ProteinG
+	}
+	if b.CarbsG != nil {
+		in.Macros["carbs"] = *b.CarbsG
+	}
+	if b.FatG != nil {
+		in.Macros["fat"] = *b.FatG
+	}
+	if b.FiberG != nil {
+		in.Macros["fiber"] = *b.FiberG
+	}
+	if b.SugarG != nil {
+		in.Macros["sugar"] = *b.SugarG
+	}
+	return in
+}
+
+// List returns the current user's templates (with items).
+// Optional query param: favorites=true restricts to starred templates.
+func (h *MealTemplatesHandler) List(w http.ResponseWriter, r *http.Request) {
+	user := middleware.GetCurrentUser(r)
+	favoritesOnly := r.URL.Query().Get("favorites") == "true"
+
+	var query string
+	args := []any{user.ID}
+	if favoritesOnly {
+		query = `SELECT id, name, is_favorite, sort_order, created_at, updated_at
+		         FROM meal_templates WHERE user_id = $1 AND is_favorite = TRUE
+		         ORDER BY sort_order, created_at DESC`
+	} else {
+		query = `SELECT id, name, is_favorite, sort_order, created_at, updated_at
+		         FROM meal_templates WHERE user_id = $1
+		         ORDER BY is_favorite DESC, sort_order, created_at DESC`
+	}
+
+	rows, err := h.Pool.Query(r.Context(), query, args...)
+	if err != nil {
+		slog.Error("failed to list meal templates", "error", err)
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to load templates")
+		return
+	}
+	defer rows.Close()
+
+	templates := []model.MealTemplate{}
+	idByIdx := map[int]int{}
+	for rows.Next() {
+		var t model.MealTemplate
+		if err := rows.Scan(&t.ID, &t.Name, &t.IsFavorite, &t.SortOrder, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			slog.Error("scan meal template", "error", err)
+			continue
+		}
+		t.UserID = user.ID
+		t.Items = []model.MealTemplateItem{}
+		idByIdx[t.ID] = len(templates)
+		templates = append(templates, t)
+	}
+	rows.Close()
+
+	if len(templates) == 0 {
+		JSON(w, http.StatusOK, map[string]any{"ok": true, "templates": templates})
+		return
+	}
+
+	ids := make([]int, 0, len(templates))
+	for _, t := range templates {
+		ids = append(ids, t.ID)
+	}
+
+	itemRows, err := h.Pool.Query(r.Context(), `
+		SELECT id, template_id, entry_name, amount, protein_g, carbs_g, fat_g, fiber_g, sugar_g, sort_order
+		FROM meal_template_items WHERE template_id = ANY($1) ORDER BY template_id, sort_order, id`, ids)
+	if err != nil {
+		slog.Error("failed to load template items", "error", err)
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to load templates")
+		return
+	}
+	defer itemRows.Close()
+	for itemRows.Next() {
+		var it model.MealTemplateItem
+		if err := itemRows.Scan(&it.ID, &it.TemplateID, &it.EntryName, &it.Amount,
+			&it.ProteinG, &it.CarbsG, &it.FatG, &it.FiberG, &it.SugarG, &it.SortOrder); err != nil {
+			slog.Error("scan template item", "error", err)
+			continue
+		}
+		if idx, ok := idByIdx[it.TemplateID]; ok {
+			templates[idx].Items = append(templates[idx].Items, it)
+		}
+	}
+
+	JSON(w, http.StatusOK, map[string]any{"ok": true, "templates": templates})
+}
+
+// Create handles POST /templates.
+func (h *MealTemplatesHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var body templateWriteBody
+	if err := ReadJSON(r, &body); err != nil {
+		ErrorJSON(w, http.StatusBadRequest, "Invalid request.")
+		return
+	}
+
+	input := service.MealTemplateInput{
+		Name:       body.Name,
+		IsFavorite: body.IsFavorite,
+		Items:      make([]service.MealTemplateItemInput, 0, len(body.Items)),
+	}
+	for _, it := range body.Items {
+		input.Items = append(input.Items, itemBodyToInput(it))
+	}
+	cleaned, errMsg := service.ValidateMealTemplateInput(input)
+	if errMsg != "" {
+		ErrorJSON(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	user := middleware.GetCurrentUser(r)
+	var count int
+	if err := h.Pool.QueryRow(r.Context(), "SELECT COUNT(*)::int FROM meal_templates WHERE user_id = $1", user.ID).Scan(&count); err != nil {
+		slog.Error("count meal templates", "error", err)
+	}
+	if count >= service.MaxMealTemplates {
+		ErrorJSON(w, http.StatusBadRequest, fmt.Sprintf("Maximum %d templates allowed", service.MaxMealTemplates))
+		return
+	}
+
+	tx, err := h.Pool.Begin(r.Context())
+	if err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to save template")
+		return
+	}
+	defer tx.Rollback(r.Context())
+
+	var id int
+	err = tx.QueryRow(r.Context(),
+		`INSERT INTO meal_templates (user_id, name, is_favorite, sort_order)
+		 VALUES ($1, $2, $3, $4) RETURNING id`,
+		user.ID, cleaned.Name, cleaned.IsFavorite, count,
+	).Scan(&id)
+	if err != nil {
+		slog.Error("insert meal template", "error", err)
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to save template")
+		return
+	}
+
+	if err := insertTemplateItems(r, tx, id, cleaned.Items); err != nil {
+		slog.Error("insert meal template items", "error", err)
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to save template")
+		return
+	}
+
+	if err := tx.Commit(r.Context()); err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to save template")
+		return
+	}
+	h.Broker.BroadcastTemplateChange(user.ID)
+	OkJSON(w, map[string]any{"id": id})
+}
+
+// Update handles POST /templates/{id}/update. Replaces name/is_favorite and all items.
+func (h *MealTemplatesHandler) Update(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		ErrorJSON(w, http.StatusBadRequest, "Invalid template id")
+		return
+	}
+	var body templateWriteBody
+	if err := ReadJSON(r, &body); err != nil {
+		ErrorJSON(w, http.StatusBadRequest, "Invalid request.")
+		return
+	}
+
+	input := service.MealTemplateInput{
+		Name:       body.Name,
+		IsFavorite: body.IsFavorite,
+		Items:      make([]service.MealTemplateItemInput, 0, len(body.Items)),
+	}
+	for _, it := range body.Items {
+		input.Items = append(input.Items, itemBodyToInput(it))
+	}
+	cleaned, errMsg := service.ValidateMealTemplateInput(input)
+	if errMsg != "" {
+		ErrorJSON(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	user := middleware.GetCurrentUser(r)
+
+	tx, err := h.Pool.Begin(r.Context())
+	if err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to update template")
+		return
+	}
+	defer tx.Rollback(r.Context())
+
+	tag, err := tx.Exec(r.Context(),
+		`UPDATE meal_templates SET name = $1, is_favorite = $2, updated_at = NOW()
+		 WHERE id = $3 AND user_id = $4`,
+		cleaned.Name, cleaned.IsFavorite, id, user.ID,
+	)
+	if err != nil || tag.RowsAffected() == 0 {
+		ErrorJSON(w, http.StatusNotFound, "Template not found")
+		return
+	}
+
+	if _, err := tx.Exec(r.Context(), "DELETE FROM meal_template_items WHERE template_id = $1", id); err != nil {
+		slog.Error("delete template items", "error", err)
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to update template")
+		return
+	}
+	if err := insertTemplateItems(r, tx, id, cleaned.Items); err != nil {
+		slog.Error("insert template items on update", "error", err)
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to update template")
+		return
+	}
+
+	if err := tx.Commit(r.Context()); err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to update template")
+		return
+	}
+	h.Broker.BroadcastTemplateChange(user.ID)
+	OkJSON(w)
+}
+
+// Delete handles POST /templates/{id}/delete.
+func (h *MealTemplatesHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		ErrorJSON(w, http.StatusBadRequest, "Invalid template id")
+		return
+	}
+	user := middleware.GetCurrentUser(r)
+	tag, err := h.Pool.Exec(r.Context(),
+		"DELETE FROM meal_templates WHERE id = $1 AND user_id = $2", id, user.ID)
+	if err != nil || tag.RowsAffected() == 0 {
+		ErrorJSON(w, http.StatusNotFound, "Template not found")
+		return
+	}
+	h.Broker.BroadcastTemplateChange(user.ID)
+	OkJSON(w)
+}
+
+// ToggleFavorite handles POST /templates/{id}/favorite.
+// Body: optional {"is_favorite": true|false}. If absent, toggles.
+func (h *MealTemplatesHandler) ToggleFavorite(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		ErrorJSON(w, http.StatusBadRequest, "Invalid template id")
+		return
+	}
+	user := middleware.GetCurrentUser(r)
+
+	var body struct {
+		IsFavorite *bool `json:"is_favorite"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+
+	var newVal bool
+	var query string
+	var args []any
+	if body.IsFavorite != nil {
+		query = `UPDATE meal_templates SET is_favorite = $1, updated_at = NOW()
+		         WHERE id = $2 AND user_id = $3 RETURNING is_favorite`
+		args = []any{*body.IsFavorite, id, user.ID}
+	} else {
+		query = `UPDATE meal_templates SET is_favorite = NOT is_favorite, updated_at = NOW()
+		         WHERE id = $1 AND user_id = $2 RETURNING is_favorite`
+		args = []any{id, user.ID}
+	}
+	if err := h.Pool.QueryRow(r.Context(), query, args...).Scan(&newVal); err != nil {
+		ErrorJSON(w, http.StatusNotFound, "Template not found")
+		return
+	}
+	h.Broker.BroadcastTemplateChange(user.ID)
+	JSON(w, http.StatusOK, map[string]any{"ok": true, "is_favorite": newVal})
+}
+
+// Apply handles POST /templates/{id}/apply?day=YYYY-MM-DD.
+// Inserts the template's items into calorie_entries for the given day.
+func (h *MealTemplatesHandler) Apply(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		ErrorJSON(w, http.StatusBadRequest, "Invalid template id")
+		return
+	}
+
+	user := middleware.GetCurrentUser(r)
+	userTz := getUserTimezone(r, user)
+	day := strings.TrimSpace(r.URL.Query().Get("day"))
+	if day == "" {
+		day = service.FormatDateInTz(time.Now(), userTz)
+	}
+	if !dateRe.MatchString(day) {
+		ErrorJSON(w, http.StatusBadRequest, "Invalid day")
+		return
+	}
+
+	// Load items.
+	rows, err := h.Pool.Query(r.Context(), `
+		SELECT mti.entry_name, mti.amount, mti.protein_g, mti.carbs_g, mti.fat_g, mti.fiber_g, mti.sugar_g
+		FROM meal_template_items mti
+		JOIN meal_templates mt ON mt.id = mti.template_id
+		WHERE mt.id = $1 AND mt.user_id = $2
+		ORDER BY mti.sort_order, mti.id`, id, user.ID)
+	if err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to apply template")
+		return
+	}
+	defer rows.Close()
+
+	type item struct {
+		EntryName *string
+		Amount    int
+		ProteinG  *int
+		CarbsG    *int
+		FatG      *int
+		FiberG    *int
+		SugarG    *int
+	}
+	var items []item
+	for rows.Next() {
+		var it item
+		if err := rows.Scan(&it.EntryName, &it.Amount, &it.ProteinG, &it.CarbsG, &it.FatG, &it.FiberG, &it.SugarG); err != nil {
+			ErrorJSON(w, http.StatusInternalServerError, "Failed to apply template")
+			return
+		}
+		items = append(items, it)
+	}
+	rows.Close()
+	if len(items) == 0 {
+		// Either the template doesn't exist for this user, or it's empty (shouldn't happen per validation).
+		ErrorJSON(w, http.StatusNotFound, "Template not found")
+		return
+	}
+
+	tx, err := h.Pool.Begin(r.Context())
+	if err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to apply template")
+		return
+	}
+	defer tx.Rollback(r.Context())
+
+	inserted := 0
+	for _, it := range items {
+		_, err := tx.Exec(r.Context(), `
+			INSERT INTO calorie_entries (user_id, entry_date, amount, entry_name, protein_g, carbs_g, fat_g, fiber_g, sugar_g)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+			user.ID, day, it.Amount, it.EntryName, it.ProteinG, it.CarbsG, it.FatG, it.FiberG, it.SugarG)
+		if err != nil {
+			slog.Error("insert applied entry", "error", err)
+			ErrorJSON(w, http.StatusInternalServerError, "Failed to apply template")
+			return
+		}
+		inserted++
+	}
+
+	if err := tx.Commit(r.Context()); err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to apply template")
+		return
+	}
+	h.Broker.BroadcastEntryChange(user.ID)
+	OkJSON(w, map[string]any{"count": inserted, "day": day})
+}
+
+// insertTemplateItems writes the ordered list of items for a template inside an open tx.
+func insertTemplateItems(r *http.Request, tx pgx.Tx, templateID int, items []service.MealTemplateItemInput) error {
+	for idx, it := range items {
+		var entryName *string
+		if it.EntryName != "" {
+			name := it.EntryName
+			entryName = &name
+		}
+		_, err := tx.Exec(r.Context(), `
+			INSERT INTO meal_template_items (template_id, entry_name, amount, protein_g, carbs_g, fat_g, fiber_g, sugar_g, sort_order)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+			templateID,
+			entryName,
+			it.Amount,
+			macroNilInt(it.Macros, "protein"),
+			macroNilInt(it.Macros, "carbs"),
+			macroNilInt(it.Macros, "fat"),
+			macroNilInt(it.Macros, "fiber"),
+			macroNilInt(it.Macros, "sugar"),
+			idx,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func macroNilInt(m map[string]int, key string) any {
+	if v, ok := m[key]; ok {
+		return v
+	}
+	return nil
+}

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -213,8 +213,10 @@ func (h *SettingsHandler) AISettings(w http.ResponseWriter, r *http.Request) {
 		updates = append(updates, fmt.Sprintf("ai_key_last4 = $%d", idx))
 		values = append(values, last4)
 		idx++
-	} else if newProvider != nil {
-		// Clear key on provider change with no new key
+	} else if newProvider != nil && (user.PreferredAIProvider == nil || *user.PreferredAIProvider != *newProvider) {
+		// Clear stored key only when the provider actually changes, since keys are
+		// provider-specific. Saves with the same provider and empty key (common with
+		// autosave after the input is cleared client-side) must NOT wipe the existing key.
 		updates = append(updates, "ai_key = NULL", "ai_key_last4 = NULL")
 	}
 

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -95,3 +95,27 @@ type AdminSetting struct {
 	Value     *string   `json:"value"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
+
+type MealTemplate struct {
+	ID         int                `json:"id"`
+	UserID     int                `json:"user_id"`
+	Name       string             `json:"name"`
+	IsFavorite bool               `json:"is_favorite"`
+	SortOrder  int                `json:"sort_order"`
+	CreatedAt  time.Time          `json:"created_at"`
+	UpdatedAt  time.Time          `json:"updated_at"`
+	Items      []MealTemplateItem `json:"items"`
+}
+
+type MealTemplateItem struct {
+	ID         int     `json:"id"`
+	TemplateID int     `json:"template_id"`
+	EntryName  *string `json:"entry_name"`
+	Amount     int     `json:"amount"`
+	ProteinG   *int    `json:"protein_g,omitempty"`
+	CarbsG     *int    `json:"carbs_g,omitempty"`
+	FatG       *int    `json:"fat_g,omitempty"`
+	FiberG     *int    `json:"fiber_g,omitempty"`
+	SugarG     *int    `json:"sugar_g,omitempty"`
+	SortOrder  int     `json:"sort_order"`
+}

--- a/internal/service/meal_template.go
+++ b/internal/service/meal_template.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// Meal template limits.
+const (
+	MaxMealTemplates     = 200
+	MaxMealTemplateItems = 50
+	MaxTemplateNameRunes = 100
+	MaxTemplateAmount    = 9999
+	MaxTemplateMacro     = 999
+)
+
+// MealTemplateItemInput is the validated form of a single item in a template.
+type MealTemplateItemInput struct {
+	EntryName string         // trimmed; may be empty
+	Amount    int            // calories; -9999..9999
+	Macros    map[string]int // keys: protein/carbs/fat/fiber/sugar; each 0..999
+}
+
+// MealTemplateInput is the validated form of a template write.
+type MealTemplateInput struct {
+	Name       string
+	IsFavorite bool
+	Items      []MealTemplateItemInput
+}
+
+// ValidateMealTemplateName returns the trimmed name or an error message.
+func ValidateMealTemplateName(raw string) (string, string) {
+	n := strings.TrimSpace(raw)
+	if n == "" {
+		return "", "Name is required"
+	}
+	if utf8.RuneCountInString(n) > MaxTemplateNameRunes {
+		return "", "Name is too long"
+	}
+	return n, ""
+}
+
+// ValidateMealTemplateAmount validates a template item amount.
+func ValidateMealTemplateAmount(amount int) string {
+	if amount < -MaxTemplateAmount || amount > MaxTemplateAmount {
+		return "Calories must be between -9999 and 9999"
+	}
+	return ""
+}
+
+// ValidateMealTemplateMacro checks one macro value.
+func ValidateMealTemplateMacro(value int) string {
+	if value < 0 || value > MaxTemplateMacro {
+		return "Macro values must be between 0 and 999"
+	}
+	return ""
+}
+
+// ValidateMealTemplateItem validates one item and returns a cleaned copy or an error message.
+func ValidateMealTemplateItem(item MealTemplateItemInput) (MealTemplateItemInput, string) {
+	cleaned := MealTemplateItemInput{
+		EntryName: strings.TrimSpace(item.EntryName),
+		Amount:    item.Amount,
+		Macros:    map[string]int{},
+	}
+	if utf8.RuneCountInString(cleaned.EntryName) > 120 {
+		// Match the 120-char cap used by calorie_entries (see entries_crud.CreateEntry).
+		runes := []rune(cleaned.EntryName)
+		cleaned.EntryName = string(runes[:120])
+	}
+	if msg := ValidateMealTemplateAmount(cleaned.Amount); msg != "" {
+		return cleaned, msg
+	}
+	hasMacro := false
+	for _, key := range MacroKeys {
+		v, ok := item.Macros[key]
+		if !ok {
+			continue
+		}
+		if msg := ValidateMealTemplateMacro(v); msg != "" {
+			return cleaned, msg
+		}
+		cleaned.Macros[key] = v
+		hasMacro = true
+	}
+	if cleaned.Amount == 0 && !hasMacro && cleaned.EntryName == "" {
+		return cleaned, "Each item needs a name, calories, or macros"
+	}
+	return cleaned, ""
+}
+
+// ValidateMealTemplateInput runs full validation on the template and all items.
+// Returns the cleaned input or an error message.
+func ValidateMealTemplateInput(in MealTemplateInput) (MealTemplateInput, string) {
+	name, msg := ValidateMealTemplateName(in.Name)
+	if msg != "" {
+		return in, msg
+	}
+	if len(in.Items) == 0 {
+		return in, "Template needs at least one item"
+	}
+	if len(in.Items) > MaxMealTemplateItems {
+		return in, "Too many items (max 50)"
+	}
+	cleaned := MealTemplateInput{
+		Name:       name,
+		IsFavorite: in.IsFavorite,
+		Items:      make([]MealTemplateItemInput, 0, len(in.Items)),
+	}
+	for _, item := range in.Items {
+		ci, msg := ValidateMealTemplateItem(item)
+		if msg != "" {
+			return in, msg
+		}
+		cleaned.Items = append(cleaned.Items, ci)
+	}
+	return cleaned, ""
+}

--- a/internal/service/meal_template_test.go
+++ b/internal/service/meal_template_test.go
@@ -1,0 +1,170 @@
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateMealTemplateName(t *testing.T) {
+	tests := []struct {
+		raw, wantName, wantErr string
+	}{
+		{"  Breakfast  ", "Breakfast", ""},
+		{"", "", "Name is required"},
+		{"   ", "", "Name is required"},
+		{strings.Repeat("a", 100), strings.Repeat("a", 100), ""},
+		{strings.Repeat("a", 101), "", "Name is too long"},
+		{"Müsli-Bowl 🥣", "Müsli-Bowl 🥣", ""},
+	}
+	for _, tt := range tests {
+		name, errMsg := ValidateMealTemplateName(tt.raw)
+		if name != tt.wantName || errMsg != tt.wantErr {
+			t.Errorf("ValidateMealTemplateName(%q) = (%q, %q), want (%q, %q)",
+				tt.raw, name, errMsg, tt.wantName, tt.wantErr)
+		}
+	}
+}
+
+func TestValidateMealTemplateAmount(t *testing.T) {
+	tests := []struct {
+		amount  int
+		wantErr bool
+	}{
+		{0, false},
+		{500, false},
+		{-9999, false},
+		{9999, false},
+		{10000, true},
+		{-10000, true},
+	}
+	for _, tt := range tests {
+		err := ValidateMealTemplateAmount(tt.amount)
+		if (err != "") != tt.wantErr {
+			t.Errorf("ValidateMealTemplateAmount(%d) err=%q, wantErr=%v", tt.amount, err, tt.wantErr)
+		}
+	}
+}
+
+func TestValidateMealTemplateMacro(t *testing.T) {
+	tests := []struct {
+		v       int
+		wantErr bool
+	}{
+		{0, false},
+		{500, false},
+		{999, false},
+		{1000, true},
+		{-1, true},
+	}
+	for _, tt := range tests {
+		err := ValidateMealTemplateMacro(tt.v)
+		if (err != "") != tt.wantErr {
+			t.Errorf("ValidateMealTemplateMacro(%d) err=%q, wantErr=%v", tt.v, err, tt.wantErr)
+		}
+	}
+}
+
+func TestValidateMealTemplateItem(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   MealTemplateItemInput
+		wantErr bool
+	}{
+		{
+			"valid calories only",
+			MealTemplateItemInput{EntryName: "Oatmeal", Amount: 300},
+			false,
+		},
+		{
+			"valid macros only",
+			MealTemplateItemInput{Amount: 0, Macros: map[string]int{"protein": 20}},
+			false,
+		},
+		{
+			"zero-amount no macros no name rejected",
+			MealTemplateItemInput{Amount: 0, Macros: map[string]int{}},
+			true,
+		},
+		{
+			"calories out of range",
+			MealTemplateItemInput{Amount: 10001},
+			true,
+		},
+		{
+			"macro out of range",
+			MealTemplateItemInput{Amount: 100, Macros: map[string]int{"protein": 1000}},
+			true,
+		},
+		{
+			"macro negative",
+			MealTemplateItemInput{Amount: 100, Macros: map[string]int{"fat": -5}},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ValidateMealTemplateItem(tt.input)
+			if (err != "") != tt.wantErr {
+				t.Errorf("got err=%q, wantErr=%v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateMealTemplateInput(t *testing.T) {
+	validItem := MealTemplateItemInput{EntryName: "Bread", Amount: 200}
+
+	t.Run("happy path", func(t *testing.T) {
+		in := MealTemplateInput{
+			Name:       " Breakfast ",
+			IsFavorite: true,
+			Items:      []MealTemplateItemInput{validItem, validItem},
+		}
+		cleaned, err := ValidateMealTemplateInput(in)
+		if err != "" {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if cleaned.Name != "Breakfast" {
+			t.Errorf("name not trimmed: %q", cleaned.Name)
+		}
+		if !cleaned.IsFavorite {
+			t.Errorf("is_favorite lost")
+		}
+		if len(cleaned.Items) != 2 {
+			t.Errorf("items count = %d, want 2", len(cleaned.Items))
+		}
+	})
+
+	t.Run("no items rejected", func(t *testing.T) {
+		in := MealTemplateInput{Name: "Empty", Items: nil}
+		if _, err := ValidateMealTemplateInput(in); err == "" {
+			t.Fatal("expected error for empty items")
+		}
+	})
+
+	t.Run("too many items rejected", func(t *testing.T) {
+		items := make([]MealTemplateItemInput, MaxMealTemplateItems+1)
+		for i := range items {
+			items[i] = validItem
+		}
+		in := MealTemplateInput{Name: "Big", Items: items}
+		if _, err := ValidateMealTemplateInput(in); err == "" {
+			t.Fatal("expected error for too many items")
+		}
+	})
+
+	t.Run("invalid name propagates", func(t *testing.T) {
+		in := MealTemplateInput{Name: "   ", Items: []MealTemplateItemInput{validItem}}
+		if _, err := ValidateMealTemplateInput(in); err == "" {
+			t.Fatal("expected error for empty name")
+		}
+	})
+
+	t.Run("invalid item propagates", func(t *testing.T) {
+		bad := MealTemplateItemInput{Amount: 20000}
+		in := MealTemplateInput{Name: "Bad", Items: []MealTemplateItemInput{bad}}
+		if _, err := ValidateMealTemplateInput(in); err == "" {
+			t.Fatal("expected error for out-of-range amount")
+		}
+	})
+}

--- a/internal/sse/broker.go
+++ b/internal/sse/broker.go
@@ -95,6 +95,16 @@ func (b *Broker) BroadcastNoteChange(sourceUserID int) {
 	}
 }
 
+// BroadcastTemplateChange notifies clients that the user's meal templates changed.
+// Only the user themselves (and linked partners) receive this — it's per-user data.
+func (b *Broker) BroadcastTemplateChange(sourceUserID int) {
+	targets := b.getTargets(sourceUserID)
+	payload := map[string]any{"sourceUserId": sourceUserID, "at": time.Now().UnixMilli()}
+	for _, id := range targets {
+		b.SendEvent(id, "template-change", payload)
+	}
+}
+
 func (b *Broker) BroadcastSettingsChange(userID int, settings any) {
 	b.SendEvent(userID, "settings-change", settings)
 }


### PR DESCRIPTION
## Summary

Adds user-owned **meal templates**: named combinations of 1..N free-form food items that can be logged in one tap. Starred templates surface as a Quick-Add chip bar on the Dashboard. Addresses the frequent "I eat the same breakfast every weekday, please stop making me retype it" ask.

## What's new

- Full CRUD at `/templates` (list, star, edit, delete)
- Favorites chip row on Dashboard between `TodayPanel` and `EntryForm`; click → applies template items to the currently selected day
- "Save as template" shortcut on Dashboard that prefills the editor with the current day's visible entries
- Header nav link

## Why one table with `is_favorite`, not two

Schautrack has no `foods` table — every entry in `calorie_entries` is free-form (name + kcal + optional macros). That makes "favorites" and "templates" the same data shape: a named collection of 1..N calorie-entry-shaped items. Collapsing them into a single `meal_templates` table with a boolean flag keeps the schema surface minimal and lets users promote/demote entries between "pinned" and "library" with one click. A partial index `WHERE is_favorite` keeps the chip-bar query cheap.

## Endpoints

All require `RequireLogin` + `CsrfProtection`, matching the `/entries` style:

```
GET  /api/templates[?favorites=true]
POST /templates
POST /templates/{id}/update
POST /templates/{id}/delete
POST /templates/{id}/favorite          # toggles; body {is_favorite: bool} explicit-sets
POST /templates/{id}/apply?day=YYYY-MM-DD
```

`Apply` wraps the inserts in a tx and broadcasts the existing `entry-change` SSE event so dashboards in other tabs refresh. Writes to templates themselves broadcast a new `template-change` event (gracefully ignored by older clients).

## Caps

- **200 templates per user** — DoS safety
- **50 items per template**
- Name 1..100 Unicode runes (`utf8.RuneCountInString`)
- Amount −9999..9999 kcal, macros 0..999 g — matches `calorie_entries` bounds

## Schema

Purely additive, idempotent migrations (`ensureMealTemplateSchema`). Rollback is `DROP TABLE meal_template_items; DROP TABLE meal_templates;` — no data migration needed.

- `meal_templates(id, user_id FK→users CASCADE, name, is_favorite, sort_order, created_at, updated_at)`
- `meal_template_items(id, template_id FK→meal_templates CASCADE, entry_name, amount, protein_g, carbs_g, fat_g, fiber_g, sugar_g, sort_order)`
- Indexes: `(user_id, sort_order, created_at DESC)`, partial `(user_id, sort_order) WHERE is_favorite`, `(template_id, sort_order)`
- CHECK constraints mirror `calorie_entries` bounds

## Edge cases handled

| Case | Behaviour |
|---|---|
| Apply empty template | Rejected at save time (`≥1 item`); defense-in-depth on apply |
| Future-dated apply | Allowed (matches existing `calorie_entries` freedom) |
| Delete template → historic entries | Untouched (items are copies, no FK back) |
| Double-tap apply | Client disables the button during the request; race duplicates accepted rather than adding an idempotency-token protocol the rest of the app doesn't use |
| Cross-tab stale chip | `template-change` SSE → React Query invalidates `['templates']` |
| Unicode name | Rune-count length check; default Postgres collation (no `CITEXT`) |

## Testing

- **Go unit tests** — table-driven validation in `internal/service/meal_template_test.go` (name bounds, amount/macro ranges, empty items, too-many items, each item must have name/kcal/macros)
- **Playwright E2E** — `e2e/meal-templates.spec.ts` covers: create with 2 items → star → chip on Dashboard → apply → 2 new entries → unstar → chip gone → delete → list empty, plus save-with-empty-items rejected

## What does NOT change

- No new env vars, no Helm chart change
- No i18n regression (English strings only, matching repo)
- CI workflow untouched — the existing `build.yml` path filters match

## Fork note

Self-hosters can deploy today from forks: the existing `build.yml` publishes to `ghcr.io/<fork>/schautrack` with no changes needed. This PR is already running in production on a self-hosted instance via that path.
