### PR TITLE
fix(client): show error state with retry when Dashboard/Settings initial load fails

### DIFF
--- a/client/src/components/ui/QueryError.tsx
+++ b/client/src/components/ui/QueryError.tsx
@@ -1,0 +1,51 @@
+import { useSyncExternalStore } from 'react';
+import { Alert } from './Alert';
+import { Button } from './Button';
+
+function subscribe(callback: () => void) {
+  window.addEventListener('online', callback);
+  window.addEventListener('offline', callback);
+  return () => {
+    window.removeEventListener('online', callback);
+    window.removeEventListener('offline', callback);
+  };
+}
+
+function getOnline() {
+  return navigator.onLine;
+}
+
+interface QueryErrorProps {
+  /** The error thrown by the failed query (used for its message when online). */
+  error?: unknown;
+  /** Re-run the failed query. */
+  onRetry: () => void;
+  /** Whether a retry is currently in flight (drives the button spinner). */
+  retrying?: boolean;
+}
+
+/**
+ * Full-page fallback for a query whose initial load failed, so pages don't hang
+ * on an infinite spinner when the device is offline or the server errors.
+ * Shows an offline hint via navigator.onLine and a Retry button.
+ */
+export function QueryError({ error, onRetry, retrying }: QueryErrorProps) {
+  // Re-render when connectivity changes so the hint stays accurate.
+  const online = useSyncExternalStore(subscribe, getOnline, () => true);
+  const message = online
+    ? error instanceof Error && error.message
+      ? error.message
+      : "Couldn't load this page. Please try again."
+    : "You appear to be offline. Check your connection and try again.";
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-12 text-center">
+      <Alert type="error" message={message} className="max-w-sm" />
+      <Button variant="outline" onClick={onRetry} loading={retrying}>
+        Retry
+      </Button>
+    </div>
+  );
+}
+
+export default QueryError;

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -5,6 +5,7 @@ import { getDashboard, getDayEntries } from '@/api/entries';
 import { getWeightDay } from '@/api/weight';
 import { useDashboardStore } from '@/stores/dashboardStore';
 import { computeMacroStatus } from '@/lib/macros';
+import { QueryError } from '@/components/ui/QueryError';
 import TodayPanel from './TodayPanel';
 import EntryForm from './EntryForm';
 import SavedFoodsRow from './SavedFoodsRow';
@@ -20,7 +21,7 @@ export default function Dashboard() {
   const queryClient = useQueryClient();
 
   // Fetch dashboard data
-  const { data: dashboard, isLoading } = useQuery({
+  const { data: dashboard, isLoading, isError, error, isFetching, refetch } = useQuery({
     queryKey: ['dashboard', rangePreset, rangeStart, rangeEnd],
     queryFn: () => getDashboard({
       range: rangePreset || undefined,
@@ -91,6 +92,10 @@ export default function Dashboard() {
     }
     return statuses;
   }, [selectedMacroTotals, dashboard]);
+
+  if (isError && !dashboard) {
+    return <QueryError error={error} onRetry={() => refetch()} retrying={isFetching} />;
+  }
 
   if (authLoading || isLoading || !dashboard) {
     return <div className="flex items-center justify-center py-12"><div className="size-6 rounded-full border-2 border-primary border-t-transparent animate-spin" /></div>;

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -9,6 +9,7 @@ import { useToastStore } from '@/stores/toastStore';
 import { Card } from '@/components/ui/Card';
 import { Alert } from '@/components/ui/Alert';
 import { Button } from '@/components/ui/Button';
+import { QueryError } from '@/components/ui/QueryError';
 import { OIDC_SETTINGS_ERRORS, OIDC_SETTINGS_SUCCESS } from '@/lib/oidcMessages';
 import MacroSettings from './MacroSettings';
 import PreferencesSettings from './PreferencesSettings';
@@ -60,10 +61,14 @@ export default function Settings() {
     setImportMessage(null);
   }, []);
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error, isFetching, refetch } = useQuery({
     queryKey: ['settings'],
     queryFn: getSettings,
   });
+
+  if (isError && !data) {
+    return <QueryError error={error} onRetry={() => refetch()} retrying={isFetching} />;
+  }
 
   if (authLoading || isLoading || !data) {
     return <div className="flex items-center justify-center p-12"><div className="size-6 rounded-full border-2 border-primary border-t-transparent animate-spin" /></div>;


### PR DESCRIPTION
Dashboard and Settings only guarded their render on `isLoading`/data presence, so a rejected initial query (offline, 500, expired proxy) left an infinite spinner with no message or recovery. This adds a shared `QueryError` component (Alert + Retry button, offline hint via `navigator.onLine`) and renders it from both pages when the query errored with no data, while preserving stale data on later failed refetches.

Verified: `cd client && npm run build` (tsc type-check + vite build) passes cleanly; the new component and both call sites type-check.

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)