### PR TITLE
fix(entries): validate inputs, harden export integrity, batch imports

### DIFF
--- a/internal/handler/entries.go
+++ b/internal/handler/entries.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
@@ -93,7 +94,12 @@ func (h *EntriesHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	mu := service.ParseMacroUser(user.MacrosEnabled, user.MacroGoals, user.DailyGoal, user.GoalThreshold)
-	totalsByDate := getTotalsByDate(r, h.Pool, user.ID, oldest, newest)
+	totalsByDate, err := getTotalsByDate(r, h.Pool, user.ID, oldest, newest)
+	if err != nil {
+		slog.Error("dashboard: failed to load calorie totals", "error", err)
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to load entries")
+		return
+	}
 	todayTotal := totalsByDate[todayStr]
 	macroModes := service.GetMacroModes(mu)
 	enabledMacros := service.GetEnabledMacros(mu)
@@ -203,7 +209,13 @@ func (h *EntriesHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 			linkOldest := linkDayOptions[len(linkDayOptions)-1]
 			linkNewest := linkDayOptions[0]
 			linkGoal := service.GetCalorieGoal(lmu)
-			linkTotals := getTotalsByDate(r, h.Pool, link.UserID, linkOldest, linkNewest)
+			linkTotals, err := getTotalsByDate(r, h.Pool, link.UserID, linkOldest, linkNewest)
+			if err != nil {
+				// Skip this link's card rather than rendering all-zero
+				// totals as if they were real data.
+				slog.Error("dashboard: failed to load linked user's calorie totals", "error", err, "linkUserId", link.UserID)
+				return
+			}
 			linkEnabledMacros := service.GetEnabledMacros(lmu)
 			linkMacroGoals := service.GetMacroGoals(lmu)
 			linkMacroModes := service.GetMacroModes(lmu)
@@ -372,7 +384,12 @@ func (h *EntriesHandler) Overview(w http.ResponseWriter, r *http.Request) {
 	todayStrTz := service.FormatDateInTz(time.Now(), targetTz)
 
 	dailyGoal := service.GetCalorieGoal(mu)
-	totalsByDate := getTotalsByDate(r, h.Pool, targetUserID, oldest, newest)
+	totalsByDate, err := getTotalsByDate(r, h.Pool, targetUserID, oldest, newest)
+	if err != nil {
+		slog.Error("overview: failed to load calorie totals", "error", err)
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to load entries")
+		return
+	}
 	todayTotal := totalsByDate[todayStrTz]
 	threshold := mu.GoalThreshold
 	enabledMacros := service.GetEnabledMacros(mu)

--- a/internal/handler/entries_crud.go
+++ b/internal/handler/entries_crud.go
@@ -30,15 +30,17 @@ func (h *EntriesHandler) CreateEntry(w http.ResponseWriter, r *http.Request) {
 	hasCalorieEntry := amountResult.Ok && amountResult.Value != 0
 
 	entryDate, _ := body["entry_date"].(string)
+	entryDate = strings.TrimSpace(entryDate)
 	if entryDate == "" {
 		entryDate = service.FormatDateInTz(time.Now(), userTz)
 	}
+	if !isValidDate(entryDate) {
+		ErrorJSON(w, http.StatusBadRequest, "Invalid date")
+		return
+	}
 	entryName := ""
 	if v, ok := body["entry_name"].(string); ok {
-		entryName = strings.TrimSpace(v)
-		if len(entryName) > 120 {
-			entryName = entryName[:120]
-		}
+		entryName = truncateUTF8(strings.TrimSpace(v), 120)
 	}
 
 	// Parse weight (frontend may send as string or number)
@@ -81,6 +83,10 @@ func (h *EntriesHandler) CreateEntry(w http.ResponseWriter, r *http.Request) {
 		c := macroValues["carbs"]
 		f := macroValues["fat"]
 		if computed := service.ComputeCaloriesFromMacros(p, c, f); computed != nil && *computed > 0 {
+			if !entryCaloriesInRange(*computed) {
+				ErrorJSON(w, http.StatusBadRequest, fmt.Sprintf("Calories computed from macros exceed the maximum of %d", MaxEntryCalories))
+				return
+			}
 			amountResult.Value = *computed
 			amountResult.Ok = true
 			hasCalorieEntry = true
@@ -172,10 +178,7 @@ func (h *EntriesHandler) UpdateEntry(w http.ResponseWriter, r *http.Request) {
 	idx := 1
 
 	if v, ok := body["name"]; ok {
-		name := strings.TrimSpace(fmt.Sprintf("%v", v))
-		if len(name) > 120 {
-			name = name[:120]
-		}
+		name := truncateUTF8(strings.TrimSpace(fmt.Sprintf("%v", v)), 120)
 		updates = append(updates, fmt.Sprintf("entry_name = $%d", idx))
 		values = append(values, nilString(name))
 		idx++
@@ -237,7 +240,17 @@ func (h *EntriesHandler) UpdateEntry(w http.ResponseWriter, r *http.Request) {
 	var createdAt time.Time
 	var proteinG, carbsG, fatG, fiberG, sugarG *int
 
-	err = h.Pool.QueryRow(r.Context(), query, values...).Scan(
+	// Run the field update and the auto-calc amount update in one
+	// transaction so a rejected computed amount can't leave the entry
+	// half-updated (name/macros committed, amount stale).
+	tx, err := h.Pool.Begin(r.Context())
+	if err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to update entry")
+		return
+	}
+	defer tx.Rollback(r.Context())
+
+	err = tx.QueryRow(r.Context(), query, values...).Scan(
 		&id, &entryDate, &amount, &entryName, &createdAt,
 		&proteinG, &carbsG, &fatG, &fiberG, &sugarG)
 	if err != nil {
@@ -249,12 +262,21 @@ func (h *EntriesHandler) UpdateEntry(w http.ResponseWriter, r *http.Request) {
 	if autoCalc {
 		p, c, f := intOrZero(proteinG), intOrZero(carbsG), intOrZero(fatG)
 		if computed := service.ComputeCaloriesFromMacros(p, c, f); computed != nil {
-			if _, err := h.Pool.Exec(r.Context(), "UPDATE calorie_entries SET amount = $1 WHERE id = $2 AND user_id = $3", *computed, entryID, user.ID); err != nil {
+			if !entryCaloriesInRange(*computed) {
+				ErrorJSON(w, http.StatusBadRequest, fmt.Sprintf("Calories computed from macros exceed the maximum of %d", MaxEntryCalories))
+				return
+			}
+			if _, err := tx.Exec(r.Context(), "UPDATE calorie_entries SET amount = $1 WHERE id = $2 AND user_id = $3", *computed, entryID, user.ID); err != nil {
 				ErrorJSON(w, http.StatusInternalServerError, "Failed to update entry")
 				return
 			}
 			amount = *computed
 		}
+	}
+
+	if err := tx.Commit(r.Context()); err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "Failed to update entry")
+		return
 	}
 
 	enabledMacros := service.GetEnabledMacros(mu)

--- a/internal/handler/entries_export.go
+++ b/internal/handler/entries_export.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,9 +11,29 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+
 	"schautrack/internal/middleware"
 	"schautrack/internal/service"
 )
+
+// execBatch sends a pgx batch on the transaction and returns the first error
+// encountered, draining the batch results before returning so the connection
+// is safe to use (e.g. for rollback) afterwards.
+func execBatch(ctx context.Context, tx pgx.Tx, batch *pgx.Batch) error {
+	br := tx.SendBatch(ctx, batch)
+	var firstErr error
+	for i := 0; i < batch.Len(); i++ {
+		if _, err := br.Exec(); err != nil {
+			firstErr = err
+			break
+		}
+	}
+	if err := br.Close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
 
 // Export handles POST /settings/export.
 // Returns the user's full data set as a JSON download. Authorization is via
@@ -92,6 +113,14 @@ func (h *EntriesHandler) Export(w http.ResponseWriter, r *http.Request) {
 		w.Write(wj)
 		first = false
 	}
+	if err := weights.Err(); err != nil {
+		// The response is already partially written, so we cannot send an
+		// error status. Abort without closing the JSON structure: a
+		// deliberately truncated, invalid file cannot be mistaken for a
+		// complete backup.
+		slog.Error("export aborted: weight row iteration failed", "error", err)
+		return
+	}
 	fmt.Fprint(w, "],\n")
 
 	// Entries
@@ -132,6 +161,12 @@ func (h *EntriesHandler) Export(w http.ResponseWriter, r *http.Request) {
 		ej, _ := json.Marshal(entry)
 		w.Write(ej)
 		first = false
+	}
+	if err := entries.Err(); err != nil {
+		// See the weights.Err() comment above: leave the JSON truncated so
+		// a partial export is detectably invalid.
+		slog.Error("export aborted: entry row iteration failed", "error", err)
+		return
 	}
 	fmt.Fprint(w, "]\n}")
 }
@@ -211,7 +246,7 @@ func (h *EntriesHandler) Import(w http.ResponseWriter, r *http.Request) {
 			} else if v, ok := entry["entry_date"].(string); ok {
 				dateStr = v
 			}
-			if !dateRe.MatchString(dateStr) {
+			if !isValidDate(dateStr) {
 				continue
 			}
 			amountResult := service.ParseAmount(fmt.Sprintf("%v", entry["amount"]), MaxEntryCalories)
@@ -220,16 +255,10 @@ func (h *EntriesHandler) Import(w http.ResponseWriter, r *http.Request) {
 			}
 			var name *string
 			if n, ok := entry["name"].(string); ok && n != "" {
-				s := n
-				if len(s) > 120 {
-					s = s[:120]
-				}
+				s := truncateUTF8(n, 120)
 				name = &s
 			} else if n, ok := entry["entry_name"].(string); ok && n != "" {
-				s := n
-				if len(s) > 120 {
-					s = s[:120]
-				}
+				s := truncateUTF8(n, 120)
 				name = &s
 			}
 			var createdAt *time.Time
@@ -273,7 +302,7 @@ func (h *EntriesHandler) Import(w http.ResponseWriter, r *http.Request) {
 			} else if v, ok := wEntry["entry_date"].(string); ok {
 				dateStr = v
 			}
-			if !dateRe.MatchString(dateStr) {
+			if !isValidDate(dateStr) {
 				continue
 			}
 			wr := service.ParseWeight(fmt.Sprintf("%v", wEntry["weight"]))
@@ -343,34 +372,53 @@ func (h *EntriesHandler) Import(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Insert entries
-	for _, entry := range toInsert {
-		cols := "user_id, entry_date, amount, entry_name"
-		vals := "$1, $2, $3, $4"
-		args := []any{user.ID, entry.date, entry.amount, entry.name}
-		idx := 5
-		if entry.createdAt != nil {
-			cols += ", created_at"
-			vals += fmt.Sprintf(", $%d", idx)
-			args = append(args, *entry.createdAt)
-			idx++
-		}
-		for _, key := range service.MacroKeys {
-			if v, ok := entry.macros[key]; ok {
-				cols += ", " + key + "_g"
+	// Insert entries. Up to 10,000 rows may be imported, so send the
+	// INSERTs as a pipelined pgx batch on the transaction instead of one
+	// round-trip per row. Per-row values and error semantics are unchanged:
+	// any failed statement aborts the import and rolls back the tx.
+	if len(toInsert) > 0 {
+		batch := &pgx.Batch{}
+		for _, entry := range toInsert {
+			cols := "user_id, entry_date, amount, entry_name"
+			vals := "$1, $2, $3, $4"
+			args := []any{user.ID, entry.date, entry.amount, entry.name}
+			idx := 5
+			if entry.createdAt != nil {
+				cols += ", created_at"
 				vals += fmt.Sprintf(", $%d", idx)
-				args = append(args, v)
+				args = append(args, *entry.createdAt)
 				idx++
 			}
+			for _, key := range service.MacroKeys {
+				if v, ok := entry.macros[key]; ok {
+					cols += ", " + key + "_g"
+					vals += fmt.Sprintf(", $%d", idx)
+					args = append(args, v)
+					idx++
+				}
+			}
+			batch.Queue(fmt.Sprintf("INSERT INTO calorie_entries (%s) VALUES (%s)", cols, vals), args...)
 		}
-		if _, err := tx.Exec(r.Context(), fmt.Sprintf("INSERT INTO calorie_entries (%s) VALUES (%s)", cols, vals), args...); err != nil {
+		if err := execBatch(r.Context(), tx, batch); err != nil {
 			ErrorJSON(w, http.StatusInternalServerError, "Import failed.")
 			return
 		}
 	}
 
-	for _, we := range weightToInsert {
-		if _, err := service.UpsertWeightEntry(r.Context(), tx, user.ID, we.date, we.weight); err != nil {
+	// Weight rows are batched the same way. This inlines the upsert
+	// statement from service.UpsertWeightEntry (minus the unused RETURNING
+	// clause) because a batch queues raw SQL.
+	if len(weightToInsert) > 0 {
+		batch := &pgx.Batch{}
+		for _, we := range weightToInsert {
+			batch.Queue(`
+				INSERT INTO weight_entries (user_id, entry_date, weight)
+				VALUES ($1, $2, $3)
+				ON CONFLICT (user_id, entry_date)
+					DO UPDATE SET weight = EXCLUDED.weight, updated_at = NOW()`,
+				user.ID, we.date, we.weight)
+		}
+		if err := execBatch(r.Context(), tx, batch); err != nil {
 			ErrorJSON(w, http.StatusInternalServerError, "Import failed.")
 			return
 		}

--- a/internal/handler/entries_helpers.go
+++ b/internal/handler/entries_helpers.go
@@ -65,12 +65,12 @@ func sanitizeDateRange(startStr, endStr string, fallbackDays int, userTz string)
 	return startDate, endDate
 }
 
-func getTotalsByDate(r *http.Request, pool *pgxpool.Pool, userID int, oldest, newest string) map[string]int {
+func getTotalsByDate(r *http.Request, pool *pgxpool.Pool, userID int, oldest, newest string) (map[string]int, error) {
 	rows, err := pool.Query(r.Context(),
 		"SELECT entry_date, SUM(amount) AS total FROM calorie_entries WHERE user_id = $1 AND entry_date BETWEEN $2 AND $3 GROUP BY entry_date",
 		userID, oldest, newest)
 	if err != nil {
-		return map[string]int{}
+		return nil, err
 	}
 	defer rows.Close()
 	result := map[string]int{}
@@ -82,7 +82,12 @@ func getTotalsByDate(r *http.Request, pool *pgxpool.Pool, userID int, oldest, ne
 		}
 		result[date] = total
 	}
-	return result
+	// A mid-iteration error would otherwise silently yield partial totals
+	// that callers present as complete data.
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 func buildDailyStats(dayOptions []string, totalsByDate map[string]int, dailyGoal *int, enabledMacros []string, macroGoals map[string]int, macroModes map[string]string, macroTotalsByDate map[string]map[string]int, threshold int) []dailyStat {

--- a/internal/handler/notes.go
+++ b/internal/handler/notes.go
@@ -76,17 +76,13 @@ func (h *NotesHandler) Save(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !dateRe.MatchString(body.Date) {
+	if !isValidDate(body.Date) {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid date")
 		return
 	}
 
 	user := middleware.GetCurrentUser(r)
-	content := strings.TrimSpace(body.Content)
-
-	if len(content) > 10000 {
-		content = content[:10000]
-	}
+	content := truncateUTF8(strings.TrimSpace(body.Content), 10000)
 
 	if content == "" {
 		// Delete the note

--- a/internal/handler/saved_foods.go
+++ b/internal/handler/saved_foods.go
@@ -106,10 +106,7 @@ func parseSavedFoodPayload(body map[string]any, forCreate bool) (*savedFoodInput
 
 	if v, ok := body["name"]; ok {
 		out.hasName = true
-		out.name = strings.TrimSpace(fmt.Sprintf("%v", v))
-		if len(out.name) > MaxSavedFoodName {
-			out.name = out.name[:MaxSavedFoodName]
-		}
+		out.name = truncateUTF8(strings.TrimSpace(fmt.Sprintf("%v", v)), MaxSavedFoodName)
 		if out.name == "" {
 			return nil, http.StatusBadRequest, "Name is required"
 		}
@@ -123,9 +120,7 @@ func parseSavedFoodPayload(body map[string]any, forCreate bool) (*savedFoodInput
 		if raw == "" || raw == "<nil>" {
 			out.emoji = nil
 		} else {
-			if len(raw) > MaxSavedFoodEmoji {
-				raw = raw[:MaxSavedFoodEmoji]
-			}
+			raw = truncateUTF8(raw, MaxSavedFoodEmoji)
 			out.emoji = &raw
 		}
 	}
@@ -362,7 +357,7 @@ func (h *SavedFoodsHandler) Track(w http.ResponseWriter, r *http.Request) {
 	if entryDate == "" {
 		entryDate = service.FormatDateInTz(time.Now(), userTz)
 	}
-	if !dateRe.MatchString(entryDate) {
+	if !isValidDate(entryDate) {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid date")
 		return
 	}
@@ -400,9 +395,7 @@ func (h *SavedFoodsHandler) Track(w http.ResponseWriter, r *http.Request) {
 	if emoji != nil && *emoji != "" {
 		entryName = *emoji + " " + name
 	}
-	if len(entryName) > 120 {
-		entryName = entryName[:120]
-	}
+	entryName = truncateUTF8(entryName, 120)
 
 	entryAmount := 0
 	if amount != nil {
@@ -413,18 +406,18 @@ func (h *SavedFoodsHandler) Track(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mulPtr := func(p *int) *int {
-		if p == nil {
-			return nil
-		}
-		v := *p * qty
-		return &v
+	// Multiplied macros must respect the macro column CHECK (0..999) just
+	// like the multiplied calorie amount above, or the INSERT fails with a
+	// constraint violation (a 500 for the user).
+	mProtein, okP := multiplyMacro(protein, qty)
+	mCarbs, okC := multiplyMacro(carbs, qty)
+	mFat, okF := multiplyMacro(fat, qty)
+	mFiber, okFi := multiplyMacro(fiber, qty)
+	mSugar, okS := multiplyMacro(sugar, qty)
+	if !okP || !okC || !okF || !okFi || !okS {
+		ErrorJSON(w, http.StatusBadRequest, "Quantity too high for this entry")
+		return
 	}
-	mProtein := mulPtr(protein)
-	mCarbs := mulPtr(carbs)
-	mFat := mulPtr(fat)
-	mFiber := mulPtr(fiber)
-	mSugar := mulPtr(sugar)
 
 	var entryID int
 	var createdAt time.Time
@@ -502,10 +495,7 @@ func (h *SavedFoodsHandler) SaveFromEntry(w http.ResponseWriter, r *http.Request
 	}
 	ReadJSON(r, &body)
 
-	cleanName := strings.TrimSpace(*name)
-	if len(cleanName) > MaxSavedFoodName {
-		cleanName = cleanName[:MaxSavedFoodName]
-	}
+	cleanName := truncateUTF8(strings.TrimSpace(*name), MaxSavedFoodName)
 
 	var count int
 	h.Pool.QueryRow(r.Context(), "SELECT COUNT(*)::int FROM saved_foods WHERE user_id = $1", user.ID).Scan(&count)

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -232,7 +232,7 @@ func (h *SettingsHandler) AISettings(w http.ResponseWriter, r *http.Request) {
 	// Model
 	model := strings.TrimSpace(body.AIModel)
 	if len(model) > 100 {
-		model = model[:100]
+		model = truncateUTF8(model, 100)
 	}
 	updates = append(updates, fmt.Sprintf("ai_model = $%d", idx))
 	if model == "" {
@@ -715,7 +715,7 @@ func (h *LinksHandler) LinkLabel(w http.ResponseWriter, r *http.Request) {
 
 	label := strings.TrimSpace(body.Label)
 	if len(label) > 120 {
-		label = label[:120]
+		label = truncateUTF8(label, 120)
 	}
 	var labelPtr *string
 	if label != "" {

--- a/internal/handler/todos.go
+++ b/internal/handler/todos.go
@@ -73,10 +73,7 @@ func (h *TodosHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	name := strings.TrimSpace(fmt.Sprintf("%v", body["name"]))
-	if len(name) > 100 {
-		name = name[:100]
-	}
+	name := truncateUTF8(strings.TrimSpace(fmt.Sprintf("%v", body["name"])), 100)
 	if name == "" {
 		ErrorJSON(w, http.StatusBadRequest, "Name is required")
 		return
@@ -142,10 +139,7 @@ func (h *TodosHandler) Update(w http.ResponseWriter, r *http.Request) {
 	idx := 1
 
 	if v, ok := body["name"]; ok {
-		name := strings.TrimSpace(fmt.Sprintf("%v", v))
-		if len(name) > 100 {
-			name = name[:100]
-		}
+		name := truncateUTF8(strings.TrimSpace(fmt.Sprintf("%v", v)), 100)
 		if name == "" {
 			ErrorJSON(w, http.StatusBadRequest, "Name is required")
 			return
@@ -407,7 +401,7 @@ func (h *TodosHandler) Toggle(w http.ResponseWriter, r *http.Request) {
 		tz := getUserTimezone(r, user)
 		dateStr = service.FormatDateInTz(time.Now(), tz)
 	}
-	if !dateRe.MatchString(dateStr) {
+	if !isValidDate(dateStr) {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid date")
 		return
 	}

--- a/internal/handler/validate.go
+++ b/internal/handler/validate.go
@@ -1,0 +1,73 @@
+package handler
+
+import (
+	"time"
+	"unicode/utf8"
+)
+
+// Sane calendar-year bounds for user-supplied dates. Anything outside is a
+// typo or garbage input, not a plausible entry date.
+const (
+	minDateYear = 1900
+	maxDateYear = 2200
+)
+
+// truncateUTF8 caps s at maxBytes bytes without splitting a multi-byte UTF-8
+// rune. Byte-index slicing (s[:n]) can cut an emoji or other multi-byte rune
+// in half, producing invalid UTF-8 that Postgres rejects with
+// "invalid byte sequence for encoding UTF8" (error 22021). If the cap lands
+// mid-rune, the cut point walks back to the previous rune boundary, so the
+// result is always valid UTF-8 and a prefix of s.
+func truncateUTF8(s string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(s) <= maxBytes {
+		return s
+	}
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut]
+}
+
+// isValidDate reports whether s is a real calendar date in strict
+// YYYY-MM-DD form within a sane year range. Unlike dateRe (a shape-only
+// regex), the time.Parse round-trip rejects impossible dates such as
+// 2026-02-31, which Postgres would reject with a query error (a 500 for the
+// caller). The Format round-trip additionally rejects non-padded forms like
+// 2026-7-3 that time.Parse tolerates.
+func isValidDate(s string) bool {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return false
+	}
+	if t.Format("2006-01-02") != s {
+		return false
+	}
+	y := t.Year()
+	return y >= minDateYear && y <= maxDateYear
+}
+
+// entryCaloriesInRange reports whether amount satisfies the calorie_entries
+// amount CHECK constraint (-MaxEntryCalories..MaxEntryCalories). Used to
+// validate auto-computed calories, which can reach 16983 (999g protein +
+// 999g carbs + 999g fat) — far beyond what the column accepts.
+func entryCaloriesInRange(amount int) bool {
+	return amount >= -MaxEntryCalories && amount <= MaxEntryCalories
+}
+
+// multiplyMacro multiplies an optional macro gram value by qty. ok is false
+// when the result would violate the macro column CHECK constraint
+// (0..MaxEntryMacro); a nil input passes through unchanged.
+func multiplyMacro(v *int, qty int) (*int, bool) {
+	if v == nil {
+		return nil, true
+	}
+	m := *v * qty
+	if m < 0 || m > MaxEntryMacro {
+		return nil, false
+	}
+	return &m, true
+}

--- a/internal/handler/validate_test.go
+++ b/internal/handler/validate_test.go
@@ -1,0 +1,153 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateUTF8(t *testing.T) {
+	// Byte layout reference:
+	//   "🍕" is 4 bytes, "é" is 2 bytes, "€" is 3 bytes.
+	//   The family ZWJ sequence "👨‍👩‍👧‍👦" is
+	//   👨(4) ZWJ(3) 👩(4) ZWJ(3) 👧(4) ZWJ(3) 👦(4) = 25 bytes.
+	tests := []struct {
+		name     string
+		in       string
+		maxBytes int
+		want     string
+	}{
+		{"empty string", "", 10, ""},
+		{"ascii under cap", "hello", 10, "hello"},
+		{"ascii exactly at cap", "hello", 5, "hello"},
+		{"ascii over cap", "hello world", 5, "hello"},
+		{"zero cap", "hello", 0, ""},
+		{"negative cap", "hello", -1, ""},
+		{"emoji fits exactly at cap", "🍕🍕", 8, "🍕🍕"},
+		{"emoji would be split at cap", "🍕🍕", 7, "🍕"},
+		{"cap lands mid-rune after ascii", "ab🍕", 4, "ab"},
+		{"two-byte rune split", "aé", 2, "a"},
+		{"three-byte rune kept", "€", 3, "€"},
+		{"three-byte rune split", "€", 2, ""},
+		{"zwj sequence cut on rune boundary", "👨‍👩‍👧‍👦", 16, "👨‍👩‍"},
+		{"zwj sequence fits", "👨‍👩‍👧‍👦", 25, "👨‍👩‍👧‍👦"},
+		{"sixteen byte emoji cap", strings.Repeat("🍕", 5), MaxSavedFoodEmoji, strings.Repeat("🍕", 4)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateUTF8(tt.in, tt.maxBytes)
+			if got != tt.want {
+				t.Errorf("truncateUTF8(%q, %d) = %q, want %q", tt.in, tt.maxBytes, got, tt.want)
+			}
+			// Invariants that must hold for every input: never longer than
+			// the cap, always valid UTF-8 (Postgres rejects invalid byte
+			// sequences), and always a prefix of the original string.
+			if tt.maxBytes >= 0 && len(got) > tt.maxBytes {
+				t.Errorf("result %q is %d bytes, exceeds cap %d", got, len(got), tt.maxBytes)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("result %q is not valid UTF-8", got)
+			}
+			if !strings.HasPrefix(tt.in, got) {
+				t.Errorf("result %q is not a prefix of input %q", got, tt.in)
+			}
+		})
+	}
+}
+
+func TestIsValidDate(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"valid date", "2026-07-03", true},
+		{"valid leap day", "2024-02-29", true},
+		{"lower bound", "1900-01-01", true},
+		{"upper bound", "2200-12-31", true},
+		{"empty", "", false},
+		{"malformed text", "not-a-date", false},
+		{"slashes instead of dashes", "2026/07/03", false},
+		{"non-padded month and day", "2026-7-3", false},
+		{"missing dashes", "20260703", false},
+		{"impossible feb 31 (passes dateRe)", "2026-02-31", false},
+		{"impossible feb 30", "2026-02-30", false},
+		{"feb 29 in non-leap year", "2023-02-29", false},
+		{"month 13", "2026-13-01", false},
+		{"month 00", "2026-00-10", false},
+		{"day 32", "2026-01-32", false},
+		{"day 00", "2026-01-00", false},
+		{"before sane range", "1899-12-31", false},
+		{"after sane range", "2201-01-01", false},
+		{"trailing garbage", "2026-07-03x", false},
+		{"datetime instead of date", "2026-07-03T00:00:00Z", false},
+		{"surrounding whitespace", " 2026-07-03 ", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidDate(tt.in); got != tt.want {
+				t.Errorf("isValidDate(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEntryCaloriesInRange(t *testing.T) {
+	tests := []struct {
+		name   string
+		amount int
+		want   bool
+	}{
+		{"zero", 0, true},
+		{"typical entry", 650, true},
+		{"exactly max", MaxEntryCalories, true},
+		{"exactly min", -MaxEntryCalories, true},
+		{"just over max", MaxEntryCalories + 1, false},
+		{"just under min", -MaxEntryCalories - 1, false},
+		// 999g protein + 999g carbs + 999g fat = 999*4 + 999*4 + 999*9,
+		// the largest value ComputeCaloriesFromMacros can produce.
+		{"max computed from macros", 16983, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := entryCaloriesInRange(tt.amount); got != tt.want {
+				t.Errorf("entryCaloriesInRange(%d) = %v, want %v", tt.amount, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMultiplyMacro(t *testing.T) {
+	iptr := func(v int) *int { return &v }
+	tests := []struct {
+		name   string
+		v      *int
+		qty    int
+		want   *int
+		wantOk bool
+	}{
+		{"nil macro passes through", nil, 25, nil, true},
+		{"small multiply ok", iptr(40), 24, iptr(960), true},
+		{"result exactly at cap", iptr(111), 9, iptr(999), true},
+		{"result over cap", iptr(40), 25, nil, false},
+		{"max value qty 1", iptr(MaxEntryMacro), 1, iptr(MaxEntryMacro), true},
+		{"max value qty 2", iptr(MaxEntryMacro), 2, nil, false},
+		{"zero times max qty", iptr(0), 99, iptr(0), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := multiplyMacro(tt.v, tt.qty)
+			if ok != tt.wantOk {
+				t.Fatalf("multiplyMacro ok = %v, want %v", ok, tt.wantOk)
+			}
+			switch {
+			case got == nil && tt.want != nil:
+				t.Errorf("multiplyMacro = nil, want %d", *tt.want)
+			case got != nil && tt.want == nil:
+				t.Errorf("multiplyMacro = %d, want nil", *got)
+			case got != nil && tt.want != nil && *got != *tt.want:
+				t.Errorf("multiplyMacro = %d, want %d", *got, *tt.want)
+			}
+		})
+	}
+}

--- a/internal/service/macros.go
+++ b/internal/service/macros.go
@@ -197,6 +197,10 @@ func GetMacroTotalsByDate(ctx context.Context, pool *pgxpool.Pool, userID int, o
 			"protein": protein, "carbs": carbs, "fat": fat, "fiber": fiber, "sugar": sugar,
 		}
 	}
+	// Propagate mid-iteration errors instead of returning partial totals.
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
Implements six verified findings from the code audit covering entry/input validation, export integrity, and import performance.

## Findings fixed

- Addresses MEDIUM item "Auto-calculated calories are not clamped to MaxEntryCalories, causing DB CHECK violations and 500s" from #141 — `ComputeCaloriesFromMacros` can return up to 16983, violating the `calorie_entries` amount CHECK (±9999). CreateEntry and UpdateEntry now reject computed calories outside the range with a 400 ("Calories computed from macros exceed the maximum of 9999"). UpdateEntry additionally runs its field update and the auto-calc amount update in a **single transaction**, so a rejected/failed amount update can no longer leave name/macros committed with a stale amount (verified end-to-end: rejected update leaves the entry fully unchanged).

- Addresses MEDIUM item "Saved-food Track multiplies macros by quantity without the 999 cap — CHECK violation → 500" from #141 — Track now validates each quantity-multiplied macro against MaxEntryMacro (999) via a shared `multiplyMacro` helper and returns the same 400 "Quantity too high for this entry" used for calories (verified: 40g protein × 25 → 400; × 24 → 200).

- Addresses MEDIUM item "Byte-index string truncation can split UTF-8 runes → Postgres 'invalid byte sequence' (500)" from #141 — new rune-boundary-safe `truncateUTF8` helper in `internal/handler/validate.go`, used at every cap site listed in the audit: saved-food emoji `[:16]` and name `[:80]` (also Track's entry name and SaveFromEntry's name), entry name `[:120]` in CreateEntry/UpdateEntry and both Import name sites, todo name `[:100]` (Create and Update), note content `[:10000]`, link label `[:120]`, and AI model `[:100]` in settings.go (verified: a name with an emoji straddling the 120-byte cap and a 20-byte emoji against the 16-byte cap both succeed, emoji truncated to whole runes).

- Addresses MEDIUM item "CreateEntry accepts entry_date without validation — malformed dates 500 instead of 400" from #141 — new shared `isValidDate` validator (strict `time.Parse("2006-01-02")` round-trip plus a 1900–2200 year guard) rejects impossible dates like `2026-02-31` that the shape-only `dateRe` accepts. Used in CreateEntry (400 "Invalid date"), and the `dateRe` checks in todos.go `Toggle` and saved_foods.go `Track` are switched to it as the audit requested. Also applied to notes.go `Save` and both Import date checks — same bug class on the same write paths within this change's file set (Import keeps its skip-row semantics, so an impossible date in an import file is skipped instead of failing the whole import with a 500). weight.go untouched.

- Addresses MEDIUM item "Export never checks rows.Err() — a mid-stream DB error yields a silently truncated backup" from #141 — Export now checks `weights.Err()` / `entries.Err()` after each loop; on error it logs and aborts **without** closing the JSON structure, so the partial file is deliberately invalid and cannot be mistaken for a complete backup. The same rows.Err() gap is fixed in `getTotalsByDate` (entries_helpers.go) — which now returns an error that the Dashboard/Overview handlers turn into a 500 instead of rendering all-zero days, and the linked-user goroutine skips that link's card — and in `GetMacroTotalsByDate`, which lives in `internal/service/macros.go` (the audit placed it in entries_helpers.go) and now propagates `rows.Err()` through its existing error return.

- Addresses LOW item "Data import executes up to 10,000 single-row INSERT round-trips inside one transaction" from #142 — Import's entry INSERTs are now queued in a `pgx.Batch` sent on the same transaction, keeping identical per-row values and error → rollback semantics while eliminating per-row round-trips. Weight rows are batched via the same mechanism, inlining the upsert statement from `service.UpsertWeightEntry` minus its unused RETURNING clause (batches queue raw SQL); sequential in-order execution preserves last-wins semantics for duplicate dates.

## Tests

Table-driven unit tests in `internal/handler/validate_test.go` for rune-safe truncation (ASCII, emoji at boundary, ZWJ sequence, exact-cap, empty, invariants: cap respected / valid UTF-8 / prefix), the date validator (valid, malformed, impossible, out-of-range, boundaries), the calorie range decision, and macro multiplication. `go test ./...` and `go vet ./...` are green with no database.

Additionally verified end-to-end against a real Postgres 18 + the running server (20/20 checks passed): date rejection paths, emoji truncation, Track quantity caps, auto-calc rejection with transactional rollback, batched import of 199 entries + 5 weights with correct skip counts, and export producing valid complete JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
