### PR TITLE
fix(db): serialize migrations, stop session write amplification, de-drift init.sql

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ schautrack/
 │   └── sse/               # Server-Sent Events broker
 ├── public/                # Static assets (logo, favicons)
 ├── db/
-│   └── init.sql           # Database schema
+│   └── init.sql           # Intentionally empty — schema comes from Go migrations
 ├── Dockerfile             # 3-stage build (client, Go binary, Alpine)
 ├── compose.yml            # Production Docker Compose
 ├── compose.dev.yml        # Local development setup
@@ -215,7 +215,7 @@ docker compose -f compose.dev.yml up -d --build
 ```
 - Web app: http://localhost:3000
 - PostgreSQL: localhost:5432
-- Database initializes from `db/init.sql`
+- Database schema is created by the app's startup migrations (`db/init.sql` is intentionally a no-op)
 - Go build: `go build ./cmd/server/`
 - Tests: `go test ./...`
 
@@ -251,7 +251,7 @@ displayTz := targetUser.Timezone // or "UTC" if nil
 ## Common Tasks
 
 ### Adding a New Feature
-1. Update database schema in `db/init.sql` if needed
+1. Schema changes go in `internal/database/migrations.go` only (`db/init.sql` is intentionally empty — migrations are the single source of truth)
 2. Add migration in `internal/database/migrations.go`
 3. Add service logic in `internal/service/`
 4. Add HTTP handler in `internal/handler/`

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -63,8 +63,9 @@ services:
       # PostgreSQL 18+ stores data in a version-specific subdirectory; mount the
       # parent so data persists (data lands in /var/lib/postgresql/18/docker).
       # See https://github.com/docker-library/postgres/pull/1259
+      # No init script: the schema is created by the app's startup migrations
+      # (internal/database/migrations.go), same as prod and E2E.
       - db-data:/var/lib/postgresql
-      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
 
 volumes:
   db-data:

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,171 +1,21 @@
-CREATE TABLE IF NOT EXISTS users (
-  id SERIAL PRIMARY KEY,
-  email TEXT NOT NULL UNIQUE,
-  password_hash TEXT NOT NULL,
-  daily_goal INTEGER,
-  totp_secret TEXT,
-  totp_enabled BOOLEAN DEFAULT FALSE,
-  email_verified BOOLEAN DEFAULT FALSE,
-  created_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE TABLE IF NOT EXISTS calorie_entries (
-  id SERIAL PRIMARY KEY,
-  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  entry_date DATE NOT NULL DEFAULT CURRENT_DATE,
-  amount INTEGER NOT NULL CHECK (amount >= -9999 AND amount <= 9999),
-  entry_name TEXT,
-  created_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE INDEX IF NOT EXISTS calorie_entries_user_date_idx ON calorie_entries (user_id, entry_date);
-
-CREATE TABLE IF NOT EXISTS account_links (
-  id SERIAL PRIMARY KEY,
-  requester_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  target_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  status TEXT NOT NULL CHECK (status IN ('pending', 'accepted')),
-  created_at TIMESTAMPTZ DEFAULT NOW(),
-  updated_at TIMESTAMPTZ DEFAULT NOW(),
-  CONSTRAINT account_links_not_self CHECK (requester_id <> target_id)
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS account_links_pair_idx
-  ON account_links (LEAST(requester_id, target_id), GREATEST(requester_id, target_id));
-
-CREATE INDEX IF NOT EXISTS account_links_requester_idx ON account_links (requester_id);
-CREATE INDEX IF NOT EXISTS account_links_target_idx ON account_links (target_id);
-CREATE INDEX IF NOT EXISTS account_links_status_idx ON account_links (status);
-
-CREATE TABLE IF NOT EXISTS "session" (
-  "sid" VARCHAR NOT NULL,
-  "sess" JSON NOT NULL,
-  "expire" TIMESTAMP(6) NOT NULL,
-  CONSTRAINT "session_pkey" PRIMARY KEY ("sid")
-);
-
-CREATE INDEX IF NOT EXISTS "IDX_session_expire" ON "session" ("expire");
-
-CREATE TABLE IF NOT EXISTS weight_entries (
-  id SERIAL PRIMARY KEY,
-  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  entry_date DATE NOT NULL,
-  weight NUMERIC(6, 2) NOT NULL,
-  created_at TIMESTAMPTZ DEFAULT NOW(),
-  updated_at TIMESTAMPTZ DEFAULT NOW(),
-  CONSTRAINT weight_entries_positive CHECK (weight > 0)
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS weight_unique_per_day_idx ON weight_entries (user_id, entry_date);
-
-CREATE TABLE IF NOT EXISTS password_reset_tokens (
-  id SERIAL PRIMARY KEY,
-  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  token TEXT NOT NULL UNIQUE,
-  expires_at TIMESTAMPTZ NOT NULL,
-  used BOOLEAN DEFAULT FALSE,
-  created_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE INDEX IF NOT EXISTS password_reset_tokens_user_idx ON password_reset_tokens (user_id);
-CREATE INDEX IF NOT EXISTS password_reset_tokens_expires_idx ON password_reset_tokens (expires_at);
-
-CREATE TABLE IF NOT EXISTS email_verification_tokens (
-  id SERIAL PRIMARY KEY,
-  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  token TEXT NOT NULL UNIQUE,
-  expires_at TIMESTAMPTZ NOT NULL,
-  used BOOLEAN DEFAULT FALSE,
-  created_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE INDEX IF NOT EXISTS email_verification_tokens_user_idx ON email_verification_tokens (user_id);
-CREATE INDEX IF NOT EXISTS email_verification_tokens_expires_idx ON email_verification_tokens (expires_at);
-
-CREATE TABLE IF NOT EXISTS admin_settings (
-  key TEXT PRIMARY KEY,
-  value TEXT,
-  updated_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE TABLE IF NOT EXISTS todos (
-  id SERIAL PRIMARY KEY,
-  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  name TEXT NOT NULL,
-  schedule JSONB NOT NULL DEFAULT '{"type":"daily"}',
-  time_of_day TEXT,
-  sort_order INTEGER DEFAULT 0,
-  archived BOOLEAN DEFAULT FALSE,
-  created_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE INDEX IF NOT EXISTS todos_user_idx ON todos (user_id);
-
-CREATE TABLE IF NOT EXISTS todo_completions (
-  id SERIAL PRIMARY KEY,
-  todo_id INTEGER NOT NULL REFERENCES todos(id) ON DELETE CASCADE,
-  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  completion_date DATE NOT NULL,
-  created_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS todo_completions_unique_idx ON todo_completions (todo_id, completion_date);
-CREATE INDEX IF NOT EXISTS todo_completions_user_date_idx ON todo_completions (user_id, completion_date);
-
-CREATE TABLE IF NOT EXISTS invite_codes (
-  id SERIAL PRIMARY KEY,
-  code TEXT UNIQUE NOT NULL,
-  email TEXT,
-  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
-  used_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
-  used_at TIMESTAMPTZ,
-  expires_at TIMESTAMPTZ,
-  created_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE INDEX IF NOT EXISTS invite_codes_code_idx ON invite_codes (code);
-
-CREATE TABLE IF NOT EXISTS totp_backup_codes (
-  id SERIAL PRIMARY KEY,
-  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  code_hash TEXT NOT NULL,
-  used BOOLEAN DEFAULT FALSE,
-  created_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE INDEX IF NOT EXISTS totp_backup_codes_user_idx ON totp_backup_codes (user_id);
-
-CREATE TABLE IF NOT EXISTS daily_notes (
-  id SERIAL PRIMARY KEY,
-  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  note_date DATE NOT NULL,
-  content TEXT NOT NULL DEFAULT '',
-  created_at TIMESTAMPTZ DEFAULT NOW(),
-  updated_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS daily_notes_user_date_idx ON daily_notes (user_id, note_date);
-
--- Additional user columns (added via Go migrations in internal/database/migrations.go)
--- ALTER TABLE users ADD COLUMN IF NOT EXISTS notes_enabled BOOLEAN DEFAULT FALSE;
--- These are documented here for reference but applied by ensureUserPrefsSchema(), ensureAIKeysSchema(), and ensureMacroSchema()
--- ALTER TABLE users ADD COLUMN IF NOT EXISTS todos_enabled BOOLEAN DEFAULT FALSE;
--- ALTER TABLE users ADD COLUMN IF NOT EXISTS timezone TEXT;
--- ALTER TABLE users ADD COLUMN IF NOT EXISTS weight_unit TEXT DEFAULT 'kg';
--- ALTER TABLE users ADD COLUMN IF NOT EXISTS timezone_manual BOOLEAN DEFAULT FALSE;
--- ALTER TABLE users ADD COLUMN IF NOT EXISTS openai_api_key TEXT;
--- ALTER TABLE users ADD COLUMN IF NOT EXISTS claude_api_key TEXT;
--- ALTER TABLE users ADD COLUMN IF NOT EXISTS preferred_ai_provider TEXT DEFAULT 'openai';
--- ALTER TABLE users ADD COLUMN IF NOT EXISTS macros_enabled JSONB DEFAULT '{}';
--- ALTER TABLE users ADD COLUMN IF NOT EXISTS macro_goals JSONB DEFAULT '{}';
--- ALTER TABLE users ADD COLUMN IF NOT EXISTS goal_threshold INTEGER DEFAULT 10;
---   goal_threshold: percentage (0-100) above which a goal violation turns red instead of yellow.
---   macro_goals JSONB shape: { "calories": 2000, "calories_mode": "limit", "protein": 150, "protein_mode": "target", "carbs": 200, "carbs_mode": "limit" }
---   Goal values are integers (grams, or kcal for calories). Mode values are "limit" (stay under) or "target" (try to reach).
---   Note: calorie goal was migrated from the legacy daily_goal column into macro_goals.calories.
---   Missing _mode keys fall back to defaults in internal/service/macros.go MacroGoalModes.
--- ALTER TABLE calorie_entries ADD COLUMN IF NOT EXISTS protein_g INTEGER CHECK (protein_g >= 0 AND protein_g <= 999);
--- ALTER TABLE calorie_entries ADD COLUMN IF NOT EXISTS carbs_g INTEGER CHECK (carbs_g >= 0 AND carbs_g <= 999);
--- ALTER TABLE calorie_entries ADD COLUMN IF NOT EXISTS fat_g INTEGER CHECK (fat_g >= 0 AND fat_g <= 999);
--- ALTER TABLE calorie_entries ADD COLUMN IF NOT EXISTS fiber_g INTEGER CHECK (fiber_g >= 0 AND fiber_g <= 999);
--- ALTER TABLE calorie_entries ADD COLUMN IF NOT EXISTS sugar_g INTEGER CHECK (sugar_g >= 0 AND sugar_g <= 999);
+-- Schautrack database schema — INTENTIONALLY CONTAINS NO DDL.
+--
+-- The full schema (every table, index, and constraint — including the
+-- "session" table) is created and kept up to date by the application itself
+-- at startup: the ensureXxxSchema() migrations in
+-- internal/database/migrations.go are the single source of truth. They run
+-- sequentially under a Postgres advisory lock and fully initialize an empty
+-- database before the server accepts traffic.
+--
+-- A previous version of this file duplicated part of that schema and had
+-- drifted: fresh installs got doubled constraints (inline UNIQUE next to the
+-- migrations' named unique indexes, inline CHECK next to
+-- calorie_entries_amount_range), and five tables (ai_usage,
+-- user_oidc_accounts, user_passkeys, saved_foods, audit_log) were missing
+-- entirely. Rather than maintain the schema in two places, the DDL was
+-- removed. Production (compose.yml) and E2E (compose.test.yml) never mounted
+-- this file — those environments have always initialized from the app
+-- migrations alone. compose.dev.yml no longer mounts it either.
+--
+-- To change the schema, add or extend a migration in
+-- internal/database/migrations.go.

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -197,8 +197,9 @@ func ensureEmailVerificationSchema(ctx context.Context, pool *pgxpool.Pool) erro
 		// verification bypass). A persistent marker row guards it. The DDL above
 		// still runs every boot; only this UPDATE is gated.
 		//
-		// schema_data_migrations is created and read only here, so there is no
-		// concurrent-CREATE race with the parallel ensureXxx migrations.
+		// schema_data_migrations is created and read only here; migrations run
+		// sequentially under the migration advisory lock, so there is no
+		// concurrent-CREATE race.
 		_, err = tx.Exec(ctx, `
 			CREATE TABLE IF NOT EXISTS schema_data_migrations (
 				name TEXT PRIMARY KEY,
@@ -476,7 +477,9 @@ func ensureInviteSchema(ctx context.Context, pool *pgxpool.Pool) error {
 				expires_at TIMESTAMPTZ,
 				created_at TIMESTAMPTZ DEFAULT NOW()
 			);
-			CREATE INDEX IF NOT EXISTS invite_codes_code_idx ON invite_codes (code)`)
+			-- code TEXT UNIQUE already creates the invite_codes_code_key index;
+			-- the old extra plain index on the same column was pure overhead.
+			DROP INDEX IF EXISTS invite_codes_code_idx`)
 		return err
 	})
 }
