### PR TITLE
Promote staging → main (security fixes + accumulated staging changes)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ github.ref == 'refs/heads/staging' && 'arc-runner' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -60,7 +60,7 @@ jobs:
       platforms: ${{ steps.platforms.outputs.platforms }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -134,7 +134,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -157,7 +157,7 @@ jobs:
         platform: ${{ fromJson(needs.compute-version.outputs.platforms) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         if: matrix.platform != 'linux/amd64'
@@ -271,7 +271,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -341,7 +341,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -390,7 +390,7 @@ jobs:
           helm package helm/schautrack -d .helm-packages
 
       - name: Checkout gh-pages
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: gh-pages
           path: gh-pages

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1893,9 +1893,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
-      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "version": "5.101.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.1.tgz",
+      "integrity": "sha512-Y6Y92dkXtNqx67m2pMSxUsA3zOCwv862JexZRP8/EPwvKXMPu9m8rv43spiXWzOUIggQ3SQApttALStzhA8B4g==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1903,12 +1903,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
-      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "version": "5.101.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.1.tgz",
+      "integrity": "sha512-ZnONUuQKJe1bJMStXUL1s5uKN9FcfC28j5cK+iDZcdSHtUv1wtin1cGc/Oewhf2Oc4eKY7lggtpvT/AbMmhHew==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.101.0"
+        "@tanstack/query-core": "5.101.1"
       },
       "funding": {
         "type": "github",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,7 +21,7 @@
         "lucide-react": "^1.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router": "^7.6.1",
+        "react-router": "^8.0.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
         "zustand": "^5.0.5"
@@ -2014,18 +2014,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -2581,20 +2574,19 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.0.1.tgz",
+      "integrity": "sha512-5EL/fANovVUhRK50NLS8RYfX0BxrimoKsHWUPPy8v5UEl8i6vzF7e4POo3u+AhPItDwccUAJjMfIOmydxBJmQw==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -2661,12 +2653,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/sharp": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2390,9 +2390,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
-      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
+      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1956,13 +1956,13 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
-      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "^1.0.0"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1564,47 +1564,47 @@
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
-      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.21.0",
-        "jiti": "^2.6.1",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.0"
+        "tailwindcss": "4.3.1"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
-      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.0",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
-        "@tailwindcss/oxide-darwin-x64": "4.3.0",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+        "@tailwindcss/oxide-android-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-x64": "4.3.1",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
-      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
       "cpu": [
         "arm64"
       ],
@@ -1618,9 +1618,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
-      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
       "cpu": [
         "arm64"
       ],
@@ -1634,9 +1634,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
-      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
       "cpu": [
         "x64"
       ],
@@ -1650,9 +1650,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
-      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
       "cpu": [
         "x64"
       ],
@@ -1666,9 +1666,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
-      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
       "cpu": [
         "arm"
       ],
@@ -1682,9 +1682,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
-      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
       "cpu": [
         "arm64"
       ],
@@ -1701,9 +1701,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
       ],
@@ -1720,9 +1720,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
-      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
       "cpu": [
         "x64"
       ],
@@ -1739,9 +1739,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
       ],
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
-      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -1779,7 +1779,7 @@
         "@emnapi/runtime": "^1.10.0",
         "@emnapi/wasi-threads": "^1.2.1",
         "@napi-rs/wasm-runtime": "^1.1.4",
-        "@tybys/wasm-util": "^0.10.1",
+        "@tybys/wasm-util": "^0.10.2",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1832,7 +1832,7 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
+      "version": "0.10.2",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -1847,9 +1847,9 @@
       "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
       "cpu": [
         "arm64"
       ],
@@ -1863,9 +1863,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
       "cpu": [
         "x64"
       ],
@@ -1879,14 +1879,14 @@
       }
     },
     "node_modules/@tailwindcss/vite": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
-      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.1.tgz",
+      "integrity": "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==",
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/node": "4.3.0",
-        "@tailwindcss/oxide": "4.3.0",
-        "tailwindcss": "4.3.0"
+        "@tailwindcss/node": "4.3.1",
+        "@tailwindcss/oxide": "4.3.1",
+        "tailwindcss": "4.3.1"
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
@@ -2053,9 +2053,9 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
-      "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -2132,9 +2132,9 @@
       "optional": true
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -2733,9 +2733,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -672,12 +672,12 @@
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-arrow": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.9.tgz",
-      "integrity": "sha512-yqHW5WQ/cTpU/un7dqqIKNy2iRU8BC0JB78PEzTfCCYvZu1U6W9KwObAniMk9nhSfyotKPQTYaUD/HB0f5muig==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.10.tgz",
+      "integrity": "sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.5"
+        "@radix-ui/react-primitive": "2.1.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -695,16 +695,16 @@
       }
     },
     "node_modules/@radix-ui/react-checkbox": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.4.tgz",
-      "integrity": "sha512-m3JmIOAX5ZzZ6VPjxEU2dbTOhoHi0nT5riwcDwe8idocsWf4a5DXJLDtZ6LfJwMBx7W+A2b7kp2TgPEKtaiF6A==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.5.tgz",
+      "integrity": "sha512-pREzrmNnVwGvYaBoM64huTRK7B3lrTRuwj8A9nwhPiEtMb+yudiWh6zWAqEtP0Dzd5+iBa1Ki7V1pCxV8ExMdA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-primitive": "2.1.6",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-previous": "1.1.2",
         "@radix-ui/react-use-size": "1.1.2"
@@ -725,15 +725,15 @@
       }
     },
     "node_modules/@radix-ui/react-collection": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.9.tgz",
-      "integrity": "sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.10.tgz",
+      "integrity": "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.5",
-        "@radix-ui/react-slot": "1.2.5"
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-slot": "1.3.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -781,22 +781,22 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.16.tgz",
-      "integrity": "sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.17.tgz",
+      "integrity": "sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-dismissable-layer": "1.1.13",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-focus-scope": "1.1.10",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-portal": "1.1.12",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.5",
-        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.7.2"
@@ -832,14 +832,14 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.12.tgz",
-      "integrity": "sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.13.tgz",
+      "integrity": "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-primitive": "2.1.6",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-escape-keydown": "1.1.2"
       },
@@ -874,13 +874,13 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.9.tgz",
-      "integrity": "sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.10.tgz",
+      "integrity": "sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-primitive": "2.1.6",
         "@radix-ui/react-use-callback-ref": "1.1.2"
       },
       "peerDependencies": {
@@ -917,12 +917,12 @@
       }
     },
     "node_modules/@radix-ui/react-label": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.9.tgz",
-      "integrity": "sha512-rDoTeMbCwRVcnmo7NGT9IlPo1yXmEI+xc1URP3oeewwZEV4mdTp1dYUhYbQdo4D1q2SjKVvv4N1gNY77QAQtjA==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.10.tgz",
+      "integrity": "sha512-ib0zvq2ZsAqKm5tRnqGJn3vOxSgIts5ToxsXT0q1S/GfLD1Zj7UOEnkw8u2w6sRmn47djpQWuSU1DCL1R29/yw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.5"
+        "@radix-ui/react-primitive": "2.1.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -940,16 +940,16 @@
       }
     },
     "node_modules/@radix-ui/react-popper": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.0.tgz",
-      "integrity": "sha512-9PB589e1aWZbrlFUHdz6WiPCL+xLZHQFX7oibqG/6Q0SwOkxDyQX9W/cyPa+sAPPKuC8cpLCpRczE5a/1DiwVQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.1.tgz",
+      "integrity": "sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
-        "@radix-ui/react-arrow": "1.1.9",
+        "@radix-ui/react-arrow": "1.1.10",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-primitive": "2.1.6",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.2",
         "@radix-ui/react-use-rect": "1.1.2",
@@ -972,12 +972,12 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.11.tgz",
-      "integrity": "sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.12.tgz",
+      "integrity": "sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-primitive": "2.1.6",
         "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
@@ -1019,12 +1019,12 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz",
-      "integrity": "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
+      "integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-slot": "1.2.5"
+        "@radix-ui/react-slot": "1.3.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1042,31 +1042,31 @@
       }
     },
     "node_modules/@radix-ui/react-select": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.0.tgz",
-      "integrity": "sha512-mENc7WpJvJcW8hlMpzfFcHcEhTvYS5JMBmi9HVC1Q00uhBwML086MHYUV8QQdQv6lcu0Wg8dzd1RB8AFADcG/g==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.1.tgz",
+      "integrity": "sha512-w6eDvY78LE9ZUiNnXCA1QVK8RYN7k9galFv09kjVydJqBAgHd7Y9A6h0UJ/6DCZNGZMZrB2ohcSW1Bo9d8+wWA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.2",
         "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-collection": "1.1.10",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-dismissable-layer": "1.1.13",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-focus-scope": "1.1.10",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-popper": "1.3.0",
