### PR TITLE
fix: don't wipe stored AI key on same-provider empty-key save

### DIFF
--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -213,8 +213,10 @@ func (h *SettingsHandler) AISettings(w http.ResponseWriter, r *http.Request) {
 		updates = append(updates, fmt.Sprintf("ai_key_last4 = $%d", idx))
 		values = append(values, last4)
 		idx++
-	} else if newProvider != nil {
-		// Clear key on provider change with no new key
+	} else if newProvider != nil && (user.PreferredAIProvider == nil || *user.PreferredAIProvider != *newProvider) {
+		// Clear stored key only when the provider actually changes, since keys are
+		// provider-specific. Saves with the same provider and empty key (common with
+		// autosave after the input is cleared client-side) must NOT wipe the existing key.
 		updates = append(updates, "ai_key = NULL", "ai_key_last4 = NULL")
 	}
 


### PR DESCRIPTION
## Summary

Saving the AI settings (provider + key + model) with a non-empty API key immediately wipes it from the DB. The "Saved" toast still appears, but `ai_key` ends up `NULL` and the Dashboard's AI feature disappears because the user no longer has a valid key.

## Repro

1. Go to Settings → AI
2. Select Provider = OpenAI, enter an API key (any non-empty value), wait for autosave
3. See "Saved" indicator
4. Refresh the page

**Expected:** placeholder shows `••••xxxx` (last 4 chars of the key), Dashboard shows AI estimate button.
**Actual:** placeholder shows "Enter API key", `ai_key` and `ai_key_last4` are `NULL` in the DB, AI UI gone.

## Root cause

Race in `SettingsHandler.AISettings` combined with the autosave UX:

1. User types key → `useAutosave` fires with `{ai_provider: "openai", ai_key: "sk-..."}`. Handler stores it. Toast = "Saved".
2. `AISettings.tsx` line 29: `if (d.apiKey) setApiKey('')` clears the input state.
3. The state change retriggers `useAutosave` ~1.2s later with `{ai_provider: "openai", ai_key: ""}`.
4. Handler hits the `else if newProvider != nil` branch and wipes `ai_key` + `ai_key_last4`.

The intent of that branch — "clear key on provider change with no new key" — is correct: OpenAI/Claude/Ollama keys aren't interchangeable, so switching provider should invalidate the old key. The bug is that it fires unconditionally when provider is non-nil, not only when it actually *changes*.

## Fix

Compare `newProvider` against the current user's `PreferredAIProvider` before clearing. One-line behavior change:

```go
} else if newProvider != nil && (user.PreferredAIProvider == nil || *user.PreferredAIProvider != *newProvider) {
    // Clear stored key only when the provider actually changes, since keys are
    // provider-specific. Saves with the same provider and empty key (common with
    // autosave after the input is cleared client-side) must NOT wipe the existing key.
    updates = append(updates, "ai_key = NULL", "ai_key_last4 = NULL")
}
```

Same intent, no longer clobbers idle saves.

## Scope

- One file touched: `internal/handler/settings.go`
- No schema, no env, no new deps
- No test changes (existing `go test ./...` still green — no handler test covers the exact race, happy to add one on request)

## Alternative considered

Fixing the frontend to stop sending empty `ai_key` would also work, but the backend contract is the real issue: any future client that posts `{provider: X, ai_key: ""}` hits the same trap. Backend fix is the robust one.
