### PR TITLE
fix: validate EAN check digit and require two scans before lookup

### DIFF
--- a/client/src/pages/Dashboard/BarcodeScanModal.tsx
+++ b/client/src/pages/Dashboard/BarcodeScanModal.tsx
@@ -37,6 +37,10 @@ export default function BarcodeScanModal({ isOpen, onClose, onResult, enabledMac
   const scannerRef = useRef<HTMLDivElement>(null);
   const quaggaRunning = useRef(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Quagga2 fires onDetected several times per second and is prone to
+  // single-read errors (especially the EAN-13 check digit). Require two
+  // consecutive identical reads before triggering a lookup.
+  const lastCodeRef = useRef<{ code: string; count: number }>({ code: '', count: 0 });
 
   const stopScanner = useCallback(() => {
     if (quaggaRunning.current) {
@@ -113,8 +117,14 @@ export default function BarcodeScanModal({ isOpen, onClose, onResult, enabledMac
 
     Quagga.onDetected((data) => {
       const code = data.codeResult?.code;
-      if (code && /^\d{8,13}$/.test(code)) {
-        doLookup(code);
+      if (!code || !/^\d{8,13}$/.test(code)) return;
+      if (lastCodeRef.current.code === code) {
+        lastCodeRef.current.count += 1;
+        if (lastCodeRef.current.count >= 2) {
+          doLookup(code);
+        }
+      } else {
+        lastCodeRef.current = { code, count: 1 };
       }
     });
   }, [doLookup]);
@@ -139,6 +149,7 @@ export default function BarcodeScanModal({ isOpen, onClose, onResult, enabledMac
       setErrorMsg('');
       setCameraAvailable(true);
       setScannerReady(false);
+      lastCodeRef.current = { code: '', count: 0 };
     }
   }, [isOpen, stopScanner]);
 
@@ -218,6 +229,7 @@ export default function BarcodeScanModal({ isOpen, onClose, onResult, enabledMac
     setProduct(null);
     setGrams('100');
     setErrorMsg('');
+    lastCodeRef.current = { code: '', count: 0 };
   };
 
   const handleServingPreset = (g: number) => {

--- a/internal/handler/barcode.go
+++ b/internal/handler/barcode.go
@@ -16,6 +16,28 @@ import (
 
 var barcodeRe = regexp.MustCompile(`^\d{8,13}$`)
 
+// hasValidCheckDigit verifies the GS1 check digit for EAN-8 (8), UPC-A (12),
+// and EAN-13 (13). Other lengths skip validation (no standard checksum to
+// verify). The standard GS1 algorithm: from the right, multiply each non-check
+// digit alternately by 3 and 1, sum, and the check digit is (10 - sum%10) % 10.
+func hasValidCheckDigit(code string) bool {
+	n := len(code)
+	if n != 8 && n != 12 && n != 13 {
+		return true
+	}
+	var sum int
+	for i := 0; i < n-1; i++ {
+		d := int(code[i] - '0')
+		if (n-1-i)%2 == 1 {
+			sum += d * 3
+		} else {
+			sum += d
+		}
+	}
+	expected := (10 - sum%10) % 10
+	return int(code[n-1]-'0') == expected
+}
+
 func Barcode(cfg *config.Config) http.HandlerFunc {
 	userAgent := fmt.Sprintf("Schautrack/%s (%s)", cfg.BuildVersion, orDefault(cfg.SupportEmail, "noreply@schautrack.app"))
 
@@ -23,6 +45,14 @@ func Barcode(cfg *config.Config) http.HandlerFunc {
 		code := chi.URLParam(r, "code")
 		if !barcodeRe.MatchString(code) {
 			ErrorJSON(w, http.StatusBadRequest, "Invalid barcode format.")
+			return
+		}
+		if !hasValidCheckDigit(code) {
+			JSON(w, http.StatusOK, map[string]any{
+				"ok":    false,
+				"error": "Barcode check digit invalid — likely misread. Please rescan or enter manually.",
+				"code":  "CHECK_DIGIT",
+			})
 			return
 		}
 

--- a/internal/handler/barcode_test.go
+++ b/internal/handler/barcode_test.go
@@ -130,6 +130,63 @@ func TestBarcode_GatewayTimeout(t *testing.T) {
 	t.Log("Barcode handler uses hardcoded URL; gateway timeout test requires refactoring")
 }
 
+func TestHasValidCheckDigit(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		want bool
+	}{
+		// Real EAN-13 codes (verified against world.openfoodfacts.org)
+		{"EAN-13 Coca-Cola valid", "5449000000996", true},
+		{"EAN-13 Edeka Frischkäse valid", "4311501062449", true},
+		// Last-digit flips of valid EAN-13s — typical Quagga2 misreads
+		{"EAN-13 last digit off by 1", "4311501062448", false},
+		{"EAN-13 last digit zero", "4311501062440", false},
+		// Mid-digit flip
+		{"EAN-13 mid digit flipped", "4311501162449", false},
+		// Real EAN-8 (Coca-Cola mini)
+		{"EAN-8 valid", "96385074", true},
+		{"EAN-8 invalid", "96385075", false},
+		// UPC-A (12 digits)
+		{"UPC-A valid", "036000291452", true},
+		{"UPC-A invalid", "036000291453", false},
+		// Lengths without standard checksum: skipped (return true)
+		{"9 digits skipped", "123456789", true},
+		{"10 digits skipped", "1234567890", true},
+		{"11 digits skipped", "12345678901", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasValidCheckDigit(tt.code); got != tt.want {
+				t.Errorf("hasValidCheckDigit(%q) = %v, want %v", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBarcode_CheckDigitMismatch(t *testing.T) {
+	cfg := &config.Config{BuildVersion: "test", SupportEmail: "test@test.com"}
+	h := Barcode(cfg)
+
+	r := httptest.NewRequest("GET", "/api/barcode/4311501062448", nil)
+	r = withChiURLParam(r, "code", "4311501062448") // last digit flipped
+	w := httptest.NewRecorder()
+	h(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if ok, _ := resp["ok"].(bool); ok {
+		t.Errorf("expected ok=false, got %v", resp)
+	}
+	if code, _ := resp["code"].(string); code != "CHECK_DIGIT" {
+		t.Errorf("expected code=CHECK_DIGIT, got %q", code)
+	}
+}
+
 func TestOrDefault(t *testing.T) {
 	if got := orDefault("hello", "world"); got != "hello" {
 		t.Errorf("orDefault('hello', 'world') = %q, want 'hello'", got)


### PR DESCRIPTION
## Problem

Sometimes scanning a real product shows "Product not found" even though the product is in OpenFoodFacts. Manually entering the same barcode works.

Root cause: Quagga2 occasionally misreads a single digit — most often the EAN-13 check digit. The misread code is still 13 digits and passes the regex, hits OpenFoodFacts, and OFF returns `status:0` because that 13-digit string isn't a real product. The user sees a misleading "not found" instead of a "scan error" hint.

Verification with a real EAN-13:

| Code | OFF status |
|---|---|
| `4311501062449` (real product) | `1` — found |
| `4311501062448` (last digit flipped) | `0` — not found |
| `4311501062440` | `0` — not found |
| `4311501162449` (mid digit flipped) | `0` — not found |

Each misread is one false negative.

## Fix

### Backend (`internal/handler/barcode.go`)

Verify the GS1 check digit for EAN-8 (8 digits), UPC-A (12), and EAN-13 (13) before calling OpenFoodFacts. On mismatch, return:

```json
{ "ok": false, "error": "Barcode check digit invalid — likely misread. Please rescan or enter manually.", "code": "CHECK_DIGIT" }
```

The user now sees the difference between "scan error" and "not in DB". Lengths 9–11 have no standard checksum and skip the check (returning `true`).

### Frontend (`BarcodeScanModal.tsx`)

Require two consecutive identical reads from Quagga2's `onDetected` callback before firing the lookup. Quagga reads several times per second, so demanding agreement on consecutive frames filters single-frame errors with virtually no UX latency. The counter resets on retry/close.

## Tests

`internal/handler/barcode_test.go`:
- `TestHasValidCheckDigit` — covers EAN-13 / EAN-8 / UPC-A valid + invalid (including the specific Quagga last-digit-flip pattern), and verifies non-standard lengths skip validation.
- `TestBarcode_CheckDigitMismatch` — handler returns `ok:false code:"CHECK_DIGIT"` for misread.

## Test plan

- [x] `go test ./internal/handler/ -count=1`
- [x] `go build ./...`
- [x] `cd client && npx tsc -b`
- [x] Scan a real EAN-13 → product found.
- [x] Type a code with wrong check digit in manual mode → see "check digit invalid" message.
- [x] Camera scanning still works (consecutive reads should fire lookup within ~1 second of stable view).
