### PR TITLE
fix(ai): harden AI estimation subsystem (audit #140/#141/#142)

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -230,6 +230,3 @@ func (h *AdminHandler) DeleteInvite(w http.ResponseWriter, r *http.Request) {
 	}
 	OkJSON(w)
 }
-
-// Suppress unused
-var _ = strings.TrimSpace

--- a/internal/handler/ai.go
+++ b/internal/handler/ai.go
@@ -1,8 +1,10 @@
 package handler
 
 import (
-	"encoding/json"
+	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"regexp"
@@ -23,14 +25,98 @@ type AIHandler struct {
 	Settings *database.SettingsCache
 }
 
-var imageDataRe = regexp.MustCompile(`^data:image/\w+;base64,`)
+var (
+	imageDataRe      = regexp.MustCompile(`^data:image/\w+;base64,`)
+	imageMediaTypeRe = regexp.MustCompile(`^data:(image/\w+);base64,`)
+)
+
+const (
+	// maxImageBase64Bytes is the largest accepted base64 image payload:
+	// 14MB of base64 is roughly 10MB of raw image data (~1.37x blowup).
+	maxImageBase64Bytes = 14 * 1024 * 1024
+	// maxAIRequestBytes bounds the AI estimate JSON body. It must fit the
+	// 14MB base64 image plus JSON overhead and matches the global 15MB
+	// body cap set in cmd/server/main.go.
+	maxAIRequestBytes = 15 << 20
+)
+
+// aiConfigInputs are the effective global (admin panel / env) and user-level
+// AI settings feeding resolveAIConfig. UserKey must already be decrypted.
+type aiConfigInputs struct {
+	GlobalKey      string
+	GlobalEndpoint string
+	GlobalModel    string
+	UserKey        string
+	UserModel      string
+}
+
+// resolvedAIConfig is the credential set to use for an AI call.
+type resolvedAIConfig struct {
+	APIKey         string
+	Endpoint       string
+	Model          string
+	UsingGlobalKey bool
+}
+
+// resolveAIConfig implements the documented three-tier key hierarchy: a
+// global admin key takes precedence and pins endpoint and model to the global
+// config; otherwise the user's personal key applies, with global settings
+// filling any gaps. Only a global KEY disables personal keys — a provider-only
+// global config must NOT block users from using their own saved key.
+func resolveAIConfig(in aiConfigInputs) resolvedAIConfig {
+	if in.GlobalKey != "" {
+		return resolvedAIConfig{
+			APIKey:         in.GlobalKey,
+			Endpoint:       in.GlobalEndpoint,
+			Model:          in.GlobalModel,
+			UsingGlobalKey: true,
+		}
+	}
+	model := in.UserModel
+	if model == "" {
+		model = in.GlobalModel
+	}
+	return resolvedAIConfig{
+		APIKey:   in.UserKey,
+		Endpoint: in.GlobalEndpoint,
+		Model:    model,
+	}
+}
+
+// aiClientErrorMessage maps an AI provider failure to a safe client-facing
+// message. It must never include the raw upstream response body or the
+// (possibly internal) endpoint URL — those are logged server-side instead.
+func aiClientErrorMessage(err error) string {
+	var provErr *service.AIProviderError
+	if errors.As(err, &provErr) {
+		switch provErr.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return "The AI provider rejected the configured API key."
+		case http.StatusTooManyRequests:
+			return "The AI provider is rate limiting requests. Please try again later."
+		}
+	}
+	return "AI estimation failed, please try again."
+}
+
+func settingValue(s database.SettingResult) string {
+	if s.Value == nil {
+		return ""
+	}
+	return *s.Value
+}
 
 func (h *AIHandler) Estimate(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Image   string `json:"image"`
 		Context string `json:"context"`
 	}
-	if err := ReadJSON(r, &body); err != nil {
+	if err := ReadJSONLimit(w, r, &body, maxAIRequestBytes); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			ErrorJSON(w, http.StatusRequestEntityTooLarge, "Image too large. Maximum size is 10MB.")
+			return
+		}
 		ErrorJSON(w, http.StatusBadRequest, "Invalid request.")
 		return
 	}
@@ -39,7 +125,7 @@ func (h *AIHandler) Estimate(w http.ResponseWriter, r *http.Request) {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid image data")
 		return
 	}
