### PR TITLE
fix(a11y): add aria-label to icon-only entry-flow buttons

### DIFF
--- a/client/src/pages/Dashboard/AIPhotoModal.tsx
+++ b/client/src/pages/Dashboard/AIPhotoModal.tsx
@@ -203,8 +203,8 @@ export default function AIPhotoModal({ isOpen, onClose, onResult, enabledMacros:
         <Dialog.Content className="fixed inset-0 z-50 bg-black flex flex-col overflow-hidden sm:overflow-y-auto sm:inset-auto sm:inset-x-4 sm:top-1/2 sm:-translate-y-1/2 sm:mx-auto sm:max-w-md sm:max-h-[90vh] sm:rounded-xl sm:border sm:border-border sm:bg-card">
           <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-card/80 sm:bg-transparent shrink-0 z-10">
             <Dialog.Title className="text-sm font-semibold text-foreground">AI Calorie Estimate</Dialog.Title>
-            <Dialog.Close className="size-8 flex items-center justify-center rounded-md border border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors cursor-pointer">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <Dialog.Close aria-label="Close" className="size-8 flex items-center justify-center rounded-md border border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors cursor-pointer">
+              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M18 6L6 18" /><path d="M6 6l12 12" />
               </svg>
             </Dialog.Close>

--- a/client/src/pages/Dashboard/BarcodeScanModal.tsx
+++ b/client/src/pages/Dashboard/BarcodeScanModal.tsx
@@ -258,8 +258,8 @@ export default function BarcodeScanModal({ isOpen, onClose, onResult, enabledMac
         <Dialog.Content className="fixed inset-0 z-50 bg-black flex flex-col overflow-hidden sm:overflow-y-auto sm:inset-auto sm:inset-x-4 sm:top-1/2 sm:-translate-y-1/2 sm:mx-auto sm:max-w-md sm:max-h-[90vh] sm:rounded-xl sm:border sm:border-border sm:bg-card">
           <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-card/80 sm:bg-transparent shrink-0 z-10">
             <Dialog.Title className="text-sm font-semibold text-foreground">Scan Barcode</Dialog.Title>
-            <Dialog.Close className="size-8 flex items-center justify-center rounded-md border border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors cursor-pointer">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <Dialog.Close aria-label="Close" className="size-8 flex items-center justify-center rounded-md border border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors cursor-pointer">
+              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M18 6L6 18" /><path d="M6 6l12 12" />
               </svg>
             </Dialog.Close>

--- a/client/src/pages/Dashboard/EntryForm.tsx
+++ b/client/src/pages/Dashboard/EntryForm.tsx
@@ -255,9 +255,10 @@ export default function EntryForm({ selectedDate, caloriesEnabled, autoCalcCalor
                 className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:border-primary/50 hover:bg-primary/5 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed bg-transparent"
                 onClick={() => setAiModalOpen(true)}
                 disabled={!!aiDisabled}
+                aria-label="Estimate calories with AI"
                 title={aiDisabled ? 'Daily AI limit reached' : 'Estimate with AI'}
               >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.582a.5.5 0 0 1 0 .963L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z" />
                   <path d="M20 3v4" /><path d="M22 5h-4" />
                 </svg>
@@ -272,9 +273,10 @@ export default function EntryForm({ selectedDate, caloriesEnabled, autoCalcCalor
                 type="button"
                 className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:border-primary/50 hover:bg-primary/5 transition-colors cursor-pointer bg-transparent"
                 onClick={() => setBarcodeModalOpen(true)}
+                aria-label="Scan barcode"
                 title="Scan barcode"
               >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M3 5v-2h4" /><path d="M17 3h4v2" /><path d="M21 19v2h-4" /><path d="M7 21h-4v-2" />
                   <path d="M7 8v8" /><path d="M12 8v8" /><path d="M17 8v8" /><path d="M5 8v8" /><path d="M15 8v8" /><path d="M19 8v8" />
                 </svg>
@@ -286,12 +288,13 @@ export default function EntryForm({ selectedDate, caloriesEnabled, autoCalcCalor
               className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:border-primary/50 hover:bg-primary/5 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed bg-transparent"
               onClick={handleSaveAsFood}
               disabled={!canSaveAsFood || savingFood}
+              aria-label="Save as quick-add"
               title={canSaveAsFood ? 'Save as template for quick-add' : 'Add a name and values first'}
             >
               {savingFood ? (
                 <span className="size-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
               ) : (
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
                 </svg>
               )}

--- a/client/src/pages/Dashboard/EntryList.tsx
+++ b/client/src/pages/Dashboard/EntryList.tsx
@@ -145,20 +145,21 @@ function EntryRow({ entry, canEdit, enabledMacros, caloriesEnabled, autoCalcCalo
             className="size-7 flex items-center justify-center rounded-[10px] border border-border text-muted-foreground hover:text-primary hover:border-primary/40 hover:bg-primary/5 transition-colors cursor-pointer shrink-0 disabled:opacity-40"
             onClick={handleSaveAsFood}
             disabled={savingFood}
+            aria-label="Save as quick-add"
             title="Save as quick-add"
           >
             {savingFood ? (
               <span className="size-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
             ) : (
-              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg aria-hidden="true" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
               </svg>
             )}
           </button>
         )}
         {canEdit && (
-          <button type="button" className="size-7 flex items-center justify-center rounded-[10px] border border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors cursor-pointer shrink-0" onClick={handleDelete} title="Delete">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <button type="button" className="size-7 flex items-center justify-center rounded-[10px] border border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors cursor-pointer shrink-0" onClick={handleDelete} aria-label="Delete entry" title="Delete">
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M18 6L6 18" /><path d="M6 6l12 12" />
             </svg>
           </button>

--- a/client/src/pages/Dashboard/SavedFoodsModal.tsx
+++ b/client/src/pages/Dashboard/SavedFoodsModal.tsx
@@ -348,9 +348,10 @@ function SavedFoodRow({ food, enabledMacros, caloriesEnabled, selectedDate, onCh
           className="size-7 flex items-center justify-center rounded-[10px] border border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors cursor-pointer shrink-0 disabled:opacity-40"
           onClick={handleDelete}
           disabled={busy}
+          aria-label="Delete saved food"
           title="Delete"
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
             <path d="M18 6L6 18" /><path d="M6 6l12 12" />
           </svg>
         </button>


### PR DESCRIPTION
Icon-only buttons in the entry flow (AI-estimate, barcode-scan and save-as-quick-add in EntryForm; save-as-quick-add and delete in EntryList; the SavedFoodsModal row delete; and the Dialog.Close X in AIPhotoModal and BarcodeScanModal) relied only on `title` attributes, which screen readers and touch devices don't reliably expose — so the controls had no accessible name.

Added an explicit `aria-label` to each button and marked the decorative SVGs `aria-hidden="true"`, matching the existing aria-label convention already used elsewhere in the app. No behavior or styling changes.

Verified with `cd client && npm run build` (tsc typecheck + vite build) — passes clean.

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)