### PR TITLE
fix(ci): kick a GitHub Pages rebuild when the chart deployment stalls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -433,6 +433,8 @@ jobs:
     runs-on: ${{ github.ref == 'refs/heads/staging' && 'arc-runner' || 'ubuntu-latest' }}
     needs: [compute-version, publish-helm]
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'
+    permissions:
+      pages: write # request a Pages rebuild when a deployment fails transiently
     steps:
       - name: Determine ArgoCD application
         id: app
@@ -465,11 +467,26 @@ jobs:
               echo "Chart version $VERSION is live on GitHub Pages"
               exit 0
             fi
+            # A Pages deployment can fail outright with a transient
+            # "Deployment failed, try again later." (both main deploys did on
+            # 2026-07-03) and GitHub never retries it on its own — the chart
+            # then stays unpublished until the NEXT gh-pages push, so waiting
+            # longer cannot help. Kick a fresh build of the latest gh-pages
+            # commit once, 5 minutes in.
+            if [[ $i -eq 60 ]]; then
+              echo "Chart still not visible — requesting a GitHub Pages rebuild"
+              curl -sf -X POST \
+                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/${{ github.repository }}/pages/builds" || true
+            fi
             echo "Waiting for GitHub Pages to serve $VERSION... ($i/$MAX_ATTEMPTS)"
             sleep 5
           done
           echo "::warning::Chart $VERSION not visible on GitHub Pages after $((MAX_ATTEMPTS * 5))s; not failing the release — ArgoCD will pick it up on its next poll."
           exit 0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Best-effort: nudge ArgoCD to sync immediately instead of waiting for its
       # poll. A transient ArgoCD hiccup must not red an already-published release.


### PR DESCRIPTION
The morning main release (run 28653317276) red-flagged on `notify-argocd`: both GitHub Pages deployments for the gh-pages push failed with a transient **"Deployment failed, try again later."** — and GitHub never retries a failed Pages deployment on its own. The chart (2.3.4) only went live 38 minutes later when an unrelated gh-pages push triggered a fresh build. Waiting longer (the current 15m window) cannot help in that failure mode; the index simply never updates until the next build.

This adds a single recovery kick to the wait loop: if the chart version is still not being served 5 minutes in, request `POST /repos/{repo}/pages/builds` (rebuilds the latest gh-pages commit), then keep polling. The job gets an explicit `pages: write` permission for that call. Everything else (15m window, non-fatal warning, best-effort ArgoCD refresh) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)