### PR TITLE
fix(client): frontend quality fixes from code audit (13 findings, #144)

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -37,11 +37,12 @@ export async function api<T = unknown>(
 
   const res = await fetch(url, { ...options, headers, credentials: 'same-origin', cache: 'no-store' });
 
-  // 403 means either CSRF failure or step-up required. Inspect the body to
-  // decide. clone() so we can still consume the body in the CSRF retry path.
+  // 403 means either CSRF failure, step-up required, or a plain
+  // authorization failure. Inspect the body to decide. clone() so we can
+  // still consume the body in the CSRF retry path.
   if (res.status === 403) {
     const body = await res.clone().json().catch(() => null) as
-      | { requireStepUp?: boolean; methods?: string[]; totpRequired?: boolean }
+      | { requireStepUp?: boolean; methods?: string[]; totpRequired?: boolean; error?: string }
       | null;
 
     if (body?.requireStepUp) {
@@ -65,16 +66,23 @@ export async function api<T = unknown>(
       });
     }
 
+    // Only mutating requests carry a CSRF token, so only they can hit a
+    // stale-token 403. A 403 on GET/HEAD is a real authorization failure.
+    const method = (options.method || 'GET').toUpperCase();
+    if (method === 'GET' || method === 'HEAD') {
+      throw new ApiError(403, body?.error || 'Forbidden', (body ?? {}) as Record<string, unknown>);
+    }
+
     // CSRF failure — refresh token and retry once.
     csrfToken = null;
     const freshToken = await fetchCsrfToken();
     headers.set('X-CSRF-Token', freshToken);
-    const retry = await fetch(url, { ...options, headers, credentials: 'same-origin' });
+    const retry = await fetch(url, { ...options, headers, credentials: 'same-origin', cache: 'no-store' });
     if (!retry.ok) {
       const err = await retry.json().catch(() => ({ error: 'Request failed' }));
       throw new ApiError(retry.status, err.error || 'Request failed', err);
     }
-    return retry.json();
+    return parseBody<T>(retry);
   }
 
   if (res.status === 401) {
@@ -99,12 +107,16 @@ export async function api<T = unknown>(
     throw new ApiError(res.status, err.error || 'Request failed', err);
   }
 
-  // Handle empty responses
+  return parseBody<T>(res);
+}
+
+// Tolerant body handling: empty / non-JSON responses resolve to {} instead
+// of throwing a SyntaxError from res.json().
+function parseBody<T>(res: Response): Promise<T> {
   const contentType = res.headers.get('content-type');
   if (!contentType || !contentType.includes('application/json')) {
-    return {} as T;
+    return Promise.resolve({} as T);
   }
-
   return res.json();
 }
 

--- a/client/src/hooks/useAutosave.ts
+++ b/client/src/hooks/useAutosave.ts
@@ -16,12 +16,18 @@ export function useAutosave<T>(
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const initialRef = useRef(true);
   const savingRef = useRef(false);
+  const pendingRef = useRef(false);
   const latestDataRef = useRef(data);
   latestDataRef.current = data;
   const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
 
   const save = useCallback(async () => {
-    if (savingRef.current) return;
+    if (savingRef.current) {
+      // A save is in flight — remember that newer data arrived and save
+      // again once it completes, instead of silently dropping the change.
+      pendingRef.current = true;
+      return;
+    }
     savingRef.current = true;
     setStatus('saving');
     try {
@@ -34,6 +40,10 @@ export function useAutosave<T>(
       addToast('error', err instanceof Error ? err.message : 'Failed to save');
     }
     savingRef.current = false;
+    if (pendingRef.current) {
+      pendingRef.current = false;
+      saveRef.current();
+    }
   }, [saveFn, addToast]);
 
   const saveRef = useRef(save);

--- a/client/src/hooks/useSSE.ts
+++ b/client/src/hooks/useSSE.ts
@@ -13,20 +13,28 @@ export function useSSE() {
   useEffect(() => {
     if (!window.EventSource) return;
 
+    // Set on cleanup so an in-flight reconnect timer can't spawn a new
+    // EventSource after unmount (e.g. after logout, when the endpoint
+    // would 401 forever).
+    let disposed = false;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
     const connect = () => {
-      if (sourceRef.current) return;
+      if (disposed || sourceRef.current) return;
       const source = new EventSource('/events/entries');
       sourceRef.current = source;
 
       source.addEventListener('entry-change', () => {
         queryClient.invalidateQueries({ queryKey: ['dashboard'] });
         queryClient.invalidateQueries({ queryKey: ['day-entries'] });
-        queryClient.invalidateQueries({ queryKey: ['overview'] });
+        // The server broadcasts entry-change for weight upserts too.
+        queryClient.invalidateQueries({ queryKey: ['weight'] });
       });
 
       source.addEventListener('settings-change', () => {
         queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-        queryClient.invalidateQueries({ queryKey: ['me'] });
+        // The current user lives in the auth store, not a query.
+        fetchUser();
       });
 
       source.addEventListener('link-change', (e) => {
@@ -66,17 +74,20 @@ export function useSSE() {
       source.onerror = () => {
         source.close();
         sourceRef.current = null;
+        if (disposed) return;
         const delay = retryDelayRef.current;
         retryDelayRef.current = Math.min(delay * 2, 30000);
-        setTimeout(connect, delay);
+        reconnectTimer = setTimeout(connect, delay);
       };
     };
 
     connect();
 
     return () => {
+      disposed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
       sourceRef.current?.close();
       sourceRef.current = null;
     };
-  }, [queryClient]);
+  }, [queryClient, fetchUser]);
 }

--- a/client/src/pages/Admin/Admin.tsx
+++ b/client/src/pages/Admin/Admin.tsx
@@ -19,8 +19,12 @@ export default function Admin() {
 
   const handleDeleteUser = async (userId: number) => {
     if (!confirm('Delete this user?')) return;
-    await deleteUser(userId);
-    queryClient.invalidateQueries({ queryKey: ['admin'] });
+    try {
+      await deleteUser(userId);
+      queryClient.invalidateQueries({ queryKey: ['admin'] });
+    } catch (err) {
+      useToastStore.getState().addToast('error', err instanceof Error ? err.message : 'Failed to delete user');
+    }
   };
 
   return (
@@ -100,7 +104,7 @@ function UserList({ users, onDelete }: { users: Array<{ id: number; email: strin
       </div>
       {hasMore && (
         <div ref={sentinelRef} className="py-3 text-center text-xs text-muted-foreground">
-          Loading more\u2026
+          Loading more&hellip;
         </div>
       )}
     </Card>
@@ -377,8 +381,12 @@ function InviteManager() {
   };
 
   const handleDelete = async (id: number) => {
-    await deleteInvite(id);
-    queryClient.invalidateQueries({ queryKey: ['invites'] });
+    try {
+      await deleteInvite(id);
+      queryClient.invalidateQueries({ queryKey: ['invites'] });
+    } catch (err) {
+      useToastStore.getState().addToast('error', err instanceof Error ? err.message : 'Failed to delete invite');
+    }
   };
 
   const handleCopy = async (invite: InviteCode) => {

--- a/client/src/pages/Dashboard/AIPhotoModal.tsx
+++ b/client/src/pages/Dashboard/AIPhotoModal.tsx
@@ -78,7 +78,13 @@ export default function AIPhotoModal({ isOpen, onClose, onResult, enabledMacros:
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [cameraReady, setCameraReady] = useState(false);
 
+  // Incremented on every stopCamera so an in-flight getUserMedia (e.g. the
+  // permission prompt is open while the modal closes) knows it went stale
+  // and must release the acquired tracks instead of orphaning a live stream.
+  const cameraSessionRef = useRef(0);
+
   const stopCamera = useCallback(() => {
+    cameraSessionRef.current++;
     if (streamRef.current) {
       streamRef.current.getTracks().forEach((t) => t.stop());
       streamRef.current = null;
@@ -87,15 +93,23 @@ export default function AIPhotoModal({ isOpen, onClose, onResult, enabledMacros:
 
   const startCamera = useCallback(async () => {
     stopCamera();
+    const session = cameraSessionRef.current;
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
         video: { facingMode: 'environment', width: { ideal: 1024 }, height: { ideal: 768 } },
       });
+      if (session !== cameraSessionRef.current) {
+        // Camera was stopped (modal closed / mode switched) while we were
+        // waiting — turn the stream off again immediately.
+        stream.getTracks().forEach((t) => t.stop());
+        return;
+      }
       streamRef.current = stream;
       if (videoRef.current) {
         videoRef.current.srcObject = stream;
       }
     } catch {
+      if (session !== cameraSessionRef.current) return;
       setErrorMsg('Could not access camera. Try uploading instead.');
       setMode('upload');
     }

--- a/client/src/pages/Dashboard/BarcodeScanModal.tsx
+++ b/client/src/pages/Dashboard/BarcodeScanModal.tsx
@@ -42,9 +42,17 @@ export default function BarcodeScanModal({ isOpen, onClose, onResult, enabledMac
   // consecutive identical reads before triggering a lookup.
   const lastCodeRef = useRef<{ code: string; count: number }>({ code: '', count: 0 });
 
+  // Incremented on every stopScanner so an in-flight Quagga.init (camera
+  // permission prompt open while the modal closes) knows it went stale and
+  // must shut the camera down instead of starting the scanner.
+  const scanSessionRef = useRef(0);
+
   const stopScanner = useCallback(() => {
+    scanSessionRef.current++;
+    // Always detach the detection handler — it is registered before init
+    // finishes, so it can exist while quaggaRunning is still false.
+    Quagga.offDetected();
     if (quaggaRunning.current) {
-      Quagga.offDetected();
       Quagga.stop();
       quaggaRunning.current = false;
     }
@@ -87,6 +95,7 @@ export default function BarcodeScanModal({ isOpen, onClose, onResult, enabledMac
 
   const startScanner = useCallback(() => {
     if (!scannerRef.current || quaggaRunning.current) return;
+    const session = scanSessionRef.current;
 
     Quagga.init(
       {
@@ -105,6 +114,12 @@ export default function BarcodeScanModal({ isOpen, onClose, onResult, enabledMac
         locate: true,
       },
       (err: Error | null) => {
+        if (session !== scanSessionRef.current) {
+          // Scanner was stopped (modal closed / mode switched) while init
+          // was acquiring the camera — release it instead of starting.
+          if (!err) Quagga.stop();
+          return;
+        }
         if (err) {
           setCameraAvailable(false);
           return;

--- a/client/src/pages/Dashboard/NoteEditor.tsx
+++ b/client/src/pages/Dashboard/NoteEditor.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { getNote, saveNote } from '@/api/notes';
 import { useToastStore } from '@/stores/toastStore';
 
@@ -10,13 +10,17 @@ interface Props {
 }
 
 export default function NoteEditor({ date, userId, canEdit }: Props) {
-  const queryClient = useQueryClient();
   const [value, setValue] = useState('');
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSavedRef = useRef('');
+  // Track editing state so a refetch (SSE note-change, window refocus, …)
+  // can't clobber keystrokes typed during the save/refetch window.
+  const dirtyRef = useRef(false);
+  const focusedRef = useRef(false);
+  const valueRef = useRef('');
 
   const { data } = useQuery({
     queryKey: ['note', userId, date],
@@ -25,8 +29,19 @@ export default function NoteEditor({ date, userId, canEdit }: Props) {
   });
 
   useEffect(() => {
-    if (data) {
+    // Switching day/user is a hard context switch — discard local edit
+    // state so the incoming note content always syncs. Any pending edit
+    // was already flushed by the blur that preceded the switch.
+    dirtyRef.current = false;
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, [date, userId]);
+
+  useEffect(() => {
+    // Only sync server content into local state while the user isn't
+    // editing; otherwise in-progress typing would be silently replaced.
+    if (data && !dirtyRef.current && !focusedRef.current) {
       setValue(data.content || '');
+      valueRef.current = data.content || '';
       lastSavedRef.current = data.content || '';
     }
   }, [data]);
@@ -38,7 +53,8 @@ export default function NoteEditor({ date, userId, canEdit }: Props) {
     try {
       await saveNote(date, content);
       lastSavedRef.current = content;
-      queryClient.invalidateQueries({ queryKey: ['note'] });
+      // Only mark clean if nothing was typed while the save was in flight.
+      if (valueRef.current === content) dirtyRef.current = false;
       setSaved(true);
       if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
       savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
@@ -46,16 +62,23 @@ export default function NoteEditor({ date, userId, canEdit }: Props) {
       useToastStore.getState().addToast('error', err instanceof Error ? err.message : 'Failed to save note');
     }
     setSaving(false);
-  }, [date, queryClient]);
+  }, [date]);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;
     setValue(newValue);
+    valueRef.current = newValue;
+    dirtyRef.current = true;
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => doSave(newValue), 1000);
   };
 
+  const handleFocus = () => {
+    focusedRef.current = true;
+  };
+
   const handleBlur = () => {
+    focusedRef.current = false;
     if (timerRef.current) clearTimeout(timerRef.current);
     doSave(value);
   };
@@ -76,6 +99,7 @@ export default function NoteEditor({ date, userId, canEdit }: Props) {
         <textarea
           value={value}
           onChange={handleChange}
+          onFocus={handleFocus}
           onBlur={handleBlur}
           disabled={!canEdit}
           maxLength={10000}

--- a/client/src/pages/Dashboard/SavedFoodsModal.tsx
+++ b/client/src/pages/Dashboard/SavedFoodsModal.tsx
@@ -7,7 +7,7 @@ import { useToastStore } from '@/stores/toastStore';
 import { useAuthStore } from '@/stores/authStore';
 import { Button } from '@/components/ui/Button';
 import { MacroPill, MacroPillEditing } from '@/components/ui/MacroPill';
-import { MACRO_LABELS } from '@/lib/macros';
+import { MACRO_LABELS, getEnabledMacros } from '@/lib/macros';
 import { cn } from '@/lib/utils';
 import type { SavedFood } from '@/types';
 
@@ -24,9 +24,7 @@ export default function SavedFoodsModal({ isOpen, onClose, selectedDate }: Props
   const addToast = useToastStore((s) => s.addToast);
   const user = useAuthStore((s) => s.user);
   const enabledMacros = useMemo(
-    () => Object.entries(user?.macrosEnabled ?? {})
-      .filter(([k, v]) => v === true && k !== 'auto_calc_calories' && k !== 'calories')
-      .map(([k]) => k),
+    () => getEnabledMacros(user?.macrosEnabled ?? {}) as string[],
     [user]
   );
   const caloriesEnabled = user?.macrosEnabled?.calories !== false;

--- a/client/src/pages/Dashboard/WeightRow.tsx
+++ b/client/src/pages/Dashboard/WeightRow.tsx
@@ -58,8 +58,12 @@ export default function WeightRow({ weightEntry, lastWeightEntry, weightUnit, ca
 
   const handleBlur = () => {
     const raw = inputRef.current?.value.trim() || '';
+    // Only save if the user actually changed the rendered value. Without
+    // this, focus+blur on a date with no entry would silently write the
+    // pre-filled previous weight to that date.
+    if (raw === displayValue) return;
     const num = parseFloat(raw);
-    if (num && num > 0 && (num !== entry?.weight || !isToday)) {
+    if (num && num > 0) {
       handleSave();
     }
   };

--- a/client/src/pages/Settings/AISettings.tsx
+++ b/client/src/pages/Settings/AISettings.tsx
@@ -21,16 +21,36 @@ export default function AISettings({ user, onSave }: Props) {
   const [loading, setLoading] = useState(false);
   const addToast = useToastStore((s) => s.addToast);
 
-  // Auto-save everything including API key (on blur via useAutosave)
-  const autoData = useMemo(() => ({ provider, model, apiKey }), [provider, model, apiKey]);
+  // Auto-save provider/model only. The API key is deliberately excluded:
+  // debounced saves while typing would store partial keys on the server.
+  const autoData = useMemo(() => ({ provider, model }), [provider, model]);
 
   const autoSaveFn = useCallback(async (d: typeof autoData) => {
-    await saveAiSettings({ ai_provider: d.provider, ai_key: d.apiKey, ai_model: d.model });
-    if (d.apiKey) setApiKey('');
+    await saveAiSettings({ ai_provider: d.provider, ai_model: d.model });
     onSave();
   }, [onSave]);
 
   const { status } = useAutosave(autoData, autoSaveFn, { delay: 1200 });
+
+  // The key is submitted explicitly on blur of its input, and the field is
+  // only cleared after that save succeeds.
+  const [keySaving, setKeySaving] = useState(false);
+  const handleKeyBlur = async () => {
+    const key = apiKey.trim();
+    if (!key) return;
+    setKeySaving(true);
+    try {
+      // The server overwrites provider/model on every save, so send the
+      // current values alongside the key.
+      await saveAiSettings({ ai_provider: provider, ai_key: key, ai_model: model });
+      setApiKey('');
+      onSave();
+      addToast('success', 'API key saved');
+    } catch (err) {
+      addToast('error', err instanceof Error ? err.message : 'Failed to save API key');
+    }
+    setKeySaving(false);
+  };
 
   const handleClear = async () => {
     setLoading(true);
@@ -60,6 +80,7 @@ export default function AISettings({ user, onSave }: Props) {
         </div>
         <Input label="Model (optional)" value={model} onChange={(e) => setModel(e.target.value)} placeholder="e.g. gpt-4o" />
         <Input label="API Key" type="password" value={apiKey} onChange={(e) => setApiKey(e.target.value)}
+          onBlur={handleKeyBlur} disabled={keySaving}
           placeholder={user.hasAiKey ? `\u2022\u2022\u2022\u2022${user.aiKeyLast4}` : 'Enter API key'} />
         {!user.hasAiKey && user.hasGlobalAiKey && (
           <p className="text-xs text-muted-foreground">A global API key is configured. AI features work without setting your own key.</p>

--- a/client/src/pages/Settings/LinkSettings.tsx
+++ b/client/src/pages/Settings/LinkSettings.tsx
@@ -83,7 +83,7 @@ export default function LinkSettings({ incomingRequests, outgoingRequests, accep
         <div className="mb-4">
           <h4 className="text-xs uppercase tracking-wider text-muted-foreground mb-2">Linked</h4>
           {acceptedLinks.map((link) => (
-            <LinkRow key={link.linkId} link={link} onRemove={() => handleRemove(link.linkId)} />
+            <LinkRow key={link.linkId} link={link} onRemove={() => handleRemove(link.linkId)} onUpdate={onUpdate} />
           ))}
         </div>
       )}
@@ -100,7 +100,7 @@ export default function LinkSettings({ incomingRequests, outgoingRequests, accep
   );
 }
 
-function LinkRow({ link, onRemove }: { link: AcceptedLink; onRemove: () => void }) {
+function LinkRow({ link, onRemove, onUpdate }: { link: AcceptedLink; onRemove: () => void; onUpdate: () => void }) {
   const [editing, setEditing] = useState(false);
   const [label, setLabel] = useState(link.label || '');
 
@@ -109,6 +109,9 @@ function LinkRow({ link, onRemove }: { link: AcceptedLink; onRemove: () => void 
   const saveLabel = async () => {
     try {
       await updateLinkLabel(link.linkId, label);
+      // Refresh the settings query so the edited label doesn't visually
+      // revert to the stale server copy on the next render.
+      onUpdate();
     } catch (err) {
       addToast('error', err instanceof Error ? err.message : 'Failed to update label');
     }

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { useSearchParams } from 'react-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRequireAuth } from '@/hooks/useAuth';
+import { useAuthStore } from '@/stores/authStore';
 import { getSettings, importData, exportData } from '@/api/settings';
 import { ApiError } from '@/api/client';
 import { useToastStore } from '@/stores/toastStore';
@@ -70,7 +71,9 @@ export default function Settings() {
 
   const refresh = () => {
     queryClient.invalidateQueries({ queryKey: ['settings'] });
-    queryClient.invalidateQueries({ queryKey: ['me'] });
+    // The current user lives in the auth store, not a query — re-fetch it
+    // so changes (macros, preferences, …) propagate app-wide.
+    useAuthStore.getState().fetchUser();
   };
 
   const handleImport = async () => {

--- a/client/src/stores/dashboardStore.ts
+++ b/client/src/stores/dashboardStore.ts
@@ -18,7 +18,10 @@ interface DashboardState {
 // Initial (data-only) state. Recomputed on each call so `selectedDate`
 // reflects today at reset time, not module-load time.
 const initialState = (): Pick<DashboardState, 'selectedDate' | 'currentUserId' | 'currentLabel' | 'canEdit' | 'rangePreset' | 'rangeStart' | 'rangeEnd'> => ({
-  selectedDate: new Date().toISOString().slice(0, 10),
+  // Local calendar date, not UTC — toISOString would be yesterday/tomorrow
+  // around midnight for non-UTC users. The server-provided timezone date
+  // still overrides this after the first dashboard fetch.
+  selectedDate: new Date().toLocaleDateString('en-CA'),
   currentUserId: null,
   currentLabel: 'You',
   canEdit: true,


### PR DESCRIPTION
Implements the 13 verified frontend findings from the code audit (#144). All changes are confined to `client/`.

## Findings fixed

### MEDIUM
1. **useSSE reconnect timer never cancelled on unmount** (`client/src/hooks/useSSE.ts`) — the `onerror` reconnect `setTimeout` id is now stored and cleared in effect cleanup, and `connect()` checks a `disposed` flag, so logout can no longer leave an orphaned EventSource looping 401 reconnects forever.
2. **NoteEditor refetch clobbers in-progress typing** (`client/src/pages/Dashboard/NoteEditor.tsx`) — server content only syncs into local state while the user is not editing (dirty + focus tracking, reset on date/user switch), and the self-invalidation of `['note']` after saving your own content was dropped.
3. **useAutosave silently drops the newest change during an in-flight save** (`client/src/hooks/useAutosave.ts`) — a skipped save now sets a pending flag; when the in-flight save completes, the hook immediately saves again with the latest data. Benefits MacroSettings, PreferencesSettings, AISettings.
4. **AISettings autosaved partial API keys while typing** (`client/src/pages/Settings/AISettings.tsx`) — the key is excluded from the debounced autosave payload; it is submitted on blur of the key input and the field is only cleared after that save succeeds. The blur save includes the current provider/model because `POST /settings/ai` overwrites them on every request.
5. **WeightRow wrote an old weight to the selected date on mere focus+blur** (`client/src/pages/Dashboard/WeightRow.tsx`) — blur only saves when the input value actually differs from the rendered default.
6. **SSE entry-change did not invalidate `['weight']`** (`client/src/hooks/useSSE.ts`) — added, and the dead `['overview']` key removed.
7. **Camera stayed on when the AI photo / barcode modal closed during async init** (`client/src/pages/Dashboard/AIPhotoModal.tsx`, `BarcodeScanModal.tsx`) — a session counter is bumped on every stop; stale `getUserMedia` / `Quagga.init` resolutions release the camera instead of storing/starting it. Both modals fixed.

### LOW
8. **dashboardStore initial selectedDate used the UTC date** (`client/src/stores/dashboardStore.ts`) — now `new Date().toLocaleDateString('en-CA')` (local calendar date); the server-provided timezone date still overrides later.
9. **Link label rename never refreshed the settings query** (`client/src/pages/Settings/LinkSettings.tsx`) — `onUpdate` is passed down to `LinkRow` and called after a successful `updateLinkLabel`.
10. **api() treated every non-step-up 403 as a CSRF failure** (`client/src/api/client.ts`) — the CSRF-retry path is now taken only for mutating (non-GET/HEAD) requests; the retry reuses `cache: 'no-store'` and the same tolerant empty-body handling as the primary path; other 403s throw `ApiError(403, …)`. Client-side only.
11. **Dead query keys and duplicated macro-filter logic** — `['overview']` invalidation removed; `['me']` invalidations in `useSSE` and `Settings.refresh` replaced with an authStore `fetchUser()` call; `SavedFoodsModal` now uses `lib/macros.getEnabledMacros` instead of its inline reimplementation.
12. **Admin user list rendered the literal text `Loading more…`** (`client/src/pages/Admin/Admin.tsx`) — now renders a real ellipsis (`&hellip;`).
13. **Admin delete-user / delete-invite had no error handling** (`client/src/pages/Admin/Admin.tsx`) — both wrapped in try/catch with an error toast, matching the rest of the codebase.

## Verification

- `npm run build` in `client/` (runs `tsc -b && vite build`) passes, and a standalone `tsc -b --force` typecheck exits 0.
- **No client unit-test runner exists** (no vitest/jest in `client/package.json`), so none was introduced; the hook changes (`useAutosave` pending-save, `useSSE` cleanup) are covered by the typecheck/build only.
- **Playwright e2e was NOT run.** The `compose.test.yml` stack came up healthy, but the locally cached Playwright browsers did not match the pinned `@playwright/test` version and the required chromium download was aborted rather than stall the session. Suggested targeted specs to re-check on CI / locally: `weight`, `notes`, `settings`, `settings-extra`, `macros-settings`, `admin`, `sse-realtime`, `linked-sse`, `csrf`, `dashboard-state`, `account-linking`, `barcode`, `ai-modal`, `error-handling`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
