### PR TITLE
fix(a11y): associate form labels with inputs in EntryForm and Settings

### DIFF
--- a/client/src/pages/Dashboard/EntryForm.tsx
+++ b/client/src/pages/Dashboard/EntryForm.tsx
@@ -169,6 +169,7 @@ export default function EntryForm({ selectedDate, caloriesEnabled, autoCalcCalor
             <input
               className={inputClass}
               type="text"
+              aria-label="Food name"
               placeholder="Breakfast, snack..."
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -185,8 +186,9 @@ export default function EntryForm({ selectedDate, caloriesEnabled, autoCalcCalor
         {/* Calories */}
         {caloriesEnabled && (
           <div className="mb-3 flex flex-col gap-1">
-            <label className="text-xs font-semibold uppercase tracking-wider text-macro-kcal">Calories</label>
+            <label htmlFor="entry-calories" className="text-xs font-semibold uppercase tracking-wider text-macro-kcal">Calories</label>
             <input
+              id="entry-calories"
               className={`${inputClass} ${autoCalcCalories ? 'opacity-60 cursor-not-allowed' : ''}`}
               type="text"
               inputMode="tel"
@@ -215,10 +217,11 @@ export default function EntryForm({ selectedDate, caloriesEnabled, autoCalcCalor
 
               return (
                 <div key={key} className="flex flex-col gap-1">
-                  <label className={`text-xs font-semibold uppercase tracking-wider ${color}`}>
+                  <label htmlFor={`entry-macro-${key}`} className={`text-xs font-semibold uppercase tracking-wider ${color}`}>
                     {MACRO_LABELS[key as keyof typeof MACRO_LABELS]?.label || key}
                   </label>
                   <input
+                    id={`entry-macro-${key}`}
                     className={inputClass}
                     type="text"
                     inputMode="numeric"
@@ -243,6 +246,7 @@ export default function EntryForm({ selectedDate, caloriesEnabled, autoCalcCalor
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
           <input
             type="date"
+            aria-label="Entry date"
             className="rounded-md border border-input bg-muted/50 px-2 py-1.5 text-sm text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
             value={date}
             onChange={(e) => setDate(e.target.value)}

--- a/client/src/pages/Settings/PreferencesSettings.tsx
+++ b/client/src/pages/Settings/PreferencesSettings.tsx
@@ -30,15 +30,15 @@ export default function PreferencesSettings({ user, timezones, onSave }: Props) 
       <h3 className="text-sm font-semibold mb-3">Internationalization</h3>
       <div className="flex flex-col gap-3">
         <div className="flex flex-col gap-1.5">
-          <label className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Weight Unit</label>
-          <select value={weightUnit} onChange={(e) => setWeightUnit(e.target.value as 'kg' | 'lb')} className={selectClass}>
+          <label htmlFor="pref-weight-unit" className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Weight Unit</label>
+          <select id="pref-weight-unit" value={weightUnit} onChange={(e) => setWeightUnit(e.target.value as 'kg' | 'lb')} className={selectClass}>
             <option value="kg">Kilograms (kg)</option>
             <option value="lb">Pounds (lb)</option>
           </select>
         </div>
         <div className="flex flex-col gap-1.5">
-          <label className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Timezone</label>
-          <select value={timezone} onChange={(e) => setTimezone(e.target.value)} className={selectClass}>
+          <label htmlFor="pref-timezone" className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Timezone</label>
+          <select id="pref-timezone" value={timezone} onChange={(e) => setTimezone(e.target.value)} className={selectClass}>
             {timezones.map((tz) => <option key={tz} value={tz}>{tz}</option>)}
           </select>
         </div>


### PR DESCRIPTION
Associates visual `<label>` elements with their form controls so screen readers announce an accessible name and clicking a label focuses the field. In EntryForm the Calories and macro inputs now use htmlFor/id, the name input gets aria-label="Food name", and the date input gets aria-label="Entry date". In PreferencesSettings the Weight Unit and Timezone selects are linked via htmlFor/id. The calorie field's inputmode="tel" is left unchanged.

Verified: `cd client && npm run build` (tsc typecheck + vite build) passes clean; only the pre-existing chunk-size warning remains. No lint script exists in client/package.json.

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)