-        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-popper": "1.3.1",
+        "@radix-ui/react-portal": "1.1.12",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.5",
-        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-layout-effect": "1.1.2",
         "@radix-ui/react-use-previous": "1.1.2",
-        "@radix-ui/react-visually-hidden": "1.2.5",
+        "@radix-ui/react-visually-hidden": "1.2.6",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.7.2"
       },
@@ -1086,12 +1086,12 @@
       }
     },
     "node_modules/@radix-ui/react-separator": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.9.tgz",
-      "integrity": "sha512-gvgW+JV/Mbjj6darztTetnmElpQEzZrXpJvfj+dOxNAxiyHEAyUvEjjl4zxblvmjmKmi3jfPoy7ZdxzCuUBJSA==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.10.tgz",
+      "integrity": "sha512-Y6K6jLQCVfCnTL2MEtGxDLffkhNfEfHsEg3Wa8JU+IWdn3EWbLXd3OuOfQRN7p/W/cUce1WyTk3QeuAoDBzN9g==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.5"
+        "@radix-ui/react-primitive": "2.1.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1109,9 +1109,9 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
-      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3"
@@ -1263,12 +1263,12 @@
       }
     },
     "node_modules/@radix-ui/react-visually-hidden": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.5.tgz",
-      "integrity": "sha512-tPcHNI3FajdDBFpl/Ez1m2WL0ufJqBKyHxMDBvKitopamK36WwBGOMicuMEZKkM5Wce41QxUyv6BsiqfrWBiGg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.6.tgz",
+      "integrity": "sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.5"
+        "@radix-ui/react-primitive": "2.1.6"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -36,20 +36,20 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -633,13 +633,13 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -651,9 +651,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -1292,9 +1292,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
       "cpu": [
         "arm64"
       ],
@@ -1308,9 +1308,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
       "cpu": [
         "arm64"
       ],
@@ -1324,9 +1324,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
       "cpu": [
         "x64"
       ],
@@ -1340,9 +1340,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
       "cpu": [
         "x64"
       ],
@@ -1356,9 +1356,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
       "cpu": [
         "arm"
       ],
@@ -1372,9 +1372,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
       "cpu": [
         "arm64"
       ],
@@ -1391,9 +1391,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
       ],
@@ -1410,9 +1410,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
       "cpu": [
         "ppc64"
       ],
@@ -1429,9 +1429,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
       ],
@@ -1448,9 +1448,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
       "cpu": [
         "x64"
       ],
@@ -1467,9 +1467,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
       ],
@@ -1486,9 +1486,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
       "cpu": [
         "arm64"
       ],
@@ -1502,27 +1502,27 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
       "cpu": [
         "arm64"
       ],
@@ -1536,9 +1536,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
       "cpu": [
         "x64"
       ],