-	if len(body.Image) > 14*1024*1024 {
+	if len(body.Image) > maxImageBase64Bytes {
 		ErrorJSON(w, http.StatusRequestEntityTooLarge, "Image too large. Maximum size is 10MB.")
 		return
 	}
@@ -52,7 +138,7 @@ func (h *AIHandler) Estimate(w http.ResponseWriter, r *http.Request) {
 	globalEndpoint := h.Settings.GetEffectiveSetting(ctx, "ai_endpoint", os.Getenv("AI_ENDPOINT"))
 	globalModel := h.Settings.GetEffectiveSetting(ctx, "ai_model", os.Getenv("AI_MODEL"))
 
-	// Priority: env/admin setting > user preference
+	// Provider priority: env/admin setting > user preference
 	var provider string
 	if globalProvider.Value != nil && *globalProvider.Value != "" {
 		provider = *globalProvider.Value
@@ -68,27 +154,21 @@ func (h *AIHandler) Estimate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var apiKey string
-	var endpoint string
-	usingGlobalKey := false
-	hasGlobalConfig := (globalKey.Value != nil && *globalKey.Value != "") ||
-		(globalProvider.Value != nil && *globalProvider.Value != "")
-
-	// When global AI config is set, ignore user's personal key/endpoint/model.
-	// Users can only bring their own key when nothing is configured globally.
-	if hasGlobalConfig {
-		if globalKey.Value != nil {
-			apiKey = *globalKey.Value
-			usingGlobalKey = true
-		}
-		if globalEndpoint.Value != nil {
-			endpoint = *globalEndpoint.Value
-		}
-	} else {
-		if user.AIKey != nil && *user.AIKey != "" {
-			apiKey = service.DecryptApiKey(*user.AIKey, h.Cfg.AIKeyEncryptSecret)
-		}
+	// Only decrypt the personal key when no global key overrides it.
+	globalKeyVal := settingValue(globalKey)
+	var userKey string
+	if globalKeyVal == "" && user.AIKey != nil && *user.AIKey != "" {
+		userKey = service.DecryptApiKey(*user.AIKey, h.Cfg.AIKeyEncryptSecret)
 	}
+
+	cfg := resolveAIConfig(aiConfigInputs{
+		GlobalKey:      globalKeyVal,
+		GlobalEndpoint: settingValue(globalEndpoint),
+		GlobalModel:    settingValue(globalModel),
+		UserKey:        userKey,
+		UserModel:      derefString(user.AIModel),
+	})
+	apiKey, endpoint, customModel, usingGlobalKey := cfg.APIKey, cfg.Endpoint, cfg.Model, cfg.UsingGlobalKey
 
 	if (provider == "openai" || provider == "claude") && apiKey == "" {
 		ErrorJSON(w, http.StatusBadRequest, fmt.Sprintf("%s requires an API key.", provider))
@@ -104,47 +184,16 @@ func (h *AIHandler) Estimate(w http.ResponseWriter, r *http.Request) {
 			usingGlobalKey = true
 		}
 	}
-
-	// Rate limiting
-	usageToday, _ := service.GetAIUsageToday(ctx, h.Pool, user.ID)
-	if usingGlobalKey {
-		dailyLimitSetting := h.Settings.GetEffectiveSetting(ctx, "ai_daily_limit", os.Getenv("AI_DAILY_LIMIT"))
-		if dailyLimitSetting.Value != nil {
-			if limit, err := strconv.Atoi(*dailyLimitSetting.Value); err == nil && limit > 0 && usageToday >= limit {
-				JSON(w, http.StatusTooManyRequests, map[string]any{
-					"ok": false, "error": fmt.Sprintf("Daily limit reached (%d requests).", limit),
-					"limitReached": true, "limit": limit, "used": usageToday,
-				})
-				return
-			}
-		}
-	} else if user.AIDailyLimit != nil && *user.AIDailyLimit > 0 && usageToday >= *user.AIDailyLimit {
-		JSON(w, http.StatusTooManyRequests, map[string]any{
-			"ok": false, "error": fmt.Sprintf("Daily limit reached (%d requests).", *user.AIDailyLimit),
-			"limitReached": true, "limit": *user.AIDailyLimit, "used": usageToday,
-		})
+	if (provider == "openai" || provider == "claude") && customModel == "" {
+		ErrorJSON(w, http.StatusBadRequest, fmt.Sprintf("%s requires AI_MODEL to be configured.", provider))
 		return
 	}
 
 	// Extract base64 data and media type
 	base64Data := imageDataRe.ReplaceAllString(body.Image, "")
 	mediaType := "image/jpeg"
-	if m := regexp.MustCompile(`^data:(image/\w+);base64,`).FindStringSubmatch(body.Image); len(m) > 1 {
+	if m := imageMediaTypeRe.FindStringSubmatch(body.Image); len(m) > 1 {
 		mediaType = m[1]
-	}
-
-	// Model: global config > user preference
-	var customModel string
-	if hasGlobalConfig && globalModel.Value != nil && *globalModel.Value != "" {
-		customModel = *globalModel.Value
-	} else if !hasGlobalConfig && user.AIModel != nil && *user.AIModel != "" {
-		customModel = *user.AIModel
-	} else if globalModel.Value != nil {
-		customModel = *globalModel.Value
-	}
-	if (provider == "openai" || provider == "claude") && customModel == "" {
-		ErrorJSON(w, http.StatusBadRequest, fmt.Sprintf("%s requires AI_MODEL to be configured.", provider))
-		return
 	}
 
 	// Build prompt
@@ -178,8 +227,51 @@ If you cannot identify any food in the image, set calories to 0 and food to "No 
 Only respond with the JSON object, no other text.`,
 		contextHint, strings.Join(macroList, ", "), strings.Join(macroList, ", "))
 
-	result, err := service.CallAIProvider(provider, apiKey, endpoint, base64Data, mediaType, prompt, customModel)
+	// Resolve the applicable daily limit (0 = unlimited).
+	dailyLimit := 0
+	if usingGlobalKey {
+		dailyLimitSetting := h.Settings.GetEffectiveSetting(ctx, "ai_daily_limit", os.Getenv("AI_DAILY_LIMIT"))
+		if dailyLimitSetting.Value != nil {
+			if limit, err := strconv.Atoi(*dailyLimitSetting.Value); err == nil && limit > 0 {
+				dailyLimit = limit
+			}
+		}
+	} else if user.AIDailyLimit != nil && *user.AIDailyLimit > 0 {
+		dailyLimit = *user.AIDailyLimit
+	}
+
+	// Reserve the usage slot atomically BEFORE calling the provider so
+	// concurrent requests cannot all pass a stale pre-increment check.
+	// A reservation that yields no estimation is released again below.
+	trackUsage := usingGlobalKey || (user.AIDailyLimit != nil && *user.AIDailyLimit > 0)
+	reserved := false
+	if trackUsage {
+		count, err := service.ReserveAIUsage(ctx, h.Pool, user.ID)
+		if err != nil {
+			// Fail closed: without a usage count we must not hand out
+			// unmetered AI calls.
+			slog.Error("failed to reserve AI usage", "error", err, "userID", user.ID)
+			ErrorJSON(w, http.StatusInternalServerError, "AI estimation failed, please try again.")
+			return
+		}
+		reserved = true
+		if dailyLimit > 0 && count > dailyLimit {
+			service.ReleaseAIUsage(context.WithoutCancel(ctx), h.Pool, user.ID)
+			JSON(w, http.StatusTooManyRequests, map[string]any{
+				"ok": false, "error": fmt.Sprintf("Daily limit reached (%d requests).", dailyLimit),
+				"limitReached": true, "limit": dailyLimit, "used": count - 1,
+			})
+			return
+		}
+	}
+
+	result, err := service.CallAIProvider(ctx, provider, apiKey, endpoint, base64Data, mediaType, prompt, customModel)
 	if err != nil {
+		if reserved {
+			// No estimation happened — hand the slot back. Use a
+			// non-cancelable context so an aborted request still releases.
+			service.ReleaseAIUsage(context.WithoutCancel(ctx), h.Pool, user.ID)
+		}
 		if err.Error() == "NO_FOOD_DETECTED" {
 			JSON(w, http.StatusBadRequest, map[string]any{
 				"ok": false, "error": "Could not identify food in the image.",
@@ -187,13 +279,9 @@ Only respond with the JSON object, no other text.`,
 			})
 			return
 		}
-		ErrorJSON(w, http.StatusInternalServerError, err.Error())
+		slog.Error("AI estimation failed", "provider", provider, "userID", user.ID, "error", err)
+		ErrorJSON(w, http.StatusInternalServerError, aiClientErrorMessage(err))
 		return
-	}
-
-	// Increment usage
-	if usingGlobalKey || (user.AIDailyLimit != nil && *user.AIDailyLimit > 0) {
-		service.IncrementAIUsage(ctx, h.Pool, user.ID)
 	}
 
 	// Compute calories from macros
@@ -221,5 +309,9 @@ Only respond with the JSON object, no other text.`,
 	})
 }
 
-// Suppress unused imports
-var _ = json.Marshal
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/internal/handler/ai_test.go
+++ b/internal/handler/ai_test.go
@@ -1,0 +1,209 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"schautrack/internal/service"
+)
+
+// TestResolveAIConfig guards the three-tier key hierarchy fix: only a global
+// KEY disables personal keys. A provider-only global config (no global key)
+// must fall back to the user's personal key/model.
+func TestResolveAIConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		in   aiConfigInputs
+		want resolvedAIConfig
+	}{
+		{
+			name: "global key pins global config and ignores personal key",
+			in: aiConfigInputs{
+				GlobalKey: "gk", GlobalEndpoint: "https://proxy.example", GlobalModel: "gpt-4o",
+				UserKey: "uk", UserModel: "user-model",
+			},
+			want: resolvedAIConfig{
+				APIKey: "gk", Endpoint: "https://proxy.example", Model: "gpt-4o", UsingGlobalKey: true,
+			},
+		},
+		{
+			name: "provider-only global config falls back to personal key (regression: #141)",
+			in: aiConfigInputs{
+				GlobalKey: "", GlobalEndpoint: "", GlobalModel: "",
+				UserKey: "uk", UserModel: "user-model",
+			},
+			want: resolvedAIConfig{
+				APIKey: "uk", Endpoint: "", Model: "user-model", UsingGlobalKey: false,
+			},
+		},
+		{
+			name: "personal key with global model as fallback",
+			in: aiConfigInputs{
+				GlobalKey: "", GlobalModel: "gpt-4o-mini",
+				UserKey: "uk", UserModel: "",
+			},
+			want: resolvedAIConfig{
+				APIKey: "uk", Model: "gpt-4o-mini", UsingGlobalKey: false,
+			},
+		},
+		{
+			name: "personal key path still uses global endpoint (ollama)",
+			in: aiConfigInputs{
+				GlobalKey: "", GlobalEndpoint: "http://ollama.internal:11434/v1", GlobalModel: "gemma3:12b",
+				UserKey: "", UserModel: "",
+			},
+			want: resolvedAIConfig{
+				APIKey: "", Endpoint: "http://ollama.internal:11434/v1", Model: "gemma3:12b", UsingGlobalKey: false,
+			},
+		},
+		{
+			name: "global key without global model does not borrow the user model",
+			in: aiConfigInputs{
+				GlobalKey: "gk", GlobalModel: "",
+				UserKey: "uk", UserModel: "user-model",
+			},
+			want: resolvedAIConfig{
+				APIKey: "gk", Model: "", UsingGlobalKey: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveAIConfig(tt.in)
+			if got != tt.want {
+				t.Errorf("resolveAIConfig() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAIClientErrorMessage guards the error-sanitization fix: the message sent
+// to clients must never contain the upstream response body or the (possibly
+// internal) endpoint URL.
+func TestAIClientErrorMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		want       string
+		mustNotHold []string
+	}{
+		{
+			name: "url.Error must not leak internal endpoint",
+			err: fmt.Errorf("AI request failed: %w", &url.Error{
+				Op:  "Post",
+				URL: "http://ollama.internal.lan:11434/v1/chat/completions",
+				Err: errors.New("connection refused"),
+			}),
+			want:        "AI estimation failed, please try again.",
+			mustNotHold: []string{"ollama.internal.lan", "11434", "connection refused"},
+		},
+		{
+			name:        "provider 500 must not leak upstream body",
+			err:         &service.AIProviderError{StatusCode: 500, Body: `{"error":"secret internal details"}`},
+			want:        "AI estimation failed, please try again.",
+			mustNotHold: []string{"secret internal details"},
+		},
+		{
+			name:        "provider 429 maps to coarse rate-limit category",
+			err:         &service.AIProviderError{StatusCode: 429, Body: "org quota details"},
+			want:        "The AI provider is rate limiting requests. Please try again later.",
+			mustNotHold: []string{"org quota details"},
+		},
+		{
+			name:        "provider 401 maps to coarse auth category",
+			err:         &service.AIProviderError{StatusCode: 401, Body: "invalid api key sk-abc123"},
+			want:        "The AI provider rejected the configured API key.",
+			mustNotHold: []string{"sk-abc123"},
+		},
+		{
+			name:        "provider 403 maps to coarse auth category",
+			err:         &service.AIProviderError{StatusCode: 403, Body: "forbidden"},
+			want:        "The AI provider rejected the configured API key.",
+			mustNotHold: []string{"forbidden"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := aiClientErrorMessage(tt.err)
+			if got != tt.want {
+				t.Errorf("aiClientErrorMessage() = %q, want %q", got, tt.want)
+			}
+			for _, leak := range tt.mustNotHold {
+				if strings.Contains(got, leak) {
+					t.Errorf("message %q leaks %q", got, leak)
+				}
+			}
+		})
+	}
+}
+
+// TestEstimate_OversizedBodyReturns413 guards the ReadJSONLimit fix: a body
+// over the AI route limit must map to 413 "Image too large", not a generic
+// 400 from silent truncation.
+func TestEstimate_OversizedBodyReturns413(t *testing.T) {
+	h := &AIHandler{}
+	huge := `{"image":"data:image/jpeg;base64,` + strings.Repeat("A", maxAIRequestBytes) + `"}`
+	r := httptest.NewRequest("POST", "/api/ai/estimate", strings.NewReader(huge))
+	w := httptest.NewRecorder()
+
+	h.Estimate(w, r)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusRequestEntityTooLarge)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if msg, _ := resp["error"].(string); !strings.Contains(msg, "Image too large") {
+		t.Errorf("error = %q, want message about image size", msg)
+	}
+}
+
+// TestEstimate_ImageOver14MBReturns413 verifies the previously-unreachable
+// 14MB image check now triggers: an image field over 14MB inside a body under
+// the 15MB route limit must return 413.
+func TestEstimate_ImageOver14MBReturns413(t *testing.T) {
+	h := &AIHandler{}
+	img := "data:image/jpeg;base64," + strings.Repeat("A", maxImageBase64Bytes)
+	body := `{"image":"` + img + `"}`
+	if int64(len(body)) > maxAIRequestBytes {
+		t.Fatalf("test body (%d bytes) exceeds the route limit; adjust the test", len(body))
+	}
+	r := httptest.NewRequest("POST", "/api/ai/estimate", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.Estimate(w, r)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusRequestEntityTooLarge)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if msg, _ := resp["error"].(string); !strings.Contains(msg, "Image too large") {
+		t.Errorf("error = %q, want message about image size", msg)
+	}
+}
+
+// TestEstimate_InvalidJSONReturns400 pins the non-oversize error path.
+func TestEstimate_InvalidJSONReturns400(t *testing.T) {
+	h := &AIHandler{}
+	r := httptest.NewRequest("POST", "/api/ai/estimate", strings.NewReader(`{not json`))
+	w := httptest.NewRecorder()
+
+	h.Estimate(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}

--- a/internal/handler/helpers.go
+++ b/internal/handler/helpers.go
@@ -16,9 +16,17 @@ func JSON(w http.ResponseWriter, status int, data any) {
 	}
 }
 
-// ReadJSON decodes a JSON request body into dst.
+// ReadJSON decodes a JSON request body into dst, limited to 10MB.
 func ReadJSON(r *http.Request, dst any) error {
-	body, err := io.ReadAll(io.LimitReader(r.Body, 10<<20)) // 10MB
+	return ReadJSONLimit(nil, r, dst, 10<<20)
+}
+
+// ReadJSONLimit decodes a JSON request body into dst, rejecting bodies larger
+// than limit bytes. Oversize bodies surface as a *http.MaxBytesError (instead
+// of being silently truncated) so callers can map them to 413. w may be nil;
+// when non-nil, the server also stops reading the connection on overflow.
+func ReadJSONLimit(w http.ResponseWriter, r *http.Request, dst any, limit int64) error {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, limit))
 	if err != nil {
 		return err
 	}

--- a/internal/handler/helpers_test.go
+++ b/internal/handler/helpers_test.go
@@ -1,0 +1,71 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestReadJSONLimit_DecodesWithinLimit(t *testing.T) {
+	var dst struct {
+		Name string `json:"name"`
+	}
+	r := httptest.NewRequest("POST", "/", strings.NewReader(`{"name":"apple"}`))
+	w := httptest.NewRecorder()
+
+	if err := ReadJSONLimit(w, r, &dst, 1024); err != nil {
+		t.Fatalf("ReadJSONLimit: %v", err)
+	}
+	if dst.Name != "apple" {
+		t.Errorf("Name = %q, want %q", dst.Name, "apple")
+	}
+}
+
+// TestReadJSONLimit_OversizeIsMaxBytesError guards the 413 mapping: bodies
+// over the limit must surface as *http.MaxBytesError, not be silently
+// truncated into a generic JSON parse error.
+func TestReadJSONLimit_OversizeIsMaxBytesError(t *testing.T) {
+	var dst map[string]any
+	body := `{"pad":"` + strings.Repeat("x", 64) + `"}`
+	r := httptest.NewRequest("POST", "/", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	err := ReadJSONLimit(w, r, &dst, 16)
+	if err == nil {
+		t.Fatal("expected error for oversize body")
+	}
+	var maxErr *http.MaxBytesError
+	if !errors.As(err, &maxErr) {
+		t.Fatalf("error = %T (%v), want *http.MaxBytesError", err, err)
+	}
+	if maxErr.Limit != 16 {
+		t.Errorf("Limit = %d, want 16", maxErr.Limit)
+	}
+}
+
+// ReadJSONLimit must also work with a nil ResponseWriter (used by ReadJSON).
+func TestReadJSONLimit_NilWriter(t *testing.T) {
+	var dst map[string]any
+	r := httptest.NewRequest("POST", "/", strings.NewReader(strings.Repeat("x", 64)))
+
+	err := ReadJSONLimit(nil, r, &dst, 16)
+	var maxErr *http.MaxBytesError
+	if !errors.As(err, &maxErr) {
+		t.Fatalf("error = %T (%v), want *http.MaxBytesError", err, err)
+	}
+}
+
+func TestReadJSON_StillDecodes(t *testing.T) {
+	var dst struct {
+		Amount int `json:"amount"`
+	}
+	r := httptest.NewRequest("POST", "/", strings.NewReader(`{"amount":420}`))
+	if err := ReadJSON(r, &dst); err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+	if dst.Amount != 420 {
+		t.Errorf("Amount = %d, want 420", dst.Amount)
+	}
+}

--- a/internal/service/ai.go
+++ b/internal/service/ai.go
@@ -1,12 +1,14 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -14,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -95,8 +98,22 @@ type AIResult struct {
 	Macros     map[string]int    `json:"macros"`
 }
 
+// AIProviderError reports a non-2xx response from the upstream AI provider.
+// Error() includes the upstream status and body for server-side logging;
+// handlers must never send it to clients verbatim.
+type AIProviderError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *AIProviderError) Error() string {
+	return fmt.Sprintf("AI provider returned %d: %s", e.StatusCode, e.Body)
+}
+
 // CallAIProvider calls the configured AI provider with an image and prompt.
-func CallAIProvider(provider, apiKey, endpoint, base64Data, mediaType, prompt, model string) (*AIResult, error) {
+// The request is bound to ctx so an aborted client request cancels the
+// upstream call instead of running out the full 30-60s provider timeout.
+func CallAIProvider(ctx context.Context, provider, apiKey, endpoint, base64Data, mediaType, prompt, model string) (*AIResult, error) {
 	timeout := 30 * time.Second
 	if provider == "ollama" {
 		timeout = 60 * time.Second
@@ -171,7 +188,7 @@ func CallAIProvider(provider, apiKey, endpoint, base64Data, mediaType, prompt, m
 	}
 
 	client := &http.Client{Timeout: timeout}
-	req, err := http.NewRequest("POST", url, strings.NewReader(string(reqBody)))
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +208,7 @@ func CallAIProvider(provider, apiKey, endpoint, base64Data, mediaType, prompt, m
 		return nil, fmt.Errorf("failed to read AI response: %w", err)
 	}
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("AI provider returned %d: %s", resp.StatusCode, string(respBody))
+		return nil, &AIProviderError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
 	return parseAIResponse(provider, respBody)
@@ -252,24 +269,56 @@ func parseAIResponse(provider string, body []byte) (*AIResult, error) {
 	return &result, nil
 }
 
+// GetAIUsageToday returns the user's AI request count for today. A missing
+// row means zero usage; any other query error is propagated so callers can
+// fail closed instead of treating outages as "no usage yet".
 func GetAIUsageToday(ctx context.Context, pool *pgxpool.Pool, userID int) (int, error) {
 	var count int
 	err := pool.QueryRow(ctx,
 		"SELECT COALESCE(request_count, 0) FROM ai_usage WHERE user_id = $1 AND usage_date = CURRENT_DATE",
 		userID).Scan(&count)
+	return aiUsageFromScan(count, err)
+}
+
+// aiUsageFromScan maps a usage-count scan result: no row means zero usage,
+// while real database errors are propagated instead of being swallowed.
+func aiUsageFromScan(count int, err error) (int, error) {
 	if err != nil {
-		return 0, nil
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, err
 	}
 	return count, nil
 }
 
-func IncrementAIUsage(ctx context.Context, pool *pgxpool.Pool, userID int) {
-	if _, err := pool.Exec(ctx, `
+// ReserveAIUsage atomically increments today's usage counter and returns the
+// post-increment count. Callers reserve a slot BEFORE calling the provider —
+// rejecting when the returned count exceeds the daily limit — so concurrent
+// requests cannot all pass a stale pre-increment check. Reservations that do
+// not produce an estimation are handed back via ReleaseAIUsage.
+func ReserveAIUsage(ctx context.Context, pool *pgxpool.Pool, userID int) (int, error) {
+	var count int
+	err := pool.QueryRow(ctx, `
 		INSERT INTO ai_usage (user_id, usage_date, request_count)
 		VALUES ($1, CURRENT_DATE, 1)
-		ON CONFLICT (user_id, usage_date) DO UPDATE SET request_count = ai_usage.request_count + 1`,
+		ON CONFLICT (user_id, usage_date) DO UPDATE SET request_count = ai_usage.request_count + 1
+		RETURNING request_count`,
+		userID).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// ReleaseAIUsage hands back a slot reserved by ReserveAIUsage (e.g. after a
+// provider failure or an over-limit rejection).
+func ReleaseAIUsage(ctx context.Context, pool *pgxpool.Pool, userID int) {
+	if _, err := pool.Exec(ctx, `
+		UPDATE ai_usage SET request_count = GREATEST(request_count - 1, 0)
+		WHERE user_id = $1 AND usage_date = CURRENT_DATE`,
 		userID); err != nil {
-		slog.Error("failed to increment AI usage", "error", err, "userID", userID)
+		slog.Error("failed to release AI usage reservation", "error", err, "userID", userID)
 	}
 }
 

--- a/internal/service/ai_test.go
+++ b/internal/service/ai_test.go
@@ -1,11 +1,17 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
 )
 
 func TestEncryptDecryptApiKey(t *testing.T) {
@@ -117,12 +123,96 @@ func TestCallAIProvider_TokenLimitParam(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			_, err := CallAIProvider(tt.provider, "test-key", srv.URL, "Zg==", "image/jpeg", "describe", "test-model")
+			_, err := CallAIProvider(context.Background(), tt.provider, "test-key", srv.URL, "Zg==", "image/jpeg", "describe", "test-model")
 			if err != nil {
 				t.Fatalf("CallAIProvider: %v", err)
 			}
 			tt.assert(t, captured)
 		})
+	}
+}
+
+// TestCallAIProvider_ContextCancellation guards the fix for the request
+// context being ignored: when the caller cancels (e.g. the user aborts the
+// HTTP request), the upstream AI call must return promptly instead of
+// running for the full 30-60s provider timeout.
+func TestCallAIProvider_ContextCancellation(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // block until the test tears down
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := CallAIProvider(ctx, "openai", "test-key", srv.URL, "Zg==", "image/jpeg", "describe", "test-model")
+		done <- err
+	}()
+
+	// Give the request a moment to reach the blocking server, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error after context cancellation, got nil")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled in the chain", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("CallAIProvider did not return promptly after context cancellation")
+	}
+}
+
+// TestCallAIProvider_UpstreamErrorType pins that non-2xx upstream responses
+// yield a typed *AIProviderError carrying the status code and body, so
+// handlers can log the details while sending clients a sanitized message.
+func TestCallAIProvider_UpstreamErrorType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"quota exceeded for org acme-internal"}`))
+	}))
+	defer srv.Close()
+
+	_, err := CallAIProvider(context.Background(), "openai", "test-key", srv.URL, "Zg==", "image/jpeg", "describe", "test-model")
+	if err == nil {
+		t.Fatal("expected error for 429 upstream response")
+	}
+
+	var provErr *AIProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatalf("error = %T (%v), want *AIProviderError", err, err)
+	}
+	if provErr.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("StatusCode = %d, want %d", provErr.StatusCode, http.StatusTooManyRequests)
+	}
+	if !strings.Contains(provErr.Body, "quota exceeded") {
+		t.Errorf("Body = %q, want upstream body preserved for logging", provErr.Body)
+	}
+	// Error() keeps the details for server-side logs.
+	if !strings.Contains(err.Error(), "429") || !strings.Contains(err.Error(), "quota exceeded") {
+		t.Errorf("Error() = %q, want status and body for logging", err.Error())
+	}
+}
+
+// TestAIUsageFromScan guards the GetAIUsageToday fix: only a missing row maps
+// to (0, nil); real database errors must be propagated, not swallowed.
+func TestAIUsageFromScan(t *testing.T) {
+	if n, err := aiUsageFromScan(7, nil); n != 7 || err != nil {
+		t.Errorf("aiUsageFromScan(7, nil) = (%d, %v), want (7, nil)", n, err)
+	}
+	if n, err := aiUsageFromScan(0, pgx.ErrNoRows); n != 0 || err != nil {
+		t.Errorf("aiUsageFromScan(0, ErrNoRows) = (%d, %v), want (0, nil)", n, err)
+	}
+	sentinel := errors.New("connection refused")
+	if _, err := aiUsageFromScan(0, sentinel); !errors.Is(err, sentinel) {
+		t.Errorf("aiUsageFromScan(0, sentinel) err = %v, want sentinel propagated", err)
 	}
 }
 


