### PR TITLE
fix(client): add autocomplete hints to password-reset auth fields

### DIFF
--- a/client/src/pages/ForgotPassword/ForgotPassword.tsx
+++ b/client/src/pages/ForgotPassword/ForgotPassword.tsx
@@ -45,7 +45,7 @@ export default function ForgotPassword() {
         <h2 className="mb-6 text-xl font-semibold">Forgot Password</h2>
         {error && <Alert type="error" message={error} className="mb-4" />}
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          <Input label="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+          <Input label="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required autoComplete="email" />
           {captchaSvg && (
             <div className="flex flex-col gap-2">
               <div className="flex justify-center rounded-md bg-muted/50 p-2 invert [&_img]:max-w-full">

--- a/client/src/pages/ResetPassword/ResetPassword.tsx
+++ b/client/src/pages/ResetPassword/ResetPassword.tsx
@@ -48,11 +48,11 @@ export default function ResetPassword() {
         {!success && (
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             {!codeVerified ? (
-              <Input label="Reset Code" value={code} onChange={(e) => setCode(e.target.value)} required autoComplete="off" />
+              <Input label="Reset Code" value={code} onChange={(e) => setCode(e.target.value)} required autoComplete="one-time-code" inputMode="numeric" pattern="[0-9]*" />
             ) : (
               <>
-                <Input label="New Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required minLength={10} />
-                <Input label="Confirm Password" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required />
+                <Input label="New Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required minLength={10} autoComplete="new-password" />
+                <Input label="Confirm Password" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required autoComplete="new-password" />
               </>
             )}
             <Button type="submit" loading={loading}>{codeVerified ? 'Reset Password' : 'Verify Code'}</Button>


### PR DESCRIPTION
The password-reset flow was missing the autocomplete hints the rest of the app uses. Added `autoComplete="new-password"` to both New/Confirm Password inputs, `autoComplete="one-time-code"` + `inputMode="numeric"` + `pattern="[0-9]*"` to the 6-digit reset-code input (matching the 2FA-code input in Login.tsx), and `autoComplete="email"` to the forgot-password email input. This lets password managers generate/save the new credential and enables SMS/mail code + email autofill on mobile.

Verified: `cd client && npm run build` (tsc typecheck + vite build) passes clean. No lint script exists in the client. No behavioral/logic change — attributes only.

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)