### PR TITLE
fix(auth): session invalidation, 2FA attempt cap, server-side login counters, email failure surfacing

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
@@ -164,17 +165,24 @@ func (h *AdminHandler) CreateInvite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Send email if address provided and SMTP is configured
+	// Send email if address provided and SMTP is configured. The invite is
+	// already created and its code is returned below, so a send failure is
+	// reported alongside the result instead of failing the request.
+	emailSent := false
 	if email != "" && h.Email.IsConfigured() {
 		baseURL := h.Cfg.BaseURL
 		if baseURL == "" {
 			baseURL = "https://" + r.Host
 		}
-		h.Email.SendInviteEmail(email, code, baseURL)
+		if err := h.Email.SendInviteEmail(email, code, baseURL); err != nil {
+			slog.Error("failed to send invite email", "error", err, "invite_id", id)
+		} else {
+			emailSent = true
+		}
 	}
 
 	JSON(w, http.StatusOK, map[string]any{
-		"ok": true, "invite": map[string]any{
+		"ok": true, "emailSent": emailSent, "invite": map[string]any{
 			"id": id, "code": code, "email": emailPtr,
 		},
 	})

--- a/internal/handler/api.go
+++ b/internal/handler/api.go
@@ -351,13 +351,25 @@ func CleanExpiredTokens(pool *pgxpool.Pool) {
 	// stock Keycloak/Authentik/Authelia default) would be purged within minutes
 	// of signup, cascading away all of their entries. Exclude any user that has
 	// an OIDC account or a registered passkey.
+	// The created_at grace period gives a just-registered user time to
+	// recover (resend the code, or re-login to get a fresh token) before the
+	// account is reaped — previously a single failed/expired verification
+	// email could silently cost the account within one cleanup tick.
 	if _, err := pool.Exec(ctx, `
 		DELETE FROM users
 		WHERE email_verified = FALSE
+			AND created_at < NOW() - interval '1 hour'
 			AND id NOT IN (SELECT DISTINCT user_id FROM email_verification_tokens WHERE used = FALSE)
 			AND NOT EXISTS (SELECT 1 FROM user_oidc_accounts o WHERE o.user_id = users.id)
 			AND NOT EXISTS (SELECT 1 FROM user_passkeys p WHERE p.user_id = users.id)
 	`); err != nil {
 		slog.Error("failed to clean unverified users", "error", err)
+	}
+	// Retention: audit_log and ai_usage otherwise grow unbounded.
+	if _, err := pool.Exec(ctx, "DELETE FROM audit_log WHERE created_at < NOW() - interval '90 days'"); err != nil {
+		slog.Error("failed to prune old audit log rows", "error", err)
+	}
+	if _, err := pool.Exec(ctx, "DELETE FROM ai_usage WHERE usage_date < CURRENT_DATE - 400"); err != nil {
+		slog.Error("failed to prune old ai_usage rows", "error", err)
 	}
 }

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pquerna/otp/totp"
 
+	"schautrack/internal/clientip"
 	"schautrack/internal/config"
 	"schautrack/internal/database"
 	"schautrack/internal/middleware"
@@ -23,6 +24,12 @@ type AuthHandler struct {
 	Email        *service.EmailService
 	Cfg          *config.Config
 	Settings     *database.SettingsCache
+}
+
+// trustProxy reports whether proxy headers may be trusted for client IP
+// extraction. Nil-safe because handler tests construct AuthHandler without Cfg.
+func (h *AuthHandler) trustProxy() bool {
+	return h.Cfg != nil && h.Cfg.TrustProxy
 }
 
 // Login handles POST /api/auth/login
@@ -59,9 +66,24 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 			verified = verifyAndUseBackupCodeForLogin(r, h.Pool, user.ID, body.Token)
 		}
 		if !verified {
+			// Cap failed 2FA attempts per pending session (mirrors
+			// stepup.go's maxStepUpFailures): the 6-digit TOTP must not be
+			// brute-forceable by replaying the same pending session.
+			if recordLogin2FAFailure(sess) {
+				if err := h.SessionStore.Destroy(w, r, sess); err != nil {
+					slog.Error("failed to destroy session on login 2FA lockout", "error", err)
+				}
+				JSON(w, http.StatusUnauthorized, map[string]any{
+					"error":   "Too many failed attempts. Please log in again.",
+					"lockout": true,
+				})
+				return
+			}
 			ErrorJSON(w, http.StatusUnauthorized, "Invalid 2FA code.")
 			return
 		}
