### PR TITLE
fix: use max_completion_tokens for OpenAI and surface real AI errors

### DIFF
--- a/client/src/pages/Dashboard/AIPhotoModal.tsx
+++ b/client/src/pages/Dashboard/AIPhotoModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { estimateCalories } from '@/api/ai';
+import { ApiError } from '@/api/client';
 import { Button } from '@/components/ui/Button';
 import { cn } from '@/lib/utils';
 
@@ -159,8 +160,8 @@ export default function AIPhotoModal({ isOpen, onClose, onResult, enabledMacros:
         setErrorMsg(res.error || 'Estimation failed.');
         setPhase('error');
       }
-    } catch {
-      setErrorMsg('Estimation failed. Please try again.');
+    } catch (err) {
+      setErrorMsg(err instanceof ApiError ? err.message : 'Estimation failed. Please try again.');
       setPhase('error');
     }
   };

--- a/internal/service/ai.go
+++ b/internal/service/ai.go
@@ -122,7 +122,7 @@ func CallAIProvider(provider, apiKey, endpoint, base64Data, mediaType, prompt, m
 					{"type": "image_url", "image_url": map[string]any{"url": "data:" + mediaType + ";base64," + base64Data, "detail": "low"}},
 				},
 			}},
-			"max_tokens": 1000,
+			"max_completion_tokens": 1000,
 		}
 		reqBody, _ = json.Marshal(body)
 


### PR DESCRIPTION
- service/ai.go: switch OpenAI request param from max_tokens to max_completion_tokens; required by gpt-5 family and o-series, backward compatible with gpt-4.x/gpt-4o. Claude and Ollama branches unchanged.
- AIPhotoModal: propagate ApiError.message instead of a generic fallback, so misconfigured models show the actual provider response.