### PR TITLE
fix(a11y): give DayDot a human-readable accessible name

### DIFF
--- a/client/src/pages/Dashboard/DayDot.tsx
+++ b/client/src/pages/Dashboard/DayDot.tsx
@@ -16,6 +16,14 @@ const STATUS_COLORS: Record<string, string> = {
   none: 'bg-white/[0.03]',
 };
 
+const STATUS_LABELS: Record<string, string> = {
+  under: 'under goal',
+  over: 'over goal',
+  over_threshold: 'well over goal',
+  zero: 'no entries',
+  none: 'no entries',
+};
+
 export default function DayDot({ date, status, isToday, isSelected, onClick }: Props) {
   return (
     <button
@@ -29,7 +37,7 @@ export default function DayDot({ date, status, isToday, isSelected, onClick }: P
       )}
       onClick={onClick}
       title={date}
-      aria-label={`${date}: ${status}`}
+      aria-label={`${date}: ${STATUS_LABELS[status] || 'no entries'}`}
     />
   );
 }


### PR DESCRIPTION
The timeline day-dots exposed their internal status token in the accessible name, so screen readers announced cryptic values like "2026-07-01: over_threshold" or "2026-07-01: none". Since color is the only other signal, this label was the sole non-color channel and was unusable.

This maps each status to a human phrase (under goal / over goal / well over goal / no entries) before interpolating into `aria-label`, with a safe "no entries" fallback for unknown values.

Verified: `cd client && npm run build` (tsc typecheck + vite build) passes; only `DayDot.tsx` changed.

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)