### PR TITLE
ci: drop unknown/unknown attestation images from GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,11 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Disable SLSA provenance / SBOM attestations. They are pushed as
+          # extra manifest entries that show up as "unknown/unknown" platforms
+          # on the GHCR package page (one per built arch), cluttering it.
+          provenance: false
+          sbom: false
 
       - name: Export digest
         run: |


### PR DESCRIPTION
The `latest` manifest index contains `linux/amd64`, `linux/arm64`, **and two `unknown/unknown`** entries — SLSA **provenance attestations** that `docker/build-push-action` attaches by default. They clutter the GHCR package page.

Fix: `provenance: false` + `sbom: false` on the build step. Future builds publish only the real arch manifests.

Note: this affects **new** builds only; existing images keep their `unknown/unknown` entries until pruned (the scheduled cleanup deletes untagged versions >1 day old).