@@ -688,21 +691,31 @@ func ensureAuditLogSchema(ctx context.Context, pool *pgxpool.Pool) error {
 	})
 }
 
-func runAllMigrations(ctx context.Context, pool *pgxpool.Pool) error {
-	// Base tables first (others depend on them)
-	if err := ensureBaseSchema(ctx, pool); err != nil {
-		return fmt.Errorf("base schema: %w", err)
-	}
+// migrationLockKey is the application-scoped pg_advisory_lock key that
+// serializes schema migrations across replicas. Multiple pods starting at
+// once (rolling deploy, scale-up) would otherwise race conflicting DDL:
+// concurrent CREATE TABLE IF NOT EXISTS fails with "duplicate key value
+// violates unique constraint pg_type_typname_nsp_index", and concurrent
+// ALTER TABLE users deadlocks. The value is arbitrary but must stay stable
+// forever — during a rolling deploy old and new pods run side by side and
+// must agree on the key. It spells "schautra" ("schautrack" truncated to
+// eight bytes) in ASCII.
+const migrationLockKey int64 = 0x7363686175747261
 
-	// Parallel migrations
-	type migrationResult struct {
-		name string
-		err  error
-	}
-	migrations := []struct {
-		name string
-		fn   func(context.Context, *pgxpool.Pool) error
-	}{
+type migrationStep struct {
+	name string
+	fn   func(context.Context, *pgxpool.Pool) error
+}
+
+// migrationSteps returns every schema and data migration in execution order.
+// Order matters:
+//   - "base" creates users, calorie_entries, and "session"; every migration
+//     below either REFERENCES users or ALTERs one of these tables.
+//   - the trailing data migrations read columns created by "macros"
+//     (macro_goals, macros_enabled), so they must run after it.
+func migrationSteps() []migrationStep {
+	return []migrationStep{
+		{"base", ensureBaseSchema},
 		{"account_links", ensureAccountLinksSchema},
 		{"weight_entries", ensureWeightEntriesSchema},
 		{"user_prefs", ensureUserPrefsSchema},
@@ -717,43 +730,57 @@ func runAllMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 		{"passkeys", ensurePasskeysSchema},
 		{"audit_log", ensureAuditLogSchema},
 		{"saved_foods", ensureSavedFoodsSchema},
+		{"todos", ensureTodosSchema},
+		{"daily_notes", ensureDailyNotesSchema},
+		{"backup_codes", ensureBackupCodesSchema},
+		{"invite", ensureInviteSchema},
+		// Data migrations (depend on columns created by "macros")
+		{"calorie_goal_to_macro_goals", migrateCalorieGoalToMacroGoals},
+		{"auto_calc_calories", migrateAutoCalcCalories},
+	}
+}
+
+func runAllMigrations(ctx context.Context, pool *pgxpool.Pool) error {
+	// Advisory locks are session-scoped: lock and unlock must happen on the
+	// same underlying connection, so hold a dedicated one for the whole run.
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire connection for migration lock: %w", err)
 	}
 
-	results := make(chan migrationResult, len(migrations))
-	for _, m := range migrations {
-		go func(name string, fn func(context.Context, *pgxpool.Pool) error) {
-			results <- migrationResult{name: name, err: fn(ctx, pool)}
-		}(m.name, m.fn)
+	// pg_advisory_lock blocks until the lock is free, so a replica that loses
+	// the race simply waits here while the winner migrates, then re-runs the
+	// (idempotent) migrations itself against the finished schema.
+	if _, err := conn.Exec(ctx, `SELECT pg_advisory_lock($1)`, migrationLockKey); err != nil {
+		conn.Release()
+		return fmt.Errorf("acquire migration advisory lock: %w", err)
 	}
+	defer func() {
+		// Unlock on a fresh context so a canceled ctx can't skip the unlock.
+		unlockCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if _, err := conn.Exec(unlockCtx, `SELECT pg_advisory_unlock($1)`, migrationLockKey); err != nil {
+			// A pooled connection still holding the lock would block every
+			// replica's migrations until this process exits. Close it so the
+			// server releases the lock; Release then destroys it instead of
+			// returning it to the pool.
+			log.Printf("failed to release migration advisory lock, closing connection: %v", err)
+			conn.Conn().Close(unlockCtx)
+		}
+		conn.Release()
+	}()
 
-	for range migrations {
-		r := <-results
-		if r.err != nil {
-			return fmt.Errorf("migration %s: %w", r.name, r.err)
+	// Migrations run SEQUENTIALLY, on purpose. They used to run in parallel
+	// goroutines, but five of them ALTER TABLE users in separate transactions,
+	// and ensureOIDCAccountsSchema first takes SHARE ROW EXCLUSIVE on users
+	// (CREATE TABLE ... REFERENCES users) and then upgrades to ACCESS
+	// EXCLUSIVE (ALTER TABLE users) — a lock-upgrade deadlock against any
+	// queued ACCESS EXCLUSIVE from a sibling goroutine. The parallelism saved
+	// negligible startup time.
+	for _, m := range migrationSteps() {
+		if err := m.fn(ctx, pool); err != nil {
+			return fmt.Errorf("migration %s: %w", m.name, err)
 		}
 	}
-
-	// Dependent migrations
-	if err := ensureTodosSchema(ctx, pool); err != nil {
-		return fmt.Errorf("todos schema: %w", err)
-	}
-	if err := ensureDailyNotesSchema(ctx, pool); err != nil {
-		return fmt.Errorf("daily_notes schema: %w", err)
-	}
-	if err := ensureBackupCodesSchema(ctx, pool); err != nil {
-		return fmt.Errorf("backup_codes schema: %w", err)
-	}
-	if err := ensureInviteSchema(ctx, pool); err != nil {
-		return fmt.Errorf("invite schema: %w", err)
-	}
-
-	// Data migrations
-	if err := migrateCalorieGoalToMacroGoals(ctx, pool); err != nil {
-		return fmt.Errorf("calorie goal migration: %w", err)
-	}
-	if err := migrateAutoCalcCalories(ctx, pool); err != nil {
-		return fmt.Errorf("auto calc calories migration: %w", err)
-	}
-
 	return nil
 }

--- a/internal/database/migrations_order_test.go
+++ b/internal/database/migrations_order_test.go
@@ -1,0 +1,78 @@
+package database
+
+import (
+	"testing"
+)
+
+// TestMigrationStepsOrdered guards the sequential-migrations fix: migrations
+// used to run in parallel goroutines, which deadlocked (five ALTER TABLE users
+// in separate transactions, plus ensureOIDCAccountsSchema upgrading a SHARE
+// ROW EXCLUSIVE lock on users to ACCESS EXCLUSIVE against queued siblings).
+// They now run as one flat, ordered list. This test pins the ordering
+// invariants that matter:
+//   - "base" runs first — every other migration REFERENCES or ALTERs the
+//     tables it creates (users, calorie_entries, "session")
+//   - the data migrations run after "macros", which creates the macro_goals /
+//     macros_enabled columns they read
+//   - names are unique and functions non-nil, so a failure log like
+//     "migration ai_keys: ..." identifies exactly one step
+func TestMigrationStepsOrdered(t *testing.T) {
+	steps := migrationSteps()
+	if len(steps) == 0 {
+		t.Fatal("migrationSteps() returned no migrations")
+	}
+
+	if steps[0].name != "base" {
+		t.Errorf("first migration = %q, want %q (all other migrations depend on its tables)", steps[0].name, "base")
+	}
+
+	idx := make(map[string]int, len(steps))
+	for i, s := range steps {
+		if s.fn == nil {
+			t.Errorf("migration %q (index %d) has a nil function", s.name, i)
+		}
+		if s.name == "" {
+			t.Errorf("migration at index %d has an empty name", i)
+		}
+		if prev, dup := idx[s.name]; dup {
+			t.Errorf("duplicate migration name %q at indexes %d and %d", s.name, prev, i)
+		}
+		idx[s.name] = i
+	}
+
+	mustRunBefore := [][2]string{
+		// Data migrations read columns created by the macros migration.
+		{"macros", "calorie_goal_to_macro_goals"},
+		{"macros", "auto_calc_calories"},
+		// todos/todo_completions reference users(id) from base.
+		{"base", "todos"},
+	}
+	for _, pair := range mustRunBefore {
+		before, after := pair[0], pair[1]
+		bi, ok := idx[before]
+		if !ok {
+			t.Errorf("expected migration %q to exist", before)
+			continue
+		}
+		ai, ok := idx[after]
+		if !ok {
+			t.Errorf("expected migration %q to exist", after)
+			continue
+		}
+		if bi >= ai {
+			t.Errorf("migration %q (index %d) must run before %q (index %d)", before, bi, after, ai)
+		}
+	}
+}
+
+// TestMigrationLockKeyStable pins the pg_advisory_lock key that serializes
+// migrations across replicas. The value is arbitrary but must NEVER change:
+// during a rolling deploy old and new pods run side by side, and if they
+// disagree on the key they can migrate concurrently again — exactly the race
+// the lock exists to prevent. 0x7363686175747261 is ASCII "schautra".
+func TestMigrationLockKeyStable(t *testing.T) {
+	const want int64 = 0x7363686175747261
+	if migrationLockKey != want {
+		t.Fatalf("migrationLockKey = %#x, want %#x — changing it breaks cross-replica serialization during rolling deploys", migrationLockKey, want)
+	}
+}

--- a/internal/session/middleware.go
+++ b/internal/session/middleware.go
@@ -22,13 +22,10 @@ func Middleware(store *Store) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			sess, err := store.Load(r)
 			if err != nil {
-				sess = &Session{
-					ID:     generateSID(),
-					Data:   make(map[string]any),
-					MaxAge: AnonMaxAge,
-					dirty:  true,
-					isNew:  true,
-				}
+				// Same pristine semantics as any other new session: it is
+				// only persisted (and its cookie only set) if a handler
+				// writes data into it.
+				sess = store.newSession()
 			}
 
 			holder := &sessionHolder{sess: sess}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -124,9 +126,18 @@ func (s *Session) MarkDirty() {
 	s.dirty = true
 }
 
+// dbExecutor is the subset of *pgxpool.Pool the store uses. It exists so
+// tests can substitute a fake and assert on exactly which writes the store
+// attempted (or, for pristine sessions, that none were attempted at all)
+// without a live Postgres.
+type dbExecutor interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
 // Store manages sessions in PostgreSQL.
 type Store struct {
-	pool   *pgxpool.Pool
+	pool   dbExecutor
 	secret string
 	mu     sync.Mutex
 }
@@ -186,8 +197,17 @@ func (s *Store) Save(w http.ResponseWriter, r *http.Request, sess *Session) erro
 	if sess.destroyed {
 		return nil
 	}
-	if !sess.dirty && !sess.isNew {
-		// Still refresh cookie for rolling sessions
+	if !sess.dirty {
+		if sess.isNew {
+			// Pristine new session: no handler ever wrote data into it.
+			// Persisting these would INSERT a "session" row and set a cookie
+			// for every cookie-less request — k8s probes hit /api/health every
+			// few seconds, and scanners can inflate the table at line rate.
+			// Sessions become persistable the moment data is written (Set /
+			// Delete / SetUserID / MarkStepUp / MarkDirty) or via Regenerate.
+			return nil
+		}
+		// Loaded, unmodified session: still refresh cookie for rolling sessions
 		s.setCookie(w, r, sess)
 		return nil
 	}
@@ -257,12 +277,16 @@ func (s *Store) Regenerate(r *http.Request, sess *Session) (*Session, error) {
 	return newSess, nil
 }
 
+// newSession returns a pristine (not yet dirty) session. It is only persisted
+// — and its cookie only set — once a handler actually writes data into it;
+// see Save. Regenerate is the exception: it constructs its session with
+// dirty=true because the old row was just deleted and the replacement must
+// survive even if the handler writes no further data.
 func (s *Store) newSession() *Session {
 	return &Session{
 		ID:     generateSID(),
 		Data:   make(map[string]any),
 		MaxAge: AnonMaxAge,
-		dirty:  true,
 		isNew:  true,
 	}
 }

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -1,0 +1,226 @@
+package session
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// fakeDB implements dbExecutor and records every Exec statement, so tests can
+// assert exactly which writes the store attempted — including that NONE were
+// attempted — without a live Postgres.
+type fakeDB struct {
+	mu    sync.Mutex
+	execs []string
+	// row, when set, backs QueryRow's Scan (used to simulate an existing
+	// session row). When nil, QueryRow behaves like a missing row.
+	row func(dest ...any) error
+}
+
+func (f *fakeDB) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.execs = append(f.execs, strings.Join(strings.Fields(sql), " "))
+	return pgconn.CommandTag{}, nil
+}
+
+func (f *fakeDB) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	if f.row == nil {
+		return fakeRow{scan: func(...any) error { return pgx.ErrNoRows }}
+	}
+	return fakeRow{scan: f.row}
+}
+
+func (f *fakeDB) recorded() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.execs...)
+}
+
+type fakeRow struct{ scan func(dest ...any) error }
+
+func (r fakeRow) Scan(dest ...any) error { return r.scan(dest...) }
+
+func serveWithSession(t *testing.T, db *fakeDB, req *http.Request, handler http.HandlerFunc) *http.Response {
+	t.Helper()
+	// Construct the Store directly (not via NewStore) so no prune loop
+	// goroutine leaks into the test.
+	store := &Store{pool: db}
+	rec := httptest.NewRecorder()
+	Middleware(store)(handler).ServeHTTP(rec, req)
+	return rec.Result()
+}
+
+// TestPristineSessionNotPersisted guards the write-amplification fix: a
+// cookie-less request whose handler never writes session data (k8s probes on
+// /api/health, scanners) must produce NO Set-Cookie header and NO database
+// write. Before the fix, every such request INSERTed a "session" row.
+func TestPristineSessionNotPersisted(t *testing.T) {
+	db := &fakeDB{}
+	req := httptest.NewRequest("GET", "/api/health", nil)
+
+	resp := serveWithSession(t, db, req, func(w http.ResponseWriter, r *http.Request) {
+		// Read-only session access must not count as "touched".
+		sess := GetSession(r)
+		_, _ = sess.UserID()
+		_ = sess.GetString("csrfToken")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	if cookies := resp.Header.Values("Set-Cookie"); len(cookies) != 0 {
+		t.Errorf("pristine session must not set a cookie, got Set-Cookie: %v", cookies)
+	}
+	if execs := db.recorded(); len(execs) != 0 {
+		t.Errorf("pristine session must not touch the database, got writes: %v", execs)
+	}
+}
+
+// TestNewSessionWithDataPersisted proves the flip side: a new session that a
+// handler actually writes to (captcha, pendingRegistration, CSRF token via
+// sess.Set) must still be INSERTed and must still set the cookie.
+func TestNewSessionWithDataPersisted(t *testing.T) {
+	db := &fakeDB{}
+	req := httptest.NewRequest("GET", "/api/captcha", nil)
+
+	var sid string
+	resp := serveWithSession(t, db, req, func(w http.ResponseWriter, r *http.Request) {
+		sess := GetSession(r)
+		sess.Set("captchaAnswer", "42")
+		sid = sess.ID
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	cookies := resp.Header.Values("Set-Cookie")
+	if len(cookies) != 1 || !strings.Contains(cookies[0], CookieName+"="+sid) {
+		t.Errorf("expected one %s cookie for sid %s, got %v", CookieName, sid, cookies)
+	}
+	execs := db.recorded()
+	if len(execs) != 1 || !strings.Contains(execs[0], `INSERT INTO "session"`) {
+		t.Errorf("expected exactly one session INSERT, got %v", execs)
+	}
+}
+
+// TestLoadedSessionRollingRefresh pins the pre-existing rolling-session
+// behavior: a request with a valid cookie whose handler doesn't modify the
+// session still gets its cookie refreshed (sliding expiry) but causes no
+// database write.
+func TestLoadedSessionRollingRefresh(t *testing.T) {
+	db := &fakeDB{
+		row: func(dest ...any) error {
+			*(dest[0].(*[]byte)) = []byte(`{"userId": 7}`)
+			*(dest[1].(*time.Time)) = time.Now().Add(time.Hour)
+			return nil
+		},
+	}
+	req := httptest.NewRequest("GET", "/api/entries", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "existing-sid"})
+
+	resp := serveWithSession(t, db, req, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	cookies := resp.Header.Values("Set-Cookie")
+	if len(cookies) != 1 || !strings.Contains(cookies[0], CookieName+"=existing-sid") {
+		t.Errorf("loaded session must keep its rolling cookie refresh, got %v", cookies)
+	}
+	if execs := db.recorded(); len(execs) != 0 {
+		t.Errorf("unmodified loaded session must not write to the database, got %v", execs)
+	}
+}
+
+// TestRegeneratedSessionPersisted pins Regenerate semantics: a regenerated
+// session must be persisted and set its new cookie even if no data key is
+// written afterwards (the old row was just DELETEd; losing the new one would
+// log the user out).
+func TestRegeneratedSessionPersisted(t *testing.T) {
+	db := &fakeDB{
+		row: func(dest ...any) error {
+			*(dest[0].(*[]byte)) = []byte(`{"userId": 7}`)
+			*(dest[1].(*time.Time)) = time.Now().Add(time.Hour)
+			return nil
+		},
+	}
+	req := httptest.NewRequest("POST", "/api/auth/step-up", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "old-sid"})
+
+	store := &Store{pool: db}
+	var newSID string
+	rec := httptest.NewRecorder()
+	Middleware(store)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sess := GetSession(r)
+		newSess, err := store.Regenerate(r, sess)
+		if err != nil {
+			t.Errorf("Regenerate failed: %v", err)
+		}
+		newSID = newSess.ID
+		SetSession(r, newSess)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})).ServeHTTP(rec, req)
+	resp := rec.Result()
+
+	cookies := resp.Header.Values("Set-Cookie")
+	if len(cookies) != 1 || !strings.Contains(cookies[0], CookieName+"="+newSID) {
+		t.Errorf("expected cookie for regenerated sid %s, got %v", newSID, cookies)
+	}
+	execs := db.recorded()
+	var sawDelete, sawInsert bool
+	for _, e := range execs {
+		if strings.Contains(e, `DELETE FROM "session"`) {
+			sawDelete = true
+		}
+		if strings.Contains(e, `INSERT INTO "session"`) {
+			sawInsert = true
+		}
+	}
+	if !sawDelete || !sawInsert {
+		t.Errorf("regeneration must DELETE the old row and INSERT the new one, got %v", execs)
+	}
+}
+
+// TestDestroyedSessionNotResurrected pins the Destroy guard: after Destroy,
+// the middleware's deferred save must not re-INSERT the row or re-set the
+// session cookie (only the clearing cookie from Destroy itself remains).
+func TestDestroyedSessionNotResurrected(t *testing.T) {
+	db := &fakeDB{
+		row: func(dest ...any) error {
+			*(dest[0].(*[]byte)) = []byte(`{"userId": 7}`)
+			*(dest[1].(*time.Time)) = time.Now().Add(time.Hour)
+			return nil
+		},
+	}
+	req := httptest.NewRequest("POST", "/api/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "doomed-sid"})
+
+	store := &Store{pool: db}
+	rec := httptest.NewRecorder()
+	Middleware(store)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sess := GetSession(r)
+		if err := store.Destroy(w, r, sess); err != nil {
+			t.Errorf("Destroy failed: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})).ServeHTTP(rec, req)
+	resp := rec.Result()
+
+	cookies := resp.Header.Values("Set-Cookie")
+	if len(cookies) != 1 || !strings.Contains(cookies[0], CookieName+"=;") {
+		t.Errorf("expected only the clearing cookie from Destroy, got %v", cookies)
+	}
+	for _, e := range db.recorded() {
+		if strings.Contains(e, `INSERT INTO "session"`) {
+			t.Errorf("destroyed session must not be re-INSERTed, got %v", db.recorded())
+		}
+	}
+}


### PR DESCRIPTION
Fixes the three database/infrastructure findings from the verified code audit.

## 1. Addresses MEDIUM item 'Parallel migration goroutines run conflicting DDL on users table; no cross-replica lock' from #142

`runAllMigrations` launched 14 migrations in concurrent goroutines (five of them `ALTER TABLE users` in separate transactions; `ensureOIDCAccountsSchema` upgraded a SHARE ROW EXCLUSIVE lock on `users` to ACCESS EXCLUSIVE — a lock-upgrade deadlock against queued siblings), and nothing serialized migrations across replicas.

- All migrations are now one flat, ordered `migrationSteps()` list run **sequentially**: `base` first (everything else REFERENCES or ALTERs its tables), the two data migrations last (they read columns created by `macros`).
- The whole run is wrapped in `SELECT pg_advisory_lock(migrationLockKey)` / `pg_advisory_unlock` on a **dedicated pooled connection** (advisory locks are session-scoped), so only one replica migrates at a time; losers block on the lock, then re-run the idempotent migrations against the finished schema. If the unlock fails, the connection is closed rather than returned to the pool so the server releases the lock.
- `migrationLockKey = 0x7363686175747261` (ASCII `"schautra"`) — pinned by `TestMigrationLockKeyStable` because old and new pods must agree on the key during a rolling deploy.
- The existing retry behavior (`InitSchemaWithRetry`, 10 attempts with exponential backoff) around the whole run is preserved.
- New unit tests (no DB needed): `TestMigrationStepsOrdered` (base first, uniqueness, macros-before-data-migrations ordering) and `TestMigrationLockKeyStable`.

**Verified live** against `postgres:18-alpine`: two server replicas booted **simultaneously against an empty database** — zero errors, zero retries, both healthy, full schema created; repeated against a legacy database initialized from the old `init.sql` (upgrade path) with the same result.

## 2. Addresses MEDIUM item 'Every cookie-less request INSERTs a session row (health probes, scanners)' from #142

`newSession` returned `dirty:true`/`isNew:true`, so `Save` persisted a `"session"` row and set a cookie for every cookie-less request even if the handler never touched session data.

- New sessions now start **pristine**; `dirty` is only set by actual data writes (`Set`/`Delete` — which `SetUserID`, `MarkStepUp`, `MarkDirty` and `GenerateCsrfToken` all funnel through). `Save` skips both the INSERT and the `Set-Cookie` for pristine new sessions.
- Preserved behavior, each pinned by a new `httptest`-based test in `internal/session/store_test.go`:
  - `TestPristineSessionNotPersisted` — a request that never touches the session produces **no Set-Cookie and no DB write attempt** (proven via a recording fake DB)
  - `TestNewSessionWithDataPersisted` — a request that `Set`s data still INSERTs and still sets the cookie
  - `TestLoadedSessionRollingRefresh` — loaded existing sessions keep the rolling cookie refresh with no DB write
  - `TestRegeneratedSessionPersisted` — `Regenerate`d sessions still persist (constructed dirty) with DELETE-old + INSERT-new
  - `TestDestroyedSessionNotResurrected` — destroyed sessions are not re-INSERTed by the deferred save
- To make this testable without Postgres, `Store`'s pool field was narrowed to a tiny `dbExecutor` interface (`Exec` + `QueryRow`, satisfied by `*pgxpool.Pool`); the `NewStore` signature is unchanged.

**Verified live**: 5× cookie-less `GET /api/health` → `session` table stays at 0 rows, no `Set-Cookie`; `GET /api/csrf` → 1 row + cookie; reusing that cookie → rolling refresh, still 1 row; a CSRF-protected POST validated against the persisted session token succeeds past `CsrfProtection`.

## 3. Addresses LOW item 'db/init.sql drifted from code migrations: duplicate constraints on fresh installs, five tables missing' from #142

Decision: since the `ensureXxxSchema()` migrations fully create the schema on an empty database (including the `"session"` table — verified live, all 19 tables), `db/init.sql` is reduced to a **comment-only stub** pointing at `internal/database/migrations.go` as the single source of truth. No DDL is genuinely required before the app runs.

Reference audit of every `init.sql` mention in the repo:
- `compose.yml` (prod) and `compose.test.yml` (E2E) **never mounted it** — those environments have always initialized from migrations alone, which is why this was safe to begin with.
- `compose.dev.yml`: the `docker-entrypoint-initdb.d` mount is **removed** — dev now initializes exactly like prod/E2E.
- `.github/workflows/build.yml`: keeps `db/init.sql` in its path filters (harmless — a docs-only change to the stub just triggers a build).
- `CLAUDE.md`: the three references updated to name migrations as the source of truth.

Also fixed the one duplicate that lived inside the migrations themselves: `ensureInviteSchema` created a plain `invite_codes_code_idx` on a column whose inline `UNIQUE` already creates `invite_codes_code_key`; the migration now drops it (`DROP INDEX IF EXISTS`), cleaning both fresh and existing installs.

**Verified live**: fresh install with no init.sql yields exactly one amount CHECK (`calorie_entries_amount_range`), exactly one unique token index each on `password_reset_tokens`/`email_verification_tokens`, and `invite_codes` with only `pkey` + `code_key`.

## Test evidence

```
$ go test ./...
ok  schautrack/internal/clientip
ok  schautrack/internal/database
ok  schautrack/internal/handler
ok  schautrack/internal/middleware
ok  schautrack/internal/service
ok  schautrack/internal/session
ok  schautrack/internal/sse

$ go vet ./...
(clean)
```

`go test ./...` passes with no database, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