@@ -1919,9 +1919,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2617,12 +2617,12 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.137.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -2632,21 +2632,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3"
       }
     },
     "node_modules/scheduler": {
@@ -2848,15 +2848,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "rolldown": "~1.1.2",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -2873,7 +2873,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,7 @@
     "lucide-react": "^1.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router": "^7.6.1",
+    "react-router": "^8.0.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
     "zustand": "^5.0.5"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router';
 import { useAuthStore } from '@/stores/authStore';
+import { useDashboardStore } from '@/stores/dashboardStore';
 import { useSSE } from '@/hooks/useSSE';
 import { setOn401 } from '@/api/client';
 import { queryClient } from './main';
@@ -21,6 +22,7 @@ export default function App() {
       const wasAuthenticated = useAuthStore.getState().isInitialized && useAuthStore.getState().user !== null;
       clearUser();
       queryClient.clear();
+      useDashboardStore.getState().reset();
       if (wasAuthenticated) {
         navigateRef.current('/login', { replace: true });
       }

--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -34,7 +34,7 @@ export function register(data: { step: string; email?: string; password?: string
 }
 
 export function getRegistrationInfo() {
-  return api<{ registrationEnabled: boolean }>('/api/auth/registration-info');
+  return api<{ registrationEnabled: boolean; inviteRequired?: boolean }>('/api/auth/registration-info');
 }
 
 export function logout() {

--- a/client/src/components/Layout/Footer.tsx
+++ b/client/src/components/Layout/Footer.tsx
@@ -52,7 +52,7 @@ export default function Footer() {
           <a href="/terms" className="text-muted-foreground transition-colors hover:text-foreground">Terms</a>
           <span className="text-muted-foreground/30">·</span>
           <a
-            href="https://github.com/schaurian/schautrack#android-app"
+            href="https://play.google.com/store/apps/details?id=to.schauer.schautrack"
             target="_blank"
             rel="noopener noreferrer"
             title="Get the Android app"

--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router';
+import { useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/stores/authStore';
+import { useDashboardStore } from '@/stores/dashboardStore';
 import { logout } from '@/api/auth';
 import { cn } from '@/lib/utils';
 
@@ -8,6 +10,7 @@ export default function Header() {
   const { user, isAdmin, pendingLinkRequests, clearUser } = useAuthStore();
   const [menuOpen, setMenuOpen] = useState(false);
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { pathname } = useLocation();
   const navClass = (path: string) => {
     const active = pathname.startsWith(path);
@@ -18,7 +21,11 @@ export default function Header() {
   };
 
   const handleLogout = async () => {
+    // 1. Network logout, then 2. clear all client state so the previous
+    // account's data can't leak into the next login in this tab, then 3. navigate.
     try { await logout(); } catch { /* ignore */ }
+    queryClient.clear();
+    useDashboardStore.getState().reset();
     clearUser();
     navigate('/login');
   };

--- a/client/src/pages/Admin/Admin.tsx
+++ b/client/src/pages/Admin/Admin.tsx
@@ -269,7 +269,8 @@ function SettingField({
 }) {
   const [revealing, setRevealing] = useState(false);
   const isEnv = meta.source === 'env';
-  const isBool = ['enable_legal', 'enable_barcode', 'enable_registration', 'oidc_require_invite', 'smtp_secure', 'trust_proxy', 'robots_index'].includes(settingKey);
+  const isBool = ['enable_legal', 'enable_barcode', 'oidc_require_invite', 'smtp_secure', 'trust_proxy', 'robots_index'].includes(settingKey);
+  const isRegistrationMode = settingKey === 'enable_registration';
   const value = isDirty ? draft! : meta.value;
 
   // Secrets: don't pre-populate the input. Show a "set" indicator + Replace
@@ -303,7 +304,20 @@ function SettingField({
         {isDirty && <span className="text-[10px] text-primary">• unsaved</span>}
       </div>
 
-      {isBool ? (
+      {isRegistrationMode ? (
+        <select
+          id={fieldId}
+          className={inputClass}
+          value={value || ''}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={isEnv}
+        >
+          <option value="">(default: open)</option>
+          <option value="open">open — anyone can register</option>
+          <option value="invite">invite — requires an invite code</option>
+          <option value="false">false — registration disabled</option>
+        </select>
+      ) : isBool ? (
         <select
           id={fieldId}
           className={inputClass}

--- a/client/src/pages/Register/Register.tsx
+++ b/client/src/pages/Register/Register.tsx
@@ -22,13 +22,15 @@ export default function Register() {
   const [loading, setLoading] = useState(false);
   const [step, setStep] = useState<'credentials' | 'captcha'>('credentials');
   const [requireInvite, setRequireInvite] = useState(false);
+  const [registrationDisabled, setRegistrationDisabled] = useState(false);
   const [authInfo, setAuthInfo] = useState<AuthInfo | null>(null);
   const navigate = useNavigate();
   const { fetchUser } = useAuthStore();
 
   useEffect(() => {
     getRegistrationInfo().then((info) => {
-      if (!info.registrationEnabled) setRequireInvite(true);
+      if (!info.registrationEnabled) setRegistrationDisabled(true);
+      else if (info.inviteRequired) setRequireInvite(true);
     }).catch(() => {});
     getAuthInfo().then(setAuthInfo).catch(() => {});
   }, []);
@@ -65,6 +67,20 @@ export default function Register() {
       setLoading(false);
     }
   };
+
+  if (registrationDisabled) {
+    return (
+      <div className="flex justify-center py-12">
+        <Card className="w-full max-w-sm">
+          <h2 className="mb-6 text-xl font-semibold">Create Account</h2>
+          <Alert type="warning" message="Registration is currently disabled." className="mb-4" />
+          <div className="mt-6 text-sm">
+            <Link to="/login">Already have an account?</Link>
+          </div>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="flex justify-center py-12">

--- a/client/src/stores/dashboardStore.ts
+++ b/client/src/stores/dashboardStore.ts
@@ -12,22 +12,33 @@ interface DashboardState {
   selectDay: (date: string) => void;
   selectUser: (userId: number, label: string, canEdit: boolean) => void;
   setRange: (preset: number | null, start: string, end: string) => void;
+  reset: () => void;
 }
+
+// Initial (data-only) state. Recomputed on each call so `selectedDate`
+// reflects today at reset time, not module-load time.
+const initialState = (): Pick<DashboardState, 'selectedDate' | 'currentUserId' | 'currentLabel' | 'canEdit' | 'rangePreset' | 'rangeStart' | 'rangeEnd'> => ({
+  selectedDate: new Date().toISOString().slice(0, 10),
+  currentUserId: null,
+  currentLabel: 'You',
+  canEdit: true,
+  rangePreset: 14,
+  rangeStart: '',
+  rangeEnd: '',
+});
 
 export const useDashboardStore = create<DashboardState>()(
   persist(
     (set) => ({
-      selectedDate: new Date().toISOString().slice(0, 10),
-      currentUserId: null,
-      currentLabel: 'You',
-      canEdit: true,
-      rangePreset: 14,
-      rangeStart: '',
-      rangeEnd: '',
+      ...initialState(),
 
       selectDay: (date) => set({ selectedDate: date }),
       selectUser: (userId, label, canEdit) => set({ currentUserId: userId, currentLabel: label, canEdit }),
       setRange: (preset, start, end) => set({ rangePreset: preset, rangeStart: start, rangeEnd: end }),
+      // Restore all data fields to their initial values. Called on logout /
+      // session expiry so no account's currentUserId or dashboard state leaks
+      // into the next login in the same tab. Clears the persisted range too.
+      reset: () => set(initialState()),
     }),
     {
       name: 'schautrack.dashboard',

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -137,7 +137,7 @@ func main() {
 		r.With(authLimiter.Middleware, session.CsrfProtection).Post("/auth/register", authHandler.Register)
 		r.With(middleware.RequireLogin, session.CsrfProtection).Post("/auth/logout", authHandler.Logout)
 		r.With(strictLimiter.Middleware, session.CsrfProtection).Post("/auth/forgot-password", authHandler.ForgotPassword)
-		r.With(session.CsrfProtection).Post("/auth/reset-password", authHandler.ResetPassword)
+		r.With(strictLimiter.Middleware, session.CsrfProtection).Post("/auth/reset-password", authHandler.ResetPassword)
 		r.With(session.CsrfProtection).Post("/auth/verify-email", authHandler.VerifyEmail)
 		r.With(session.CsrfProtection).Post("/auth/verify-email/resend", authHandler.VerifyEmailResend)
 		r.Get("/auth/captcha", authHandler.Captcha)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -323,7 +323,10 @@ func main() {
 		Addr:         ":" + cfg.Port,
 		Handler:      r,
 		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 60 * time.Second, // Long for SSE
+		// Absolute per-response write deadline for slow-loris protection. The
+		// SSE handler clears this deadline for its own connection (via
+		// http.ResponseController) so long-lived streams are not force-closed.
+		WriteTimeout: 60 * time.Second,
 		IdleTimeout:  60 * time.Second,
 		BaseContext: func(_ net.Listener) context.Context {
 			return ctx

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -53,9 +53,13 @@ func main() {
 	}
 	defer pool.Close()
 
-	// Migrations
+	// Migrations. A broken/partial schema makes every query 500 while
+	// /api/health only pings the DB, so probes stay green and RollingUpdate
+	// (maxUnavailable:0) would swap a healthy pod for a broken one. Fail fast so
+	// the old healthy pod keeps serving.
 	if err := database.InitSchemaWithRetry(ctx, pool, 10); err != nil {
-		slog.Warn("schema init returned error", "error", err)
+		slog.Error("schema init failed after all retries; aborting startup", "error", err)
+		os.Exit(1)
 	}
 
 	// Services

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexedwards/argon2id v1.0.0
-	github.com/coreos/go-oidc/v3 v3.18.0
+	github.com/coreos/go-oidc/v3 v3.19.0
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-webauthn/webauthn v0.17.4
 	github.com/jackc/pgx/v5 v5.10.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/coreos/go-oidc/v3 v3.18.0 h1:V9orjXynvu5wiC9SemFTWnG4F45v403aIcjWo0d41+A=
 github.com/coreos/go-oidc/v3 v3.18.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
+github.com/coreos/go-oidc/v3 v3.19.0 h1:F/xyOi3x1UnG1U27YVnM1N6bHiL1K2upi6U/0qr8r+I=
+github.com/coreos/go-oidc/v3 v3.19.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/helm/schautrack/templates/_helpers.tpl
+++ b/helm/schautrack/templates/_helpers.tpl
@@ -81,7 +81,7 @@ Database URL
 */}}
 {{- define "schautrack.databaseUrl" -}}
 {{- if .Values.postgresql.enabled }}
-{{- printf "postgres://%s:%s@%s:5432/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password (include "schautrack.postgresql.fullname" .) .Values.postgresql.auth.database }}
+{{- printf "postgres://%s:%s@%s:5432/%s" (.Values.postgresql.auth.username | urlquery) (.Values.postgresql.auth.password | urlquery) (include "schautrack.postgresql.fullname" .) .Values.postgresql.auth.database }}
 {{- else }}
 {{- .Values.externalDatabase.url }}
 {{- end }}

--- a/helm/schautrack/templates/postgresql-deployment.yaml
+++ b/helm/schautrack/templates/postgresql-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "schautrack.fullname" . }}
+                  name: {{ .Values.existingSecret | default (include "schautrack.fullname" .) }}
                   key: POSTGRES_PASSWORD
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata

--- a/helm/schautrack/values.yaml
+++ b/helm/schautrack/values.yaml
@@ -146,7 +146,7 @@ postgresql:
   auth:
     database: schautrack
     username: schautrack
-    # Password (required) - generate with: openssl rand -base64 16
+    # Password (required) - generate with: openssl rand -hex 16
     # DO NOT use default passwords in production
     password: ""
   # Persistence configuration

--- a/internal/clientip/clientip.go
+++ b/internal/clientip/clientip.go
@@ -1,0 +1,58 @@
+// Package clientip derives the originating client IP from an HTTP request.
+//
+// It is shared by the rate limiter (internal/middleware) and the audit logger
+// (internal/service) so both agree on the same value and cannot drift. It lives
+// in its own leaf package to avoid a service ↔ middleware import cycle.
+package clientip
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// FromRequest returns the client IP for rate limiting and audit logging.
+//
+// When trustProxy is true (the default for k8s/Docker deployments sitting
+// behind a trusted reverse proxy or ingress) it derives the IP from proxy
+// headers. It deliberately uses the RIGHTMOST entry of X-Forwarded-For — the
+// address appended by the closest trusted proxy — because every entry to its
+// left is client-supplied and trivially forgeable. Trusting the leftmost value
+// (the previous behaviour) let an attacker rotate X-Forwarded-For on each
+// request to land in a fresh rate-limit bucket, defeating the brute-force gate
+// on login, 2FA and password reset.
+//
+// When trustProxy is false, proxy headers are ignored entirely and RemoteAddr
+// is used, so a directly-exposed instance cannot be spoofed.
+func FromRequest(r *http.Request, trustProxy bool) string {
+	if trustProxy {
+		if ip := rightmostForwarded(r.Header.Get("X-Forwarded-For")); ip != "" {
+			return ip
+		}
+		if xri := strings.TrimSpace(r.Header.Get("X-Real-Ip")); xri != "" && net.ParseIP(xri) != nil {
+			return xri
+		}
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return strings.TrimSpace(r.RemoteAddr)
+}
+
+// rightmostForwarded returns the last syntactically-valid IP in a
+// comma-separated X-Forwarded-For header, or "" if there is none. Scanning
+// right-to-left yields the entry appended by the nearest trusted proxy; a
+// downstream client can only prepend values, never append past the proxy.
+func rightmostForwarded(xff string) string {
+	if xff == "" {
+		return ""
+	}
+	parts := strings.Split(xff, ",")
+	for i := len(parts) - 1; i >= 0; i-- {
+		ip := strings.TrimSpace(parts[i])
+		if net.ParseIP(ip) != nil {
+			return ip
+		}
+	}
+	return ""
+}

--- a/internal/clientip/clientip_test.go
+++ b/internal/clientip/clientip_test.go
@@ -1,0 +1,91 @@
+package clientip
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newReq(remoteAddr, xff, xri string) *http.Request {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = remoteAddr
+	if xff != "" {
+		r.Header.Set("X-Forwarded-For", xff)
+	}
+	if xri != "" {
+		r.Header.Set("X-Real-Ip", xri)
+	}
+	return r
+}
+
+func TestFromRequest_TrustProxy(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		xri        string
+		want       string
+	}{
+		{"remote addr only", "192.168.1.1:1234", "", "", "192.168.1.1"},
+		{"xff single", "127.0.0.1:1234", "10.0.0.1", "", "10.0.0.1"},
+		// Rightmost entry wins: it is appended by the trusted proxy and is the
+		// only value the client cannot forge.
+		{"xff multiple takes rightmost", "127.0.0.1:1234", "10.0.0.1, 10.0.0.2", "", "10.0.0.2"},
+		{"xff three hops takes rightmost", "127.0.0.1:1234", "1.1.1.1, 2.2.2.2, 3.3.3.3", "", "3.3.3.3"},
+		{"xff preferred over xri", "127.0.0.1:1234", "10.0.0.1", "10.0.0.5", "10.0.0.1"},
+		{"xri used when no xff", "127.0.0.1:1234", "", "10.0.0.5", "10.0.0.5"},
+		// Spoofing: an attacker prepends garbage; the proxy still appends the
+		// real client, which is the rightmost valid IP.
+		{"spoofed leftmost ignored", "127.0.0.1:1234", "6.6.6.6, 203.0.113.9", "", "203.0.113.9"},
+		{"invalid rightmost skipped", "127.0.0.1:1234", "203.0.113.9, garbage", "", "203.0.113.9"},
+		{"all-invalid xff falls back to xri", "127.0.0.1:1234", "junk, nope", "10.0.0.5", "10.0.0.5"},
+		{"all-invalid xff and no xri falls back to remote", "192.168.1.9:1234", "junk", "", "192.168.1.9"},
+		{"invalid xri ignored, falls back to remote", "192.168.1.9:1234", "", "not-an-ip", "192.168.1.9"},
+		{"ipv6 remote addr", "[2001:db8::1]:1234", "", "", "2001:db8::1"},
+		{"whitespace trimmed", "127.0.0.1:1234", "  10.0.0.1 ,  10.0.0.2  ", "", "10.0.0.2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FromRequest(newReq(tt.remoteAddr, tt.xff, tt.xri), true)
+			if got != tt.want {
+				t.Errorf("FromRequest() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFromRequest_SpoofingSameBucket is the core security property: whatever an
+// attacker puts in the client-controlled (leftmost) XFF positions, the derived
+// IP is stable, so they cannot rotate it to get a fresh rate-limit bucket.
+func TestFromRequest_SpoofingSameBucket(t *testing.T) {
+	a := FromRequest(newReq("127.0.0.1:1234", "1.2.3.4, 203.0.113.9", ""), true)
+	b := FromRequest(newReq("127.0.0.1:1234", "9.9.9.9, 203.0.113.9", ""), true)
+	c := FromRequest(newReq("127.0.0.1:1234", "203.0.113.9", ""), true)
+	if a != b || b != c {
+		t.Errorf("spoofed leftmost changed the key: %q, %q, %q (want all equal)", a, b, c)
+	}
+}
+
+func TestFromRequest_NoTrustProxy(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		xri        string
+		want       string
+	}{
+		{"ignores xff", "192.168.1.1:1234", "10.0.0.1", "", "192.168.1.1"},
+		{"ignores xri", "192.168.1.1:1234", "", "10.0.0.5", "192.168.1.1"},
+		{"ignores both", "192.168.1.1:1234", "10.0.0.1, 10.0.0.2", "10.0.0.5", "192.168.1.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FromRequest(newReq(tt.remoteAddr, tt.xff, tt.xri), false)
+			if got != tt.want {
+				t.Errorf("FromRequest() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -188,6 +188,36 @@ func ensureEmailVerificationSchema(ctx context.Context, pool *pgxpool.Pool) erro
 		if err != nil {
 			return err
 		}
+
+		// One-time DATA backfill: grandfather in existing users that predate
+		// email verification (they have no pending token). This MUST run at most
+		// once — re-running it on every boot flips email_verified=TRUE for any
+		// user whose only tokens have since expired or been cleaned up by the
+		// 15-min sweep, silently verifying emails nobody confirmed (an email-
+		// verification bypass). A persistent marker row guards it. The DDL above
+		// still runs every boot; only this UPDATE is gated.
+		//
+		// schema_data_migrations is created and read only here, so there is no
+		// concurrent-CREATE race with the parallel ensureXxx migrations.
+		_, err = tx.Exec(ctx, `
+			CREATE TABLE IF NOT EXISTS schema_data_migrations (
+				name TEXT PRIMARY KEY,
+				applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+			)`)
+		if err != nil {
+			return err
+		}
+		var backfillDone bool
+		err = tx.QueryRow(ctx, `
+			SELECT EXISTS(
+				SELECT 1 FROM schema_data_migrations WHERE name = 'email_verified_backfill'
+			)`).Scan(&backfillDone)
+		if err != nil {
+			return err
+		}
+		if backfillDone {
+			return nil
+		}
 		_, err = tx.Exec(ctx, `
 			UPDATE users SET email_verified = TRUE
 			WHERE email_verified = FALSE
@@ -195,6 +225,12 @@ func ensureEmailVerificationSchema(ctx context.Context, pool *pgxpool.Pool) erro
 					SELECT DISTINCT user_id FROM email_verification_tokens
 					WHERE used = FALSE AND expires_at > NOW()
 				)`)
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(ctx, `
+			INSERT INTO schema_data_migrations (name) VALUES ('email_verified_backfill')
+			ON CONFLICT (name) DO NOTHING`)
 		return err
 	})
 }
@@ -482,28 +518,40 @@ func ensureDailyNotesSchema(ctx context.Context, pool *pgxpool.Pool) error {
 
 // InitSchemaWithRetry runs all migrations with exponential backoff.
 func InitSchemaWithRetry(ctx context.Context, pool *pgxpool.Pool, maxRetries int) error {
+	return retrySchemaInit(maxRetries, time.Second, func() error {
+		return runAllMigrations(ctx, pool)
+	})
+}
+
+// retrySchemaInit runs `run` up to maxRetries times with exponential backoff.
+// It returns nil on the first success, or the LAST error once all attempts are
+// exhausted. Returning that error (instead of nil) lets the caller fail fast:
+// serving traffic against a partial/missing schema causes every query to 500,
+// while /api/health only pings the DB — so probes stay green and a broken pod
+// would replace a healthy one under RollingUpdate maxUnavailable:0.
+func retrySchemaInit(maxRetries int, initialDelay time.Duration, run func() error) error {
 	if maxRetries == 0 {
 		maxRetries = 10
 	}
-	initialDelay := time.Second
 
+	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		err := runAllMigrations(ctx, pool)
-		if err == nil {
+		lastErr = run()
+		if lastErr == nil {
 			log.Println("Schema initialization successful")
 			return nil
 		}
 
 		delay := time.Duration(float64(initialDelay) * math.Pow(2, float64(attempt-1)))
-		log.Printf("Schema init failed (attempt %d/%d): %v", attempt, maxRetries, err)
+		log.Printf("Schema init failed (attempt %d/%d): %v", attempt, maxRetries, lastErr)
 		if attempt < maxRetries {
 			log.Printf("Retrying in %v...", delay)
 			time.Sleep(delay)
 		} else {
-			log.Println("Schema initialization failed after all retries. App will start but may have issues.")
+			log.Println("Schema initialization failed after all retries; aborting startup.")
 		}
 	}
-	return nil
+	return lastErr
 }
 
 func ensureOIDCAccountsSchema(ctx context.Context, pool *pgxpool.Pool) error {

--- a/internal/database/migrations_test.go
+++ b/internal/database/migrations_test.go
@@ -1,0 +1,48 @@
+package database
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestRetrySchemaInitReturnsLastError is a regression guard for the fail-fast
+// fix: once all retries are exhausted, retrySchemaInit must RETURN the last
+// error (not nil). Returning nil made the caller's error check dead code, so
+// the app booted against a partial/missing schema.
+func TestRetrySchemaInitReturnsLastError(t *testing.T) {
+	boom := errors.New("boom")
+	calls := 0
+
+	err := retrySchemaInit(3, 0, func() error {
+		calls++
+		return boom
+	})
+
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected the last error to propagate, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 attempts, got %d", calls)
+	}
+}
+
+// TestRetrySchemaInitSucceedsAfterTransientFailures verifies the loop stops and
+// returns nil on the first success, without exhausting the remaining retries.
+func TestRetrySchemaInitSucceedsAfterTransientFailures(t *testing.T) {
+	calls := 0
+
+	err := retrySchemaInit(5, 0, func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient")
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("expected nil after eventual success, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected to stop at the 3rd (successful) attempt, got %d calls", calls)
+	}
+}

--- a/internal/database/settings.go
+++ b/internal/database/settings.go
@@ -2,9 +2,11 @@ package database
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -48,15 +50,42 @@ func (sc *SettingsCache) GetEffectiveSetting(ctx context.Context, key string, en
 
 	var value *string
 	err := sc.pool.QueryRow(ctx, "SELECT value FROM admin_settings WHERE key = $1", key).Scan(&value)
-	if err != nil || value == nil {
-		result := SettingResult{Value: nil, Source: "none"}
-		sc.set(key, result)
-		return result
-	}
 
-	result := SettingResult{Value: value, Source: "db"}
-	sc.set(key, result)
+	var cached *SettingResult
+	if ok {
+		cached = &entry.result
+	}
+	result, cache := resolveSetting(value, err, cached)
+	if cache {
+		sc.set(key, result)
+	}
 	return result
+}
+
+// resolveSetting decides the SettingResult for a lookup and whether it is safe
+// to cache, given the DB scan outcome and any (possibly stale) cached entry.
+//
+// A negative result is only cached when the row genuinely does not exist
+// (pgx.ErrNoRows) or is SQL NULL. On any other error — most importantly a
+// canceled request context, which a client can trigger at will by aborting its
+// own request — we must NOT write {nil,"none"} to the cache for the full TTL,
+// or a single aborted request would, for a minute, make enable_registration,
+// the global ai_key, enable_legal, etc. read as unset for everyone. Instead we
+// serve the stale cached value if we have one, or an uncached negative result.
+func resolveSetting(value *string, err error, cached *SettingResult) (SettingResult, bool) {
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return SettingResult{Value: nil, Source: "none"}, true
+		}
+		if cached != nil {
+			return *cached, false
+		}
+		return SettingResult{Value: nil, Source: "none"}, false
+	}
+	if value == nil {
+		return SettingResult{Value: nil, Source: "none"}, true
+	}
+	return SettingResult{Value: value, Source: "db"}, true
 }
 
 func (sc *SettingsCache) SetAdminSetting(ctx context.Context, key string, value string) error {

--- a/internal/database/settings_test.go
+++ b/internal/database/settings_test.go
@@ -1,0 +1,87 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestResolveSetting(t *testing.T) {
+	staleVal := strPtr("stale-db-value")
+	stale := &SettingResult{Value: staleVal, Source: "db"}
+
+	tests := []struct {
+		name       string
+		value      *string
+		err        error
+		cached     *SettingResult
+		wantValue  *string
+		wantSource string
+		wantCache  bool
+	}{
+		{
+			name:       "no rows caches negative",
+			err:        pgx.ErrNoRows,
+			wantSource: "none",
+			wantCache:  true,
+		},
+		{
+			name:       "wrapped no rows caches negative",
+			err:        fmt.Errorf("query admin_settings: %w", pgx.ErrNoRows),
+			wantSource: "none",
+			wantCache:  true,
+		},
+		{
+			// The core fix: a transient error (e.g. canceled request context)
+			// must NOT poison the cache; serve the stale entry instead.
+			name:       "transient error with cache serves stale, no write",
+			err:        context.Canceled,
+			cached:     stale,
+			wantValue:  staleVal,
+			wantSource: "db",
+			wantCache:  false,
+		},
+		{
+			name:       "transient error without cache returns none, no write",
+			err:        context.Canceled,
+			wantSource: "none",
+			wantCache:  false,
+		},
+		{
+			name:       "value present caches db result",
+			value:      strPtr("real"),
+			wantValue:  strPtr("real"),
+			wantSource: "db",
+			wantCache:  true,
+		},
+		{
+			name:       "sql null value caches negative",
+			value:      nil,
+			err:        nil,
+			wantSource: "none",
+			wantCache:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, cache := resolveSetting(tt.value, tt.err, tt.cached)
+			if cache != tt.wantCache {
+				t.Errorf("cache = %v, want %v", cache, tt.wantCache)
+			}
+			if got.Source != tt.wantSource {
+				t.Errorf("Source = %q, want %q", got.Source, tt.wantSource)
+			}
+			if (got.Value == nil) != (tt.wantValue == nil) {
+				t.Fatalf("Value nil-ness = %v, want %v", got.Value == nil, tt.wantValue == nil)
+			}
+			if got.Value != nil && *got.Value != *tt.wantValue {
+				t.Errorf("Value = %q, want %q", *got.Value, *tt.wantValue)
+			}
+		})
+	}
+}

--- a/internal/handler/admin_settings.go
+++ b/internal/handler/admin_settings.go
@@ -98,10 +98,10 @@ var adminSettings = []AdminSetting{
 		Help:     "Enable barcode scanning via OpenFoodFacts.",
 		Validate: validBool},
 	{Key: "enable_registration", Env: "ENABLE_REGISTRATION", Section: "features", Tier: "hot",
-		Help: `"open" (or "true") to allow public sign-up; "false"/"invite" to require an invite code.`,
-		// Accept the bool form "true" too — the UI's bool toggle stores it as
-		// "true", and the auth handler treats anything that isn't "false" or
-		// "invite" as open registration.
+		Help: `"open" (or "true") allows public sign-up; "invite" requires a valid invite code; "false" fully disables sign-up.`,
+		// "true" is accepted as a synonym for "open". Anything unrecognised is
+		// treated as open registration (see registrationMode); only "invite"
+		// gates on a code and only "false" disables sign-up.
 		Validate: oneOf("open", "true", "false", "invite", "")},
 
 	// =========================================================================

--- a/internal/handler/api.go
+++ b/internal/handler/api.go
@@ -314,15 +314,19 @@ func AdminData(pool *pgxpool.Pool, settingsCache *database.SettingsCache, adminE
 	}
 }
 
-// RegistrationInfo handles GET /api/auth/registration-info (public endpoint)
+// RegistrationInfo handles GET /api/auth/registration-info (public endpoint).
+//
+// registrationEnabled reports whether sign-up is possible at all (open OR
+// invite mode) — the client uses it to decide whether to render the register
+// form. inviteRequired is an additive flag telling the client to show the
+// invite-code field up front when the server is in invite-only mode.
 func RegistrationInfo(settingsCache *database.SettingsCache, cfg *config.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		result := settingsCache.GetEffectiveSetting(r.Context(), "enable_registration", cfg.EnableRegistration)
-		enabled := true
-		if result.Value != nil && *result.Value == "false" {
-			enabled = false
-		}
-		JSON(w, http.StatusOK, map[string]any{"registrationEnabled": enabled})
+		mode := effectiveRegistrationMode(r.Context(), settingsCache, cfg)
+		JSON(w, http.StatusOK, map[string]any{
+			"registrationEnabled": mode != regModeClosed,
+			"inviteRequired":      mode == regModeInvite,
+		})
 	}
 }
 

--- a/internal/handler/api.go
+++ b/internal/handler/api.go
@@ -339,10 +339,20 @@ func CleanExpiredTokens(pool *pgxpool.Pool) {
 	if _, err := pool.Exec(ctx, "DELETE FROM invite_codes WHERE expires_at IS NOT NULL AND expires_at < NOW() AND used_by IS NULL"); err != nil {
 		slog.Error("failed to clean expired invite codes", "error", err)
 	}
+	// Reap abandoned password signups whose email was never verified. Federated
+	// (OIDC) and passkey-backed accounts must NEVER be deleted here: they
+	// authenticate via an external IdP / authenticator and legitimately have no
+	// email_verification_tokens row, so without these guards a freshly
+	// auto-created OIDC user (whose IdP reports email_verified = false, the
+	// stock Keycloak/Authentik/Authelia default) would be purged within minutes
+	// of signup, cascading away all of their entries. Exclude any user that has
+	// an OIDC account or a registered passkey.
 	if _, err := pool.Exec(ctx, `
 		DELETE FROM users
 		WHERE email_verified = FALSE
 			AND id NOT IN (SELECT DISTINCT user_id FROM email_verification_tokens WHERE used = FALSE)
+			AND NOT EXISTS (SELECT 1 FROM user_oidc_accounts o WHERE o.user_id = users.id)
+			AND NOT EXISTS (SELECT 1 FROM user_passkeys p WHERE p.user_id = users.id)
 	`); err != nil {
 		slog.Error("failed to clean unverified users", "error", err)
 	}

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -373,8 +373,16 @@ func (h *AuthHandler) registerCaptcha(w http.ResponseWriter, r *http.Request, se
 		sess.Set("verifyEmail", emailClean)
 		JSON(w, http.StatusOK, map[string]any{"ok": true, "requireVerification": true})
 	} else {
-		sess.SetUserID(userID)
-		sess.Set("auth_method", "password")
+		// Rotate the session ID on privilege elevation (session fixation),
+		// mirroring the login path above.
+		newSess, regenErr := h.SessionStore.Regenerate(r, sess)
+		if regenErr != nil {
+			ErrorJSON(w, http.StatusInternalServerError, "Could not register.")
+			return
+		}
+		newSess.SetUserID(userID)
+		newSess.Set("auth_method", "password")
+		session.SetSession(r, newSess)
 		OkJSON(w)
 	}
 }

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -176,14 +176,6 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *AuthHandler) isRegistrationEnabled(r *http.Request) bool {
-	result := h.Settings.GetEffectiveSetting(r.Context(), "enable_registration", h.Cfg.EnableRegistration)
-	if result.Value != nil && *result.Value == "false" {
-		return false
-	}
-	return true
-}
-
 func (h *AuthHandler) registerCredentials(w http.ResponseWriter, r *http.Request, sess *session.Session, email, password, timezone, inviteCode string) {
 	emailClean := strings.ToLower(strings.TrimSpace(email))
 	if emailClean == "" || password == "" {
@@ -195,8 +187,14 @@ func (h *AuthHandler) registerCredentials(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Check registration mode
-	if !h.isRegistrationEnabled(r) {
+	// Gate on the configured registration mode.
+	switch effectiveRegistrationMode(r.Context(), h.Settings, h.Cfg) {
+	case regModeClosed:
+		// Registration fully disabled — no invite code can override this.
+		ErrorJSON(w, http.StatusForbidden, "Registration is disabled.")
+		return
+	case regModeInvite:
+		// Invite-only: fail closed unless a valid, unused invite code is given.
 		inviteCode = strings.TrimSpace(inviteCode)
 		if inviteCode == "" {
 			JSON(w, http.StatusForbidden, map[string]any{"ok": false, "error": "Registration requires an invite code.", "requireInviteCode": true})
@@ -305,12 +303,22 @@ func (h *AuthHandler) registerCaptcha(w http.ResponseWriter, r *http.Request, se
 		return
 	}
 
-	// Check if invite mode is active — reject if no invite code was provided
+	// Re-check the registration mode at this final step — it may have changed
+	// between the credentials step and now. Never create a user in a mode that
+	// forbids it (fail closed).
 	invCode := sess.GetString("pendingInviteCode")
-	if invCode == "" && !h.isRegistrationEnabled(r) {
+	switch effectiveRegistrationMode(r.Context(), h.Settings, h.Cfg) {
+	case regModeClosed:
 		sess.Delete("pendingRegistration")
-		ErrorJSON(w, http.StatusForbidden, "Registration requires an invite code.")
+		sess.Delete("pendingInviteCode")
+		ErrorJSON(w, http.StatusForbidden, "Registration is disabled.")
 		return
+	case regModeInvite:
+		if invCode == "" {
+			sess.Delete("pendingRegistration")
+			ErrorJSON(w, http.StatusForbidden, "Registration requires an invite code.")
+			return
+		}
 	}
 
 	// Create user and claim invite code atomically in a transaction

--- a/internal/handler/auth_email.go
+++ b/internal/handler/auth_email.go
@@ -79,8 +79,16 @@ func (h *AuthHandler) VerifyEmail(w http.ResponseWriter, r *http.Request) {
 
 	sess.Delete("verifyEmail")
 	sess.Delete("verifyAttempts")
-	sess.SetUserID(userID)
-	sess.Set("auth_method", "password")
+	// Rotate the session ID on privilege elevation to prevent session fixation,
+	// mirroring the login path (auth.go).
+	newSess, regenErr := h.SessionStore.Regenerate(r, sess)
+	if regenErr != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Could not verify email.")
+		return
+	}
+	newSess.SetUserID(userID)
+	newSess.Set("auth_method", "password")
+	session.SetSession(r, newSess)
 	OkJSON(w)
 }
 

--- a/internal/handler/auth_password.go
+++ b/internal/handler/auth_password.go
@@ -90,6 +90,11 @@ func (h *AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !codeVerified {
+		attempts, _ := sess.GetInt("resetAttempts")
+		if attempts >= 5 {
+			ErrorJSON(w, http.StatusTooManyRequests, "Too many attempts.")
+			return
+		}
 		if body.Code == "" {
 			ErrorJSON(w, http.StatusBadRequest, "Code is required.")
 			return
@@ -105,10 +110,12 @@ func (h *AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 			ORDER BY prt.created_at DESC LIMIT 1`,
 			email, body.Code).Scan(&tokenID, &userID, &expiresAt)
 		if err != nil || time.Now().After(expiresAt) {
+			sess.Set("resetAttempts", attempts+1)
 			ErrorJSON(w, http.StatusBadRequest, "Invalid or expired code.")
 			return
 		}
 		sess.Set("resetCodeVerified", true)
+		sess.Delete("resetAttempts")
 		sess.Set("resetTokenId", tokenID)
 		sess.Set("resetUserId", userID)
 		JSON(w, http.StatusOK, map[string]any{"ok": true, "codeVerified": true})
@@ -154,5 +161,6 @@ func (h *AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 	sess.Delete("resetCodeVerified")
 	sess.Delete("resetTokenId")
 	sess.Delete("resetUserId")
+	sess.Delete("resetAttempts")
 	OkJSON(w)
 }

--- a/internal/handler/auth_password_test.go
+++ b/internal/handler/auth_password_test.go
@@ -1,0 +1,103 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"schautrack/internal/session"
+)
+
+// newRequestWithSessionData builds a POST request whose context carries the
+// given session, and returns both the request and the session so the test can
+// inspect counter state after the handler runs.
+func newRequestWithSessionData(url, body string, data map[string]any) (*http.Request, *session.Session) {
+	r := httptest.NewRequest("POST", url, strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	sess := &session.Session{
+		ID:     "test-session-id",
+		Data:   data,
+		MaxAge: session.AnonMaxAge,
+	}
+	ctx := session.WithTestSession(r.Context(), sess)
+	return r.WithContext(ctx), sess
+}
+
+// TestResetPassword_LockoutRejectsValidCode proves the per-session attempt
+// counter locks the reset flow after 5 failed attempts: once resetAttempts is
+// at the cap, even a would-be-valid code is rejected with 429 *before* any DB
+// lookup (a nil pool would panic if the guard did not short-circuit first).
+func TestResetPassword_LockoutRejectsValidCode(t *testing.T) {
+	h := &AuthHandler{Pool: nil} // nil pool: any DB access after the guard would panic
+
+	body := `{"code":"123456","password":"","confirm_password":""}`
+	r, sess := newRequestWithSessionData("/api/auth/reset-password", body, map[string]any{
+		"resetEmail":        "victim@example.com",
+		"resetCodeVerified": false,
+		"resetAttempts":     5,
+	})
+	w := httptest.NewRecorder()
+
+	h.ResetPassword(w, r)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusTooManyRequests)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if msg, _ := resp["error"].(string); !strings.Contains(msg, "Too many attempts") {
+		t.Errorf("error = %q, want message about too many attempts", msg)
+	}
+	// The guard returns before incrementing, so the counter stays at the cap.
+	if attempts, _ := sess.GetInt("resetAttempts"); attempts != 5 {
+		t.Errorf("resetAttempts = %d, want 5", attempts)
+	}
+}
+
+// TestResetPassword_UnderLimitNotLocked proves the threshold is exactly 5:
+// at 4 recorded attempts the flow is NOT locked and proceeds past the guard to
+// normal validation (here, an empty code -> 400 "Code is required.").
+func TestResetPassword_UnderLimitNotLocked(t *testing.T) {
+	h := &AuthHandler{Pool: nil}
+
+	body := `{"code":"","password":"","confirm_password":""}`
+	r, _ := newRequestWithSessionData("/api/auth/reset-password", body, map[string]any{
+		"resetEmail":        "user@example.com",
+		"resetCodeVerified": false,
+		"resetAttempts":     4,
+	})
+	w := httptest.NewRecorder()
+
+	h.ResetPassword(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (not locked out)", w.Code, http.StatusBadRequest)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if msg, _ := resp["error"].(string); !strings.Contains(msg, "Code is required") {
+		t.Errorf("error = %q, want message about code required", msg)
+	}
+}
+
+// TestResetPassword_NoSession rejects requests without an active reset session.
+func TestResetPassword_NoSession(t *testing.T) {
+	h := &AuthHandler{Pool: nil}
+
+	body := `{"code":"123456"}`
+	r, _ := newRequestWithSessionData("/api/auth/reset-password", body, map[string]any{})
+	w := httptest.NewRecorder()
+
+	h.ResetPassword(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if msg, _ := resp["error"].(string); !strings.Contains(msg, "No reset session") {
+		t.Errorf("error = %q, want message about no reset session", msg)
+	}
+}

--- a/internal/handler/oidc.go
+++ b/internal/handler/oidc.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -88,6 +89,32 @@ func (h *OIDCHandler) Login(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, url, http.StatusFound)
 }
 
+// safeNextPath returns next if it is a safe same-origin path to redirect the
+// user back to, otherwise fallback. It defends against open redirects: values
+// browsers normalise into a different origin — protocol-relative ("//host"),
+// backslash-obfuscated ("/\host", which browsers treat as "//host") and
+// absolute or scheme-bearing URLs — are rejected, as are values containing
+// control characters that could split the Location header.
+func safeNextPath(next, fallback string) string {
+	if next == "" {
+		return fallback
+	}
+	// Browsers treat "\" as "/", so a lone leading "/" followed by "\" becomes
+	// protocol-relative. Reject backslashes and header-splitting control chars.
+	if strings.ContainsAny(next, "\\\x00\r\n\t") {
+		return fallback
+	}
+	// Must be a rooted path and not protocol-relative ("//host").
+	if !strings.HasPrefix(next, "/") || strings.HasPrefix(next, "//") {
+		return fallback
+	}
+	// Final guard: no scheme or host component may survive parsing.
+	if u, err := url.Parse(next); err != nil || u.Scheme != "" || u.Host != "" || !strings.HasPrefix(u.Path, "/") {
+		return fallback
+	}
+	return next
+}
+
 // StepUpInit handles GET /auth/oidc/step-up — initiates an OIDC redirect
 // whose only purpose is to elevate the existing session for sensitive
 // auth-method changes. After the IdP returns the user, the callback
@@ -114,10 +141,7 @@ func (h *OIDCHandler) StepUpInit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	next := r.URL.Query().Get("next")
-	if !strings.HasPrefix(next, "/") || strings.HasPrefix(next, "//") {
-		next = "/settings"
-	}
+	next := safeNextPath(r.URL.Query().Get("next"), "/settings")
 
 	sess := session.GetSession(r)
 	sess.Set("oidc_state", state)
@@ -206,11 +230,11 @@ func (h *OIDCHandler) handleStepUp(w http.ResponseWriter, r *http.Request, sess 
 		return
 	}
 
-	next := sess.GetString("oidc_step_up_next")
+	// Re-validate on use as defence in depth; also normalises an empty value
+	// (e.g. a dropped session) to a safe default so the redirect target below
+	// is never a bare "?..." relative to the callback path.
+	next := safeNextPath(sess.GetString("oidc_step_up_next"), "/settings")
 	sess.Delete("oidc_step_up_next")
-	if next == "" {
-		next = "/settings"
-	}
 
 	account, err := service.FindOIDCAccount(r.Context(), h.Pool, provider, subject)
 	if err != nil || account == nil || account.UserID != user.ID {

--- a/internal/handler/oidc.go
+++ b/internal/handler/oidc.go
@@ -401,15 +401,25 @@ func (h *OIDCHandler) Unlink(w http.ResponseWriter, r *http.Request) {
 	OkJSON(w)
 }
 
+// canAutoCreate reports whether an OIDC login for an unknown subject/email may
+// auto-provision a brand-new account. It fails closed for anything other than
+// open registration: the OIDC auto-create flow has no way to collect or
+// validate an invite code, so allowing it in invite-only mode would bypass the
+// invite gate, and "closed" means no new accounts at all.
 func (h *OIDCHandler) canAutoCreate(r *http.Request) bool {
 	if h.Cfg.OIDCRequireInvite {
 		return false
 	}
-	result := h.Settings.GetEffectiveSetting(r.Context(), "enable_registration", h.Cfg.EnableRegistration)
-	if result.Value != nil && *result.Value == "false" {
-		return h.Cfg.OIDCRequireInvite == false // OIDC bypasses invite-only unless explicitly required
+	switch effectiveRegistrationMode(r.Context(), h.Settings, h.Cfg) {
+	case regModeClosed:
+		// Sign-up fully disabled — never auto-create from SSO.
+		return false
+	case regModeInvite:
+		// Invite-only: SSO auto-provisioning would bypass the invite gate.
+		return false
+	default: // open
+		return true
 	}
-	return true
 }
 
 func generateRandomString(n int) (string, error) {

--- a/internal/handler/oidc_test.go
+++ b/internal/handler/oidc_test.go
@@ -1,0 +1,41 @@
+package handler
+
+import "testing"
+
+func TestSafeNextPath(t *testing.T) {
+	const fb = "/settings"
+	tests := []struct {
+		name string
+		next string
+		want string
+	}{
+		{"empty falls back", "", fb},
+		{"simple path", "/dashboard", "/dashboard"},
+		{"nested path", "/settings/security", "/settings/security"},
+		{"path with query kept", "/foods?tab=recent", "/foods?tab=recent"},
+		{"root path", "/", "/"},
+
+		// Open-redirect vectors that must all fall back.
+		{"protocol relative", "//evil.com", fb},
+		{"backslash obfuscation", "/\\evil.com", fb},
+		{"backslash double", "/\\/evil.com", fb},
+		{"absolute http url", "http://evil.com", fb},
+		{"absolute https url", "https://evil.com/path", fb},
+		{"scheme relative with backslashes", "\\\\evil.com", fb},
+		{"javascript scheme", "javascript:alert(1)", fb},
+		{"no leading slash", "evil.com", fb},
+		{"leading space then slash", " /dashboard", fb},
+		{"embedded newline", "/foo\nbar", fb},
+		{"embedded CR", "/foo\rbar", fb},
+		{"null byte", "/foo\x00bar", fb},
+		{"tab char", "/foo\tbar", fb},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := safeNextPath(tt.next, fb); got != tt.want {
+				t.Errorf("safeNextPath(%q) = %q, want %q", tt.next, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/handler/registration.go
+++ b/internal/handler/registration.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"context"
+	"strings"
+
+	"schautrack/internal/config"
+	"schautrack/internal/database"
+)
+
+// Registration modes returned by registrationMode.
+const (
+	regModeOpen   = "open"   // anyone may register, no invite required
+	regModeInvite = "invite" // registration allowed only with a valid invite code
+	regModeClosed = "closed" // registration fully disabled
+)
+
+// registrationMode normalizes the raw enable_registration setting value into
+// one of three canonical modes. It fails safe in the security-sensitive
+// direction: only the explicit "false" value disables sign-up, and only the
+// explicit "invite" value gates on an invite code. Every other value —
+// "" (unset), "open", "true", or anything unrecognised — is treated as open
+// registration.
+func registrationMode(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "false":
+		return regModeClosed
+	case "invite":
+		return regModeInvite
+	default:
+		return regModeOpen
+	}
+}
+
+// effectiveRegistrationMode resolves the active registration mode from the
+// admin settings cache (env var → DB → default), normalised via
+// registrationMode. This is the single source of truth used by every code
+// path that gates sign-up (credential registration, the registration-info
+// endpoint, and OIDC auto-provisioning).
+func effectiveRegistrationMode(ctx context.Context, settings *database.SettingsCache, cfg *config.Config) string {
+	result := settings.GetEffectiveSetting(ctx, "enable_registration", cfg.EnableRegistration)
+	val := ""
+	if result.Value != nil {
+		val = *result.Value
+	}
+	return registrationMode(val)
+}

--- a/internal/handler/registration_test.go
+++ b/internal/handler/registration_test.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"schautrack/internal/config"
+	"schautrack/internal/database"
+)
+
+func TestRegistrationMode(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{"empty is open", "", regModeOpen},
+		{"open is open", "open", regModeOpen},
+		{"true is open", "true", regModeOpen},
+		{"invite is invite", "invite", regModeInvite},
+		{"false is closed", "false", regModeClosed},
+		{"unknown value falls back to open", "yes", regModeOpen},
+		{"uppercase invite is invite", "INVITE", regModeInvite},
+		{"padded false is closed", "  false  ", regModeClosed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := registrationMode(tt.value); got != tt.want {
+				t.Errorf("registrationMode(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// invite/closed mode both reject at the credentials step before any DB access,
+// so we can drive them with a nil pool. The settings cache resolves the mode
+// from the env-backed config value (GetEffectiveSetting short-circuits on a
+// non-empty env value without touching the pool).
+
+func TestRegisterCredentials_InviteMode_RejectsWithoutCode(t *testing.T) {
+	h := &AuthHandler{
+		Pool:     nil, // must not be touched — rejection happens before any query
+		Cfg:      &config.Config{EnableRegistration: "invite"},
+		Settings: database.NewSettingsCache(nil),
+	}
+
+	body := `{"step":"credentials","email":"test@example.com","password":"longenoughpassword","timezone":"UTC"}`
+	r := newRequestWithSession("POST", "/api/auth/register", body)
+	w := httptest.NewRecorder()
+
+	h.Register(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if req, _ := resp["requireInviteCode"].(bool); !req {
+		t.Errorf("expected requireInviteCode=true in response, got %v", resp)
+	}
+}
+
+func TestRegisterCredentials_ClosedMode_RejectsRegistration(t *testing.T) {
+	h := &AuthHandler{
+		Pool:     nil,
+		Cfg:      &config.Config{EnableRegistration: "false"},
+		Settings: database.NewSettingsCache(nil),
+	}
+
+	// Even with an invite code supplied, closed mode must reject entirely.
+	body := `{"step":"credentials","email":"test@example.com","password":"longenoughpassword","timezone":"UTC","invite_code":"anything"}`
+	r := newRequestWithSession("POST", "/api/auth/register", body)
+	w := httptest.NewRecorder()
+
+	h.Register(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if req, _ := resp["requireInviteCode"].(bool); req {
+		t.Errorf("closed mode must not offer an invite path, got %v", resp)
+	}
+}

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -2,10 +2,11 @@ package middleware
 
 import (
 	"encoding/json"
-	"net"
 	"net/http"
 	"sync"
 	"time"
+
+	"schautrack/internal/clientip"
 )
 
 type rateLimitEntry struct {
@@ -92,24 +93,9 @@ func (rl *RateLimiter) cleanup() {
 	}
 }
 
-// clientIP extracts the client IP from the request. When trustProxy is true,
-// it reads X-Forwarded-For and X-Real-Ip headers set by a reverse proxy or
-// Kubernetes ingress. When false, it uses RemoteAddr directly to prevent
-// clients from spoofing their IP.
+// clientIP extracts the client IP used as the rate-limit bucket key. It
+// delegates to the shared clientip.FromRequest so the limiter and the audit
+// logger derive the same, non-spoofable value from proxy headers.
 func clientIP(r *http.Request, trustProxy bool) string {
-	if trustProxy {
-		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-			for i := 0; i < len(xff); i++ {
-				if xff[i] == ',' {
-					return xff[:i]
-				}
-			}
-			return xff
-		}
-		if xri := r.Header.Get("X-Real-Ip"); xri != "" {
-			return xri
-		}
-	}
-	host, _, _ := net.SplitHostPort(r.RemoteAddr)
-	return host
+	return clientip.FromRequest(r, trustProxy)
 }

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -231,7 +231,9 @@ func TestClientIP_TrustProxy(t *testing.T) {
 	}{
 		{"remote addr only", "192.168.1.1:1234", "", "", "192.168.1.1"},
 		{"x-forwarded-for single", "127.0.0.1:1234", "10.0.0.1", "", "10.0.0.1"},
-		{"x-forwarded-for multiple", "127.0.0.1:1234", "10.0.0.1, 10.0.0.2", "", "10.0.0.1"},
+		// Rightmost (proxy-appended) entry wins; the leftmost is client-supplied.
+		{"x-forwarded-for multiple", "127.0.0.1:1234", "10.0.0.1, 10.0.0.2", "", "10.0.0.2"},
+		{"spoofed leftmost cannot change the key", "127.0.0.1:1234", "6.6.6.6, 10.0.0.2", "", "10.0.0.2"},
 		{"x-real-ip", "127.0.0.1:1234", "", "10.0.0.5", "10.0.0.5"},
 		{"xff takes precedence over xri", "127.0.0.1:1234", "10.0.0.1", "10.0.0.5", "10.0.0.1"},
 	}

--- a/internal/service/audit.go
+++ b/internal/service/audit.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"net"
 	"net/http"
+
+	"schautrack/internal/clientip"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -70,22 +71,10 @@ func WriteAudit(ctx context.Context, pool *pgxpool.Pool, trustProxy bool,
 	}
 }
 
-// clientIPFromRequest mirrors middleware.ClientIP. Inlined to avoid a
-// service → middleware import cycle (middleware already imports service).
+// clientIPFromRequest delegates to the shared clientip package so the audit
+// log and the rate limiter record the same, non-spoofable client IP. It lives
+// in its own leaf package (not middleware) to avoid a service → middleware
+// import cycle.
 func clientIPFromRequest(r *http.Request, trustProxy bool) string {
-	if trustProxy {
-		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-			for i := 0; i < len(xff); i++ {
-				if xff[i] == ',' {
-					return xff[:i]
-				}
-			}
-			return xff
-		}
-		if xri := r.Header.Get("X-Real-Ip"); xri != "" {
-			return xri
-		}
-	}
-	host, _, _ := net.SplitHostPort(r.RemoteAddr)
-	return host
+	return clientip.FromRequest(r, trustProxy)
 }

--- a/internal/session/deadline_test.go
+++ b/internal/session/deadline_test.go
@@ -1,0 +1,50 @@
+package session
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestDeferredSaveWriterUnwrapReachesWriteDeadline guards the SSE fix: the SSE
+// handler clears its per-connection write deadline via
+// http.NewResponseController(w).SetWriteDeadline(time.Time{}). That only works
+// if every ResponseWriter wrapper between the router and the handler exposes
+// Unwrap() so the controller can reach the underlying net/http conn. The
+// session middleware wraps the writer in deferredSaveWriter, so this test
+// asserts that wrapper does not break the Unwrap chain over a real server
+// (where the base writer actually supports SetWriteDeadline).
+func TestDeferredSaveWriterUnwrapReachesWriteDeadline(t *testing.T) {
+	var clearErr error
+	cleared := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Wrap exactly as session.Middleware does. saved:true short-circuits
+		// saveOnce so the write below doesn't reach the (nil) store — the
+		// deadline clear under test does not depend on the session save path.
+		rw := &deferredSaveWriter{ResponseWriter: w, saved: true}
+		rc := http.NewResponseController(rw)
+		clearErr = rc.SetWriteDeadline(time.Time{})
+		close(cleared)
+		fmt.Fprint(rw, "ok")
+		rw.Flush()
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	<-cleared
+
+	if clearErr != nil {
+		t.Fatalf("SetWriteDeadline through deferredSaveWriter returned %v (ErrNotSupported=%v); "+
+			"the Unwrap chain is broken and SSE streams would be force-closed by WriteTimeout",
+			clearErr, clearErr == http.ErrNotSupported)
+	}
+}

--- a/internal/sse/broker.go
+++ b/internal/sse/broker.go
@@ -141,6 +141,19 @@ func (b *Broker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	flusher.Flush()
 
+	// Clear the write deadline for this long-lived stream. The server sets a
+	// 60s WriteTimeout to blunt slow clients on ordinary responses, but that is
+	// a single absolute deadline for the whole response — net/http never
+	// refreshes it per write. Left in place it would force-close every SSE
+	// stream after ~60s, causing needless reconnect churn (each reconnect costs
+	// a session load + full user SELECT) and dropping any events broadcast
+	// during the reconnect gap. NewResponseController reaches the underlying
+	// net/http conn through the session middleware's deferredSaveWriter.Unwrap().
+	rc := http.NewResponseController(w)
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		slog.Warn("failed to clear SSE write deadline", "error", err)
+	}
+
 	ch := b.Subscribe(userID)
 	defer func() {
 		b.Unsubscribe(userID, ch)

--- a/package-lock.json
+++ b/package-lock.json
@@ -452,13 +452,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -525,13 +525,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
Promotes 27 staging commits to `main` (production). Highlights:

- **Security (PR #151):** X-Forwarded-For rate-limit bypass, SettingsCache poisoning, OIDC step-up open redirect, session fixation — all unit-tested, validated on staging.
- Earlier staging fixes: password-reset brute-force cap, SSE write-deadline, migration fail-fast, OIDC/passkey unverified-purge exclusion, logout cache clear, helm existingSecret/DATABASE_URL encoding, invite-code gating.
- Dependency updates (react-router v8, vite v8, tailwind, radix, react-query, go-oidc, etc.).

Clean fast-forward from `main`. Staging is healthy and serving these changes.