### PR TITLE
fix(client): respect prefers-reduced-motion for persistent animations

### DIFF
--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -182,3 +182,21 @@
   0% { background-position: 200% 0; }
   100% { background-position: -200% 0; }
 }
+
+/* Respect the OS "reduce motion" preference: neutralize persistent animations
+   (e.g. the Track button's infinite shimmer) and smooth scrolling for users
+   with vestibular disorders. Kept unlayered with !important so it overrides
+   Tailwind's utility-layer animate-* classes. */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
Adds a `@media (prefers-reduced-motion: reduce)` block to `client/src/styles/global.css` that neutralizes animation/transition durations and disables smooth scrolling. This stops the Track button's infinite 4s shimmer and `scroll-behavior: smooth` for users who set the OS reduce-motion preference (WCAG 2.3.3 / vestibular safety). The block is unlayered with `!important` so it overrides Tailwind's utility-layer `animate-*` classes.

Verified: `npm run build` (tsc -b && vite build) passes, and the rule is present in the compiled production CSS (`prefers-reduced-motion:reduce{...!important}`).

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)