+		sess.Delete("pendingUserId")
+		sess.Delete("login2faFailures")
 		newSess, err := h.SessionStore.Regenerate(r, sess)
 		if err != nil {
 			ErrorJSON(w, http.StatusInternalServerError, "Session error.")
@@ -79,7 +101,20 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	email := strings.ToLower(strings.TrimSpace(body.Email))
+	clientAddr := clientip.FromRequest(r, h.trustProxy())
+
 	captchaAnswer := sess.GetString("captchaAnswer")
+	if captchaAnswer == "" && loginCaptchaRequired(sess, email, clientAddr) {
+		// The server-side failure counters (keyed by account email and
+		// client IP) demand a captcha, but this session has none in flight —
+		// e.g. a client dropping its cookies between attempts to keep the
+		// session counter at zero. Issue a challenge instead of processing.
+		c := service.GenerateCaptcha()
+		sess.Set("captchaAnswer", c.Text)
+		JSON(w, http.StatusUnauthorized, map[string]any{"ok": false, "error": "Captcha required.", "captchaSvg": c.Data, "requireCaptcha": true})
+		return
+	}
 	if captchaAnswer != "" {
 		if !service.VerifyCaptcha(captchaAnswer, body.Captcha) {
 			c := service.GenerateCaptcha()
@@ -90,7 +125,6 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		sess.Delete("captchaAnswer")
 	}
 
-	email := strings.ToLower(strings.TrimSpace(body.Email))
 	var userID int
 	var passwordHash string
 	var emailVerified bool
@@ -98,17 +132,25 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	err := h.Pool.QueryRow(r.Context(), "SELECT id, password_hash, email_verified, totp_enabled FROM users WHERE email = $1", email).
 		Scan(&userID, &passwordHash, &emailVerified, &totpEnabled)
 	if err != nil {
+		// Burn the same argon2id cost as a real password check so unknown
+		// emails aren't distinguishable from wrong passwords by timing.
+		equalizeLoginTiming(body.Password)
 		recordLoginFailure(sess)
-		replyWithCaptchaIfNeeded(w, sess)
+		recordServerLoginFailure(email, clientAddr)
+		replyWithCaptchaIfNeeded(w, sess, email, clientAddr)
 		return
 	}
 
 	valid, _ := verifyPassword(passwordHash, body.Password)
 	if !valid {
 		recordLoginFailure(sess)
-		replyWithCaptchaIfNeeded(w, sess)
+		recordServerLoginFailure(email, clientAddr)
+		replyWithCaptchaIfNeeded(w, sess, email, clientAddr)
 		return
 	}
+
+	// Correct credentials: clear the failure counters.
+	clearLoginFailures(sess, email, clientAddr)
 
 	// Migrate bcrypt → argon2id
 	if strings.HasPrefix(passwordHash, "$2b$") || strings.HasPrefix(passwordHash, "$2a$") {
@@ -120,9 +162,14 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		if _, err := h.Pool.Exec(r.Context(),
 			"INSERT INTO email_verification_tokens (user_id, token, expires_at) VALUES ($1, $2, $3)",
 			userID, code, time.Now().Add(30*time.Minute)); err != nil {
-			slog.Warn("failed to insert verification token during login", "error", err, "user_id", userID)
+			slog.Error("failed to insert verification token during login", "error", err, "user_id", userID)
+			ErrorJSON(w, http.StatusInternalServerError, "Could not send verification email. Please try again.")
+			return
 		}
-		h.Email.SendVerificationEmail(email, code)
+		if err := h.Email.SendVerificationEmail(email, code); err != nil {
+			ErrorJSON(w, http.StatusInternalServerError, "Could not send verification email. Please try again.")
+			return
+		}
 		sess.Set("verifyEmail", email)
 		JSON(w, http.StatusOK, map[string]any{"ok": true, "requireVerification": true})
 		return
@@ -321,6 +368,16 @@ func (h *AuthHandler) registerCaptcha(w http.ResponseWriter, r *http.Request, se
 		}
 	}
 
+	// Generate the verification code before opening the transaction so the
+	// token row is created atomically with the user row: if the token INSERT
+	// fails, the whole registration rolls back instead of leaving an
+	// unverified user with no token for CleanExpiredTokens to reap.
+	emailConfigured := h.Email.IsConfigured()
+	var verifyCode string
+	if emailConfigured {
+		verifyCode = service.GenerateResetCode()
+	}
+
 	// Create user and claim invite code atomically in a transaction
 	tx, txErr := h.Pool.Begin(r.Context())
 	if txErr != nil {
@@ -355,6 +412,16 @@ func (h *AuthHandler) registerCaptcha(w http.ResponseWriter, r *http.Request, se
 		sess.Delete("pendingInviteCode")
 	}
 
+	if emailConfigured {
+		if _, err := tx.Exec(r.Context(),
+			"INSERT INTO email_verification_tokens (user_id, token, expires_at) VALUES ($1, $2, $3)",
+			userID, verifyCode, time.Now().Add(30*time.Minute)); err != nil {
+			slog.Error("failed to insert verification token during registration", "error", err)
+			ErrorJSON(w, http.StatusInternalServerError, "Could not register.")
+			return
+		}
+	}
+
 	if txErr = tx.Commit(r.Context()); txErr != nil {
 		ErrorJSON(w, http.StatusInternalServerError, "Could not register.")
 		return
@@ -362,15 +429,14 @@ func (h *AuthHandler) registerCaptcha(w http.ResponseWriter, r *http.Request, se
 
 	sess.Delete("pendingRegistration")
 
-	if h.Email.IsConfigured() {
-		code := service.GenerateResetCode()
-		if _, err := h.Pool.Exec(r.Context(),
-			"INSERT INTO email_verification_tokens (user_id, token, expires_at) VALUES ($1, $2, $3)",
-			userID, code, time.Now().Add(30*time.Minute)); err != nil {
-			slog.Warn("failed to insert verification token during registration", "error", err, "user_id", userID)
-		}
-		h.Email.SendVerificationEmail(emailClean, code)
+	if emailConfigured {
+		// Email send stays outside the transaction — the account exists
+		// either way, and login/resend can retry the verification email.
 		sess.Set("verifyEmail", emailClean)
+		if err := h.Email.SendVerificationEmail(emailClean, verifyCode); err != nil {
+			ErrorJSON(w, http.StatusInternalServerError, "Could not send verification email. Please try again.")
+			return
+		}
 		JSON(w, http.StatusOK, map[string]any{"ok": true, "requireVerification": true})
 	} else {
 		// Rotate the session ID on privilege elevation (session fixation),

--- a/internal/handler/auth_email.go
+++ b/internal/handler/auth_email.go
@@ -155,7 +155,10 @@ func (h *AuthHandler) VerifyEmailResend(w http.ResponseWriter, r *http.Request) 
 		ErrorJSON(w, http.StatusInternalServerError, "Could not send verification email.")
 		return
 	}
-	h.Email.SendVerificationEmail(email, code)
+	if err := h.Email.SendVerificationEmail(email, code); err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Could not send verification email. Please try again.")
+		return
+	}
 
 	sess.Set("resendAttempts", resendAttempts+1)
 	sess.Set("verifyAttempts", 0)
@@ -210,7 +213,10 @@ func (h *AuthHandler) EmailChangeRequest(w http.ResponseWriter, r *http.Request)
 		ErrorJSON(w, http.StatusInternalServerError, "Could not initiate email change.")
 		return
 	}
-	h.Email.SendEmailChangeVerification(newEmail, code)
+	if err := h.Email.SendEmailChangeVerification(newEmail, code); err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Could not send verification email. Please try again.")
+		return
+	}
 
 	sess := session.GetSession(r)
 	sess.Set("pendingEmailChange", newEmail)
@@ -333,6 +339,10 @@ func (h *AuthHandler) DeleteAccount(w http.ResponseWriter, r *http.Request) {
 		"DELETE FROM account_links WHERE requester_id = $1 OR target_id = $1",
 		"DELETE FROM password_reset_tokens WHERE user_id = $1",
 		"DELETE FROM email_verification_tokens WHERE user_id = $1",
+		// Sessions aren't FK-linked to users: delete them explicitly so no
+		// other device stays "logged in" as a deleted account (matches
+		// admin.go's DeleteUser).
+		`DELETE FROM "session" WHERE (sess::jsonb->>'userId')::int = $1`,
 		"DELETE FROM users WHERE id = $1",
 	}
 	for _, q := range tables {

--- a/internal/handler/auth_helpers.go
+++ b/internal/handler/auth_helpers.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/alexedwards/argon2id"
@@ -44,6 +45,52 @@ func migratePasswordHash(pool *pgxpool.Pool, userID int, password string) {
 func recordLoginFailure(sess *session.Session) {
 	attempts, _ := sess.GetInt("loginFailedAttempts")
 	sess.Set("loginFailedAttempts", attempts+1)
+}
+
+// maxLogin2FAFailures caps failed TOTP/backup-code attempts during the
+// pending-2FA login step, mirroring stepup.go's maxStepUpFailures. Without a
+// cap, the 6-digit TOTP is brute-forceable through the bypassable IP limiter.
+const maxLogin2FAFailures = 5
+
+// recordLogin2FAFailure increments the pending-login 2FA failure counter and
+// reports whether the cap was reached. When it returns true, the pending
+// login state has been cleared and the caller must destroy the session and
+// reply with a lockout response (mirroring recordStepUpFailure).
+func recordLogin2FAFailure(sess *session.Session) bool {
+	failures, _ := sess.GetInt("login2faFailures")
+	failures++
+	sess.Set("login2faFailures", failures)
+	if failures >= maxLogin2FAFailures {
+		sess.Delete("pendingUserId")
+		sess.Delete("login2faFailures")
+		return true
+	}
+	return false
+}
+
+// dummyPasswordHash lazily precomputes an argon2id hash (same DefaultParams
+// as real user hashes) used to equalize login timing when the email doesn't
+// match any account. Without it, unknown emails return after a cheap DB miss
+// while known emails pay a slow argon2id verify — a measurable
+// user-enumeration timing oracle.
+var dummyPasswordHash = sync.OnceValue(func() string {
+	hash, err := argon2id.CreateHash("schautrack-timing-equalization-dummy", argon2id.DefaultParams)
+	if err != nil {
+		// CreateHash only fails if crypto/rand fails; skip equalization
+		// rather than crashing logins.
+		slog.Error("failed to precompute dummy password hash", "error", err)
+		return ""
+	}
+	return hash
+})
+
+// equalizeLoginTiming burns the same argon2id verification cost as a real
+// password check. Called on the unknown-email login path so its duration is
+// indistinguishable from a wrong password on an existing account.
+func equalizeLoginTiming(password string) {
+	if hash := dummyPasswordHash(); hash != "" {
+		_, _ = argon2id.ComparePasswordAndHash(password, hash)
+	}
 }
 
 func verifyAndUseBackupCodeForLogin(r *http.Request, pool *pgxpool.Pool, userID int, code string) bool {
@@ -90,10 +137,9 @@ func verifyAndMarkBackupCode(r *http.Request, pool *pgxpool.Pool, userID int, co
 	return false
 }
 
-func replyWithCaptchaIfNeeded(w http.ResponseWriter, sess *session.Session) {
-	attempts, _ := sess.GetInt("loginFailedAttempts")
+func replyWithCaptchaIfNeeded(w http.ResponseWriter, sess *session.Session, email, ip string) {
 	resp := map[string]any{"ok": false, "error": "Invalid credentials."}
-	if attempts >= 3 {
+	if loginCaptchaRequired(sess, email, ip) {
 		c := service.GenerateCaptcha()
 		sess.Set("captchaAnswer", c.Text)
 		resp["captchaSvg"] = c.Data
@@ -162,7 +208,12 @@ func (h *AuthHandler) Reset2FA(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		h.Email.Send2FAResetEmail(emailClean, code)
+		if err := h.Email.Send2FAResetEmail(emailClean, code); err != nil {
+			// Caller already proved email+password, so surfacing the send
+			// failure reveals nothing about account existence.
+			ErrorJSON(w, http.StatusInternalServerError, "Could not send reset code. Please try again.")
+			return
+		}
 		sess.Set("reset2faUserId", userID)
 		sess.Set("reset2faAttempts", 0)
 		OkJSON(w)
@@ -218,6 +269,14 @@ func (h *AuthHandler) Reset2FA(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if _, txErr = tx.Exec(r.Context(), "UPDATE password_reset_tokens SET used = TRUE WHERE id = $1", tokenID); txErr != nil {
+			ErrorJSON(w, http.StatusInternalServerError, "Could not reset 2FA.")
+			return
+		}
+		// Removing 2FA is a credential change: kill every existing session
+		// for the account so a stolen cookie doesn't survive the reset. The
+		// caller is on an anonymous session (login page), which has no
+		// userId and is therefore unaffected.
+		if txErr = invalidateUserSessions(r.Context(), tx, userID, ""); txErr != nil {
 			ErrorJSON(w, http.StatusInternalServerError, "Could not reset 2FA.")
 			return
 		}

--- a/internal/handler/auth_password.go
+++ b/internal/handler/auth_password.go
@@ -54,8 +54,11 @@ func (h *AuthHandler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
 			"INSERT INTO password_reset_tokens (user_id, token, expires_at) VALUES ($1, $2, $3)",
 			userID, code, time.Now().Add(30*time.Minute)); err != nil {
 			slog.Error("failed to insert password reset token", "error", err)
-		} else {
-			h.Email.SendPasswordResetEmail(userEmail, code)
+		} else if err := h.Email.SendPasswordResetEmail(userEmail, code); err != nil {
+			// Deliberately NOT surfaced to the client: this endpoint must
+			// stay non-enumerating, and a send-failure response would reveal
+			// that the account exists. Log it and return the generic success.
+			slog.Error("failed to send password reset email", "error", err)
 		}
 	}
 	// Always return success (don't reveal if email exists)
@@ -149,12 +152,32 @@ func (h *AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 		ErrorJSON(w, http.StatusInternalServerError, "Could not reset password.")
 		return
 	}
-	if _, err := h.Pool.Exec(r.Context(), "UPDATE users SET password_hash = $1 WHERE id = $2", hash, userID); err != nil {
+
+	// Update the password, consume the token, and invalidate EVERY existing
+	// session of the user atomically: an attacker holding a stolen session
+	// cookie must not keep access after the victim resets their password.
+	// The caller's own (anonymous) session carries no userId and survives.
+	tx, err := h.Pool.Begin(r.Context())
+	if err != nil {
 		ErrorJSON(w, http.StatusInternalServerError, "Could not reset password.")
 		return
 	}
-	if _, err := h.Pool.Exec(r.Context(), "UPDATE password_reset_tokens SET used = TRUE WHERE id = $1", tokenID); err != nil {
-		slog.Error("failed to mark password reset token as used", "error", err, "token_id", tokenID)
+	defer tx.Rollback(r.Context())
+	if _, err := tx.Exec(r.Context(), "UPDATE users SET password_hash = $1 WHERE id = $2", hash, userID); err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Could not reset password.")
+		return
+	}
+	if _, err := tx.Exec(r.Context(), "UPDATE password_reset_tokens SET used = TRUE WHERE id = $1", tokenID); err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Could not reset password.")
+		return
+	}
+	if err := invalidateUserSessions(r.Context(), tx, userID, ""); err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Could not reset password.")
+		return
+	}
+	if err := tx.Commit(r.Context()); err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Could not reset password.")
+		return
 	}
 
 	sess.Delete("resetEmail")

--- a/internal/handler/auth_security_test.go
+++ b/internal/handler/auth_security_test.go
@@ -1,0 +1,56 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	"schautrack/internal/session"
+)
+
+func TestRecordLogin2FAFailure_LockoutOnFifthFailure(t *testing.T) {
+	sess := &session.Session{ID: "t", Data: make(map[string]any)}
+	sess.Set("pendingUserId", 42)
+
+	for i := 1; i < maxLogin2FAFailures; i++ {
+		if locked := recordLogin2FAFailure(sess); locked {
+			t.Fatalf("locked out after %d failures, want lockout only at %d", i, maxLogin2FAFailures)
+		}
+		if got, _ := sess.GetInt("login2faFailures"); got != i {
+			t.Errorf("failure counter = %d after %d failures", got, i)
+		}
+		if _, ok := sess.GetInt("pendingUserId"); !ok {
+			t.Fatalf("pendingUserId dropped after only %d failures", i)
+		}
+	}
+
+	if locked := recordLogin2FAFailure(sess); !locked {
+		t.Fatalf("no lockout on failure #%d", maxLogin2FAFailures)
+	}
+	if _, ok := sess.GetInt("pendingUserId"); ok {
+		t.Error("pendingUserId must be cleared on lockout")
+	}
+	if _, ok := sess.GetInt("login2faFailures"); ok {
+		t.Error("failure counter must be cleared on lockout")
+	}
+}
+
+func TestEqualizeLoginTiming_UsesValidArgon2Hash(t *testing.T) {
+	hash := dummyPasswordHash()
+	if hash == "" {
+		t.Fatal("dummy password hash is empty")
+	}
+	if !strings.HasPrefix(hash, "$argon2id$") {
+		t.Fatalf("dummy hash is not argon2id: %q", hash)
+	}
+	// The dummy hash must never verify an attacker-supplied password.
+	valid, err := verifyPassword(hash, "any-password-at-all")
+	if err != nil {
+		t.Fatalf("verifyPassword on dummy hash: %v", err)
+	}
+	if valid {
+		t.Error("dummy hash verified an arbitrary password")
+	}
+	// And the equalization call itself must be safe to invoke.
+	equalizeLoginTiming("some-password")
+	equalizeLoginTiming("")
+}

--- a/internal/handler/login_failures.go
+++ b/internal/handler/login_failures.go
@@ -1,0 +1,143 @@
+package handler
+
+import (
+	"sync"
+	"time"
+
+	"schautrack/internal/session"
+)
+
+// loginCaptchaThreshold is the failed-attempt count (per session, per account
+// email, or per client IP) at which login requires solving a captcha.
+const loginCaptchaThreshold = 3
+
+// loginFailureWindow is how long server-side failure counters persist. It
+// matches the auth rate limiter's window so both defenses decay together.
+const loginFailureWindow = 15 * time.Minute
+
+// maxTrackedLoginKeys bounds the tracker's memory (same cap as the rate
+// limiter): beyond it, new keys are not tracked rather than growing the map.
+const maxTrackedLoginKeys = 10000
+
+// loginFailures tracks failed login attempts server-side, keyed by account
+// email ("email:<addr>") and proxy-validated client IP ("ip:<addr>"). The
+// session-based counter alone is client-controlled: a client that drops its
+// cookies starts every request with loginFailedAttempts=0 and never triggers
+// the captcha. These counters close that hole.
+var loginFailures = newFailureTracker(loginFailureWindow, maxTrackedLoginKeys)
+
+// failureTracker is a bounded, concurrency-safe in-memory failure counter
+// with a fixed window per key (mirrors internal/middleware/ratelimit.go).
+type failureTracker struct {
+	mu         sync.Mutex
+	entries    map[string]*failureEntry
+	window     time.Duration
+	maxEntries int
+	now        func() time.Time // injectable for tests
+}
+
+type failureEntry struct {
+	count       int
+	windowStart time.Time
+}
+
+func newFailureTracker(window time.Duration, maxEntries int) *failureTracker {
+	return &failureTracker{
+		entries:    make(map[string]*failureEntry),
+		window:     window,
+		maxEntries: maxEntries,
+		now:        time.Now,
+	}
+}
+
+// Record increments the failure count for key. The count resets once the
+// window since the first recorded failure elapses. At capacity, expired
+// entries are pruned first; if the map is still full, new keys are dropped
+// (fail open — the session counter and IP rate limiter still apply) so
+// memory stays bounded even under key-spraying.
+func (t *failureTracker) Record(key string) {
+	now := t.now()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if e, ok := t.entries[key]; ok {
+		if now.Sub(e.windowStart) > t.window {
+			e.count = 0
+			e.windowStart = now
+		}
+		e.count++
+		return
+	}
+	if len(t.entries) >= t.maxEntries {
+		t.pruneLocked(now)
+		if len(t.entries) >= t.maxEntries {
+			return
+		}
+	}
+	t.entries[key] = &failureEntry{count: 1, windowStart: now}
+}
+
+// Count returns the failures recorded for key within the current window.
+func (t *failureTracker) Count(key string) int {
+	now := t.now()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	e, ok := t.entries[key]
+	if !ok {
+		return 0
+	}
+	if now.Sub(e.windowStart) > t.window {
+		delete(t.entries, key)
+		return 0
+	}
+	return e.count
+}
+
+// Reset forgets all failures for key (called after a successful login).
+func (t *failureTracker) Reset(key string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.entries, key)
+}
+
+func (t *failureTracker) pruneLocked(now time.Time) {
+	for k, e := range t.entries {
+		if now.Sub(e.windowStart) > t.window {
+			delete(t.entries, k)
+		}
+	}
+}
+
+// recordServerLoginFailure counts a failed login against the account email
+// and the client IP, independent of the (client-controlled) session.
+func recordServerLoginFailure(email, ip string) {
+	if email != "" {
+		loginFailures.Record("email:" + email)
+	}
+	if ip != "" {
+		loginFailures.Record("ip:" + ip)
+	}
+}
+
+// clearLoginFailures resets all failure counters after a successful login.
+func clearLoginFailures(sess *session.Session, email, ip string) {
+	sess.Delete("loginFailedAttempts")
+	if email != "" {
+		loginFailures.Reset("email:" + email)
+	}
+	if ip != "" {
+		loginFailures.Reset("ip:" + ip)
+	}
+}
+
+// loginCaptchaRequired reports whether a login attempt for this
+// session/email/IP must solve a captcha: any of the three counters reaching
+// loginCaptchaThreshold triggers it.
+func loginCaptchaRequired(sess *session.Session, email, ip string) bool {
+	if attempts, _ := sess.GetInt("loginFailedAttempts"); attempts >= loginCaptchaThreshold {
+		return true
+	}
+	return loginFailures.Count("email:"+email) >= loginCaptchaThreshold ||
+		loginFailures.Count("ip:"+ip) >= loginCaptchaThreshold
+}

--- a/internal/handler/login_failures_test.go
+++ b/internal/handler/login_failures_test.go
@@ -1,0 +1,167 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"schautrack/internal/session"
+)
+
+func TestFailureTracker_CountsAndResets(t *testing.T) {
+	ft := newFailureTracker(15*time.Minute, 100)
+
+	if got := ft.Count("email:a@example.com"); got != 0 {
+		t.Errorf("Count on empty tracker = %d, want 0", got)
+	}
+
+	ft.Record("email:a@example.com")
+	ft.Record("email:a@example.com")
+	ft.Record("email:a@example.com")
+	if got := ft.Count("email:a@example.com"); got != 3 {
+		t.Errorf("Count = %d, want 3", got)
+	}
+	// Other keys are unaffected
+	if got := ft.Count("email:b@example.com"); got != 0 {
+		t.Errorf("Count for other key = %d, want 0", got)
+	}
+
+	ft.Reset("email:a@example.com")
+	if got := ft.Count("email:a@example.com"); got != 0 {
+		t.Errorf("Count after Reset = %d, want 0", got)
+	}
+}
+
+func TestFailureTracker_WindowExpiry(t *testing.T) {
+	current := time.Now()
+	ft := newFailureTracker(15*time.Minute, 100)
+	ft.now = func() time.Time { return current }
+
+	ft.Record("ip:203.0.113.9")
+	ft.Record("ip:203.0.113.9")
+	ft.Record("ip:203.0.113.9")
+	if got := ft.Count("ip:203.0.113.9"); got != 3 {
+		t.Fatalf("Count = %d, want 3", got)
+	}
+
+	// Advance past the window: the counter must expire.
+	current = current.Add(16 * time.Minute)
+	if got := ft.Count("ip:203.0.113.9"); got != 0 {
+		t.Errorf("Count after window = %d, want 0", got)
+	}
+
+	// A new failure after expiry starts a fresh window at 1.
+	ft.Record("ip:203.0.113.9")
+	if got := ft.Count("ip:203.0.113.9"); got != 1 {
+		t.Errorf("Count after expiry + record = %d, want 1", got)
+	}
+}
+
+func TestFailureTracker_Bounded(t *testing.T) {
+	current := time.Now()
+	ft := newFailureTracker(15*time.Minute, 3)
+	ft.now = func() time.Time { return current }
+
+	ft.Record("k1")
+	ft.Record("k2")
+	ft.Record("k3")
+	// At capacity with live entries: new keys must be dropped (fail open),
+	// not grow the map unboundedly.
+	ft.Record("k4")
+	if got := ft.Count("k4"); got != 0 {
+		t.Errorf("Count for key beyond capacity = %d, want 0 (dropped)", got)
+	}
+	// Existing keys still increment at capacity.
+	ft.Record("k1")
+	if got := ft.Count("k1"); got != 2 {
+		t.Errorf("Count for existing key at capacity = %d, want 2", got)
+	}
+
+	// Once old entries expire, there is room for new keys again.
+	current = current.Add(16 * time.Minute)
+	ft.Record("k5")
+	if got := ft.Count("k5"); got != 1 {
+		t.Errorf("Count for new key after prune = %d, want 1", got)
+	}
+}
+
+func TestLoginCaptchaRequired_ByEmailAndIP(t *testing.T) {
+	orig := loginFailures
+	loginFailures = newFailureTracker(15*time.Minute, 100)
+	defer func() { loginFailures = orig }()
+
+	sess := &session.Session{ID: "t", Data: make(map[string]any)}
+
+	if loginCaptchaRequired(sess, "victim@example.com", "203.0.113.5") {
+		t.Fatal("captcha required with zero failures")
+	}
+
+	// Server-side email counter alone triggers the captcha, regardless of
+	// the (client-controlled) session counter.
+	for i := 0; i < loginCaptchaThreshold; i++ {
+		recordServerLoginFailure("victim@example.com", fmt.Sprintf("198.51.100.%d", i))
+	}
+	if !loginCaptchaRequired(sess, "victim@example.com", "203.0.113.5") {
+		t.Error("captcha not required despite email failure count at threshold")
+	}
+	if loginCaptchaRequired(sess, "other@example.com", "203.0.113.5") {
+		t.Error("captcha required for unrelated email/IP")
+	}
+
+	// IP counter alone triggers it too.
+	for i := 0; i < loginCaptchaThreshold; i++ {
+		recordServerLoginFailure(fmt.Sprintf("u%d@example.com", i), "203.0.113.77")
+	}
+	if !loginCaptchaRequired(sess, "other@example.com", "203.0.113.77") {
+		t.Error("captcha not required despite IP failure count at threshold")
+	}
+
+	// Session counter still works as before.
+	sess2 := &session.Session{ID: "t2", Data: make(map[string]any)}
+	sess2.Set("loginFailedAttempts", loginCaptchaThreshold)
+	if !loginCaptchaRequired(sess2, "fresh@example.com", "192.0.2.200") {
+		t.Error("captcha not required despite session failure count at threshold")
+	}
+
+	// Successful login clears the server-side counters.
+	clearLoginFailures(sess, "victim@example.com", "203.0.113.77")
+	if loginCaptchaRequired(sess, "victim@example.com", "203.0.113.77") {
+		t.Error("captcha still required after clearLoginFailures")
+	}
+}
+
+// TestLogin_ServerSideCaptchaGate proves the captcha gate no longer depends on
+// the client persisting its session cookie: a fresh session (attempts=0) with
+// enough server-side failures for the email gets challenged before any DB
+// access (Pool is nil — reaching the DB would panic).
+func TestLogin_ServerSideCaptchaGate(t *testing.T) {
+	orig := loginFailures
+	loginFailures = newFailureTracker(15*time.Minute, 100)
+	defer func() { loginFailures = orig }()
+
+	for i := 0; i < loginCaptchaThreshold; i++ {
+		recordServerLoginFailure("brute@example.com", fmt.Sprintf("198.51.100.%d", i))
+	}
+
+	h := &AuthHandler{Pool: nil} // nil pool: must not reach the DB
+	body := `{"email":"Brute@Example.com","password":"whatever123"}`
+	r := newRequestWithSession("POST", "/api/auth/login", body)
+	w := httptest.NewRecorder()
+
+	h.Login(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if req, _ := resp["requireCaptcha"].(bool); !req {
+		t.Errorf("requireCaptcha = %v, want true; body = %s", resp["requireCaptcha"], w.Body.String())
+	}
+	if svg, _ := resp["captchaSvg"].(string); svg == "" {
+		t.Error("expected a captchaSvg challenge in the response")
+	}
+}

--- a/internal/handler/session_invalidation.go
+++ b/internal/handler/session_invalidation.go
@@ -1,0 +1,32 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// sqlExecutor is the subset of pgxpool.Pool / pgx.Tx needed by helpers that
+// must run either standalone or inside a transaction.
+type sqlExecutor interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+}
+
+// invalidateUserSessions deletes every session row belonging to userID except
+// keepSID (the session the user is acting from). Pass keepSID == "" to delete
+// ALL of the user's sessions — used by anonymous flows (email password reset,
+// 2FA reset) where the actor isn't logged in on the affected account.
+//
+// Called after credential changes (password reset/change, 2FA disable/reset)
+// so an attacker holding a stolen session cookie loses access the moment the
+// victim rotates their credentials. Same SQL shape as admin.go's DeleteUser.
+func invalidateUserSessions(ctx context.Context, db sqlExecutor, userID int, keepSID string) error {
+	if keepSID == "" {
+		_, err := db.Exec(ctx,
+			`DELETE FROM "session" WHERE (sess::jsonb->>'userId')::int = $1`, userID)
+		return err
+	}
+	_, err := db.Exec(ctx,
+		`DELETE FROM "session" WHERE (sess::jsonb->>'userId')::int = $1 AND sid <> $2`, userID, keepSID)
+	return err
+}

--- a/internal/handler/session_invalidation_test.go
+++ b/internal/handler/session_invalidation_test.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// fakeExecutor captures Exec calls so we can verify the SQL that
+// invalidateUserSessions issues without a live database.
+type fakeExecutor struct {
+	sqls []string
+	args [][]any
+}
+
+func (f *fakeExecutor) Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error) {
+	f.sqls = append(f.sqls, sql)
+	f.args = append(f.args, arguments)
+	return pgconn.CommandTag{}, nil
+}
+
+func TestInvalidateUserSessions_AllSessions(t *testing.T) {
+	f := &fakeExecutor{}
+	if err := invalidateUserSessions(context.Background(), f, 42, ""); err != nil {
+		t.Fatalf("invalidateUserSessions: %v", err)
+	}
+	if len(f.sqls) != 1 {
+		t.Fatalf("Exec calls = %d, want 1", len(f.sqls))
+	}
+	sql := f.sqls[0]
+	if !strings.Contains(sql, `DELETE FROM "session"`) || !strings.Contains(sql, "userId") {
+		t.Errorf("unexpected SQL: %s", sql)
+	}
+	if strings.Contains(sql, "sid <>") {
+		t.Errorf("empty keepSID must delete ALL sessions, got SQL: %s", sql)
+	}
+	if len(f.args[0]) != 1 || f.args[0][0] != 42 {
+		t.Errorf("args = %v, want [42]", f.args[0])
+	}
+}
+
+func TestInvalidateUserSessions_KeepsCurrentSession(t *testing.T) {
+	f := &fakeExecutor{}
+	if err := invalidateUserSessions(context.Background(), f, 7, "current-sid"); err != nil {
+		t.Fatalf("invalidateUserSessions: %v", err)
+	}
+	if len(f.sqls) != 1 {
+		t.Fatalf("Exec calls = %d, want 1", len(f.sqls))
+	}
+	sql := f.sqls[0]
+	if !strings.Contains(sql, `DELETE FROM "session"`) || !strings.Contains(sql, "sid <>") {
+		t.Errorf("expected DELETE excluding current sid, got SQL: %s", sql)
+	}
+	if len(f.args[0]) != 2 || f.args[0][0] != 7 || f.args[0][1] != "current-sid" {
+		t.Errorf("args = %v, want [7 current-sid]", f.args[0])
+	}
+}

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -298,7 +298,26 @@ func (h *SettingsHandler) Password(w http.ResponseWriter, r *http.Request) {
 		ErrorJSON(w, http.StatusInternalServerError, "Could not change password. Please try again.")
 		return
 	}
-	if _, err = h.Pool.Exec(r.Context(), "UPDATE users SET password_hash = $1 WHERE id = $2", hash, user.ID); err != nil {
+
+	// Write the new password and invalidate every OTHER session of the user
+	// atomically, so a stolen session cookie doesn't survive the change. The
+	// session the user is changing their password from stays logged in.
+	sess := session.GetSession(r)
+	tx, err := h.Pool.Begin(r.Context())
+	if err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Could not change password. Please try again.")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	if _, err = tx.Exec(r.Context(), "UPDATE users SET password_hash = $1 WHERE id = $2", hash, user.ID); err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Could not change password. Please try again.")
+		return
+	}
+	if err = invalidateUserSessions(r.Context(), tx, user.ID, sess.ID); err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Could not change password. Please try again.")
+		return
+	}
+	if err = tx.Commit(r.Context()); err != nil {
 		ErrorJSON(w, http.StatusInternalServerError, "Could not change password. Please try again.")
 		return
 	}
@@ -429,6 +448,12 @@ func (h *SettingsHandler) TwoFactorDisable(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if _, err := tx.Exec(r.Context(), "DELETE FROM totp_backup_codes WHERE user_id = $1", user.ID); err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Could not disable 2FA.")
+		return
+	}
+	// Disabling 2FA weakens the account's auth: kill every OTHER session so
+	// a stolen cookie can't ride out the change.
+	if err := invalidateUserSessions(r.Context(), tx, user.ID, session.GetSession(r).ID); err != nil {
 		ErrorJSON(w, http.StatusInternalServerError, "Could not disable 2FA.")
 		return
 	}

--- a/internal/service/email.go
+++ b/internal/service/email.go
@@ -41,8 +41,12 @@ func (es *EmailService) SendEmail(to, subject, text, html string) error {
 
 	err := smtp.SendMail(addr, auth, from, []string{to}, []byte(msg))
 	if err != nil {
+		// Log the raw SMTP detail server-side only; callers must surface a
+		// generic message. Swallowing the error here made every caller
+		// report success even when nothing was sent — combined with the
+		// unverified-user cleanup that silently cost accounts.
 		log.Printf("SMTP send failed: %v", err)
-		return nil // Don't expose SMTP errors to users
+		return fmt.Errorf("email send failed: %w", err)
 	}
 	return nil
 }

--- a/internal/service/email_test.go
+++ b/internal/service/email_test.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"net"
+	"testing"
+
+	"schautrack/internal/config"
+)
+
+// closedPortConfig returns an SMTP config pointing at a local port that is
+// guaranteed to be closed (we bind it, learn the number, then release it), so
+// SendEmail fails fast with a connection error and no network dependency.
+func closedPortConfig(t *testing.T) *config.Config {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+	return &config.Config{
+		SMTPHost: "127.0.0.1",
+		SMTPPort: port,
+		SMTPFrom: "noreply@example.com",
+	}
+}
+
+func TestSendEmail_NotConfiguredReturnsError(t *testing.T) {
+	es := NewEmailService(&config.Config{})
+	if err := es.SendEmail("to@example.com", "subject", "text", ""); err == nil {
+		t.Error("SendEmail with unconfigured SMTP returned nil, want error")
+	}
+}
+
+func TestSendEmail_SMTPFailureReturnsError(t *testing.T) {
+	es := NewEmailService(closedPortConfig(t))
+	err := es.SendEmail("to@example.com", "subject", "text body", "<p>html</p>")
+	if err == nil {
+		t.Fatal("SendEmail against a closed SMTP port returned nil, want error")
+	}
+}
+
+func TestEmailWrappers_PropagateSendErrors(t *testing.T) {
+	es := NewEmailService(closedPortConfig(t))
+
+	if err := es.SendVerificationEmail("to@example.com", "123456"); err == nil {
+		t.Error("SendVerificationEmail returned nil on SMTP failure, want error")
+	}
+	if err := es.SendPasswordResetEmail("to@example.com", "123456"); err == nil {
+		t.Error("SendPasswordResetEmail returned nil on SMTP failure, want error")
+	}
+	if err := es.Send2FAResetEmail("to@example.com", "123456"); err == nil {
+		t.Error("Send2FAResetEmail returned nil on SMTP failure, want error")
+	}
+	if err := es.SendEmailChangeVerification("to@example.com", "123456"); err == nil {
+		t.Error("SendEmailChangeVerification returned nil on SMTP failure, want error")
+	}
+}


### PR DESCRIPTION
Implements 8 verified findings from the security/correctness audit across auth, sessions, email, and cleanup. All logic is covered by unit tests that run without a database (`go test ./...` and `go vet ./...` green).

## Findings fixed

### #140

- **Addresses MEDIUM item "Credential changes do not invalidate the user's other active sessions" from #140**
  New `invalidateUserSessions` helper (`internal/handler/session_invalidation.go`, same SQL shape as admin `DeleteUser`) is now called atomically inside the relevant transactions:
  - `ResetPassword` (email flow): deletes **all** of the user's sessions, together with the password UPDATE and token consume in one tx.
  - `Settings.Password` (logged-in change): deletes all sessions **except the current one**, in a tx with the password UPDATE.
  - `TwoFactorDisable`: deletes all sessions except the current one, inside the existing tx.
  - `Reset2FA` (email flow): deletes all of the user's sessions inside the existing tx.

- **Addresses MEDIUM item "Login 2FA / backup-code verification has no per-account or per-session attempt cap" from #140**
  The login TOTP/backup-code step now tracks `login2faFailures` on the pending session; after 5 failures (mirroring `stepup.go`'s `maxStepUpFailures`) the pending login state is cleared, the session destroyed, and the client receives `401 {lockout:true}`. Counters and `pendingUserId` are cleared on success before session regeneration.

- **Addresses LOW item "Login anti-automation (captcha + failed-attempt counter) is keyed to a client-controlled session" from #140**
  Failed logins are additionally counted server-side keyed by **account email** and **proxy-validated client IP** (`internal/clientip`) in a new bounded, concurrent-safe in-memory tracker with a 15-minute window (`internal/handler/login_failures.go`, modelled on `internal/middleware/ratelimit.go`, capped at 10k keys with expiry-based pruning and fail-open at capacity). A captcha is required as soon as **any** of the three counters (session, email, IP) reaches 3 — a client that drops its cookies now gets challenged before the credential check even runs. Counters reset on successful login.

- **Addresses LOW item "User enumeration via login response timing" from #140**
  Unknown-email logins now burn an argon2id verification against a lazily precomputed dummy hash (`argon2id.DefaultParams`, same as real hashes), making them indistinguishable by timing from wrong-password attempts on existing accounts. Identical error response in both paths.

### #141

- **Addresses MEDIUM item "SMTP send failures are swallowed — SendEmail returns nil on error" from #141**
  `SendEmail` now returns the (wrapped) error; raw SMTP detail is only logged server-side. Handlers surface a generic "Could not send verification email. Please try again." for: login-verification send, registration send, verification resend, email-change verification, and 2FA-reset code. Admin invite creation reports `emailSent: false` (invite itself still succeeds since the code is shown). **Exception kept as specified:** `ForgotPassword` still always returns the generic success and only logs the failure, so the endpoint stays non-enumerating.

### #142

- **Addresses MEDIUM item "Verification token created outside the registration transaction; cleanup has zero grace period" from #142**
  The verification code is generated before `Begin` and the token row is INSERTed inside the same transaction as the user row (email send stays after commit). `CleanExpiredTokens`' unverified-user DELETE now requires `created_at < NOW() - interval '1 hour'`, so a fresh account survives a failed/expired verification email long enough to resend or re-login.

- **Addresses MEDIUM item "audit_log and ai_usage grow unbounded" from #142**
  The existing 15-minute cleanup loop now also runs `DELETE FROM audit_log WHERE created_at < NOW() - interval '90 days'` and `DELETE FROM ai_usage WHERE usage_date < CURRENT_DATE - 400`.

- **Addresses LOW item "Self-service account deletion leaves the user's other sessions in the database" from #142**
  `DeleteAccount` now deletes `"session"` rows for the user inside the deletion transaction (before the users row), matching admin `DeleteUser`.

## Tests

- `failureTracker`: threshold counting/reset, window expiry (injected clock), bounded-capacity behavior.
- `loginCaptchaRequired`: triggers on session, email, or IP counter independently; clears after success.
- Handler-level test proving the captcha gate fires for a fresh cookie-less session with only server-side failures (nil pool ⇒ no DB access possible).
- 2FA failure cap: lockout exactly on the 5th failure, pending state cleared.
- Timing equalization: dummy hash is valid argon2id, never verifies, safe to call.
- `invalidateUserSessions`: SQL/args verified via a fake executor for both "all sessions" and "keep current" modes.
- `SendEmail` + all wrappers return errors against a guaranteed-closed local SMTP port (no network dependency).

`go test ./...` passes with no database; `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