### PR DESCRIPTION
Fixes all verified audit findings for the AI-estimation subsystem (`internal/handler/ai.go`, `internal/service/ai.go`, `internal/handler/helpers.go`, plus one dead line in `internal/handler/admin.go`).

## Findings addressed

- Addresses MEDIUM item "CallAIProvider ignores the request context — no cancellation of 30–60s upstream AI calls" from #141
  `CallAIProvider` now takes `ctx context.Context` as its first parameter and builds the upstream request with `http.NewRequestWithContext`; the Estimate handler passes `r.Context()`. Aborting the client request cancels the upstream call promptly (regression test: `TestCallAIProvider_ContextCancellation` against a blocking `httptest` server).

- Addresses MEDIUM item "Setting only a global AI provider (no global key) disables all users' personal AI keys" from #141
  The "ignore personal key" behavior is now gated on a global KEY being present, not on provider-only config. Extracted into the pure, table-tested `resolveAIConfig`: a global key pins global endpoint/model; otherwise the user's personal key applies with global settings filling gaps (`TestResolveAIConfig`).

- Addresses LOW item "AI Estimate 14MB image check is unreachable — ReadJSON silently truncates at 10MB" from #141
  New `ReadJSONLimit(w, r, dst, limit)` built on `http.MaxBytesReader` (plain `ReadJSON` keeps its signature and delegates with the 10MB default, no more silent truncation). The AI route uses a 15MB limit matching the global body cap and maps `*http.MaxBytesError` to 413 with the existing "Image too large" message; the 14MB base64 image check is now reachable (`TestEstimate_OversizedBodyReturns413`, `TestEstimate_ImageOver14MBReturns413`, `TestReadJSONLimit_*`).

