### PR TITLE
fix(a11y): make ShareCard link-label editable via keyboard

### DIFF
--- a/client/src/pages/Dashboard/ShareCard.tsx
+++ b/client/src/pages/Dashboard/ShareCard.tsx
@@ -59,15 +59,18 @@ export default function ShareCard({ view, todayStr, onDotClick }: Props) {
             maxLength={30}
             autoFocus
           />
-        ) : (
-          <span
-            className={cn(
-              'text-sm font-medium text-foreground',
-              canEditLabel && 'cursor-pointer hover:text-primary transition-colors'
-            )}
-            onClick={canEditLabel ? () => setEditing(true) : undefined}
-            title={canEditLabel ? 'Click to edit label' : undefined}
+        ) : canEditLabel ? (
+          <button
+            type="button"
+            className="bg-transparent border border-transparent p-0 text-sm font-medium text-foreground text-left cursor-pointer hover:text-primary transition-colors"
+            onClick={() => setEditing(true)}
+            aria-label={`Edit label for ${view.label}`}
+            title="Click to edit label"
           >
+            {view.label}
+          </button>
+        ) : (
+          <span className="text-sm font-medium text-foreground">
             {view.label}
           </span>
         )}


### PR DESCRIPTION
Renaming a linked account's label was an onClick-only `<span>` — not focusable, no role, no keyboard handler — so keyboard/switch users couldn't rename links and screen readers saw only static text. When `canEditLabel` is true it now renders a real `<button type="button">` (matching the click-to-edit name buttons in EntryList/SavedFoodsModal) with `aria-label={`Edit label for ${view.label}`}`. Non-editable labels remain a plain `<span>`.

Verified: `cd client && npm run build` (tsc type-check + vite build) passes clean; only the pre-existing chunk-size warning remains.

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)