### PR TITLE
fix(client): drop viewport maximum-scale to allow pinch-zoom

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#070d1a" />
     <title>Schautrack</title>
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />


### PR DESCRIPTION
Removes `maximum-scale=1` from the viewport meta in `client/index.html` so Android Chrome and the Android WebView wrapper no longer block pinch-zoom. This resolves a WCAG 1.4.4 (Resize Text) failure that stopped low-vision users from magnifying the dashboard. The viewport is now `width=device-width, initial-scale=1.0`.

Verified: `cd client && npm run build` (tsc typecheck + vite build) passes, and the built `dist/index.html` emits the corrected viewport meta with no `maximum-scale`.

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)