### PR TITLE
fix(header): a11y for mobile nav drawer and pending-request badge

### DIFF
--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/stores/authStore';
@@ -12,6 +12,17 @@ export default function Header() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { pathname } = useLocation();
+
+  // Close the mobile drawer on Escape so keyboard users aren't trapped behind it.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [menuOpen]);
+
   const navClass = (path: string) => {
     const active = pathname.startsWith(path);
     return cn(
@@ -50,6 +61,8 @@ export default function Header() {
               className="relative z-[102] flex items-center justify-center p-2 md:hidden text-foreground"
               onClick={() => setMenuOpen(!menuOpen)}
               aria-label="Toggle menu"
+              aria-expanded={menuOpen}
+              aria-controls="mobile-nav"
             >
               {menuOpen ? (
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -62,7 +75,7 @@ export default function Header() {
               )}
             </button>
 
-            <nav className={cn(
+            <nav id="mobile-nav" className={cn(
               'flex items-center gap-1',
               'max-md:fixed max-md:right-0 max-md:top-0 max-md:z-[101] max-md:h-screen max-md:w-[280px] max-md:translate-x-full max-md:invisible max-md:flex-col max-md:items-stretch max-md:border-l max-md:border-border max-md:bg-background max-md:pt-16 max-md:transition-[transform,visibility] max-md:duration-250',
               menuOpen && 'max-md:translate-x-0 max-md:visible'
@@ -78,7 +91,10 @@ export default function Header() {
               <Link to="/settings" onClick={() => setMenuOpen(false)} className={cn(navClass('/settings'), 'relative')}>
                 Settings
                 {pendingLinkRequests > 0 && (
-                  <span className="absolute top-1 right-1 size-2 rounded-full bg-[#0ea5e9] max-md:top-4 max-md:right-3" />
+                  <>
+                    <span className="absolute top-1 right-1 size-2 rounded-full bg-[#0ea5e9] max-md:top-4 max-md:right-3" aria-hidden="true" />
+                    <span className="sr-only">{pendingLinkRequests} pending link requests</span>
+                  </>
                 )}
               </Link>
               <button type="button" onClick={handleLogout}


### PR DESCRIPTION
Improves accessibility of the mobile navigation drawer in `Header.tsx`:
- Hamburger toggle now exposes `aria-expanded` + `aria-controls` so its open/closed state is announced.
- The slide-in drawer closes on `Escape` via a keydown effect (registered only while open).
- The pending link-requests dot gets an `sr-only` text alternative ("N pending link requests") and the decorative dot is `aria-hidden`.

Verified: `cd client && npm run build` (tsc type-check + vite build) passes clean; confirmed the `sr-only` utility is emitted into the built CSS.

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)