- Addresses LOW item "GetAIUsageToday swallows all DB errors and returns 0 with a nil error" from #141
  Only `pgx.ErrNoRows` maps to `(0, nil)`; other errors propagate (extracted `aiUsageFromScan`, tested in `TestAIUsageFromScan`). The Estimate handler now fails closed with a generic 500 when the usage counter cannot be read/reserved.

- Addresses LOW item "AI daily limit is enforced with a non-atomic check-then-act" from #142
  The slot is reserved atomically BEFORE the provider call: `ReserveAIUsage` runs the `ON CONFLICT` increment with `RETURNING request_count` and the handler rejects with 429 when the returned count exceeds the limit. `ReleaseAIUsage` hands the slot back on provider failure or over-limit rejection, using `context.WithoutCancel` so aborted requests still release their reservation. The old post-success `IncrementAIUsage` is replaced by the reservation.

- Addresses LOW item "AI estimate handler returns raw upstream provider error text to clients" from #140 and the same LOW item from #141
  Upstream failures now yield a typed `service.AIProviderError` (status + body, for server-side logs only). The handler logs the full error via `slog` and responds with a generic message, optionally a coarse category (auth-rejected for 401/403, rate-limited for 429) derived from the upstream status — never the raw body or (possibly internal) endpoint URL (`TestAIClientErrorMessage`, `TestCallAIProvider_UpstreamErrorType`).

- Addresses LOW item "Dead-code suppressions for unused imports" from #141
  Removed `var _ = json.Marshal` (and the now-unused `encoding/json` import) from `internal/handler/ai.go` and `var _ = strings.TrimSpace` from `internal/handler/admin.go` (the `strings` import stays — it is genuinely used).

## Verification

- `go test ./...` — green, no database required
- `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
