### PR TITLE
ci: trigger build on public/** and cliff.toml changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ on:
       - 'client/**'
       - 'db/init.sql'
       - 'helm/**'
+      - 'public/**'
+      - 'cliff.toml'
       - '.github/workflows/build.yml'
     tags:
       - 'v*'
@@ -30,6 +32,8 @@ on:
       - 'client/**'
       - 'db/init.sql'
       - 'helm/**'
+      - 'public/**'
+      - 'cliff.toml'
       - '.github/workflows/build.yml'
 
 env:


### PR DESCRIPTION
The build workflow's push/pull_request `paths` filters omitted `public/**`, even though the Dockerfile bakes `COPY public ./public` into the final image — so a commit touching only static assets (logo, favicons) triggered no build, tag, or deployment and silently never shipped. `cliff.toml` (consumed by the release changelog step) was likewise unfiltered.

Added `public/**` and `cliff.toml` to both the push and pull_request `paths` lists.

Verification: `git diff` reviewed; workflow YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`; confirmed the `public/**` glob covers exactly what `COPY public ./public` copies (all of `public/`, including nested `oidc-logos/`).

Refs #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)