### PR TITLE
chore(renovate): block PostgreSQL major upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,14 @@
   "labels": ["dependencies"],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
-  "dependencyDashboard": false
+  "dependencyDashboard": false,
+  "packageRules": [
+    {
+      "description": "Block PostgreSQL major upgrades: a new major (e.g. 18 -> 19) makes the existing /var/lib/postgresql data directory incompatible with no pg_upgrade path in these compose/helm deployments, so the db container crashloops. Majors require a deliberate manual migration plan.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["postgres"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Renovate ran bare `config:recommended` with no `packageRules`, so it would open a postgres major PR (e.g. `18-alpine` -> `19-alpine`) for `compose{,.dev,.test}.yml` and the helm values. Merging that breaks the existing `/var/lib/postgresql` data directory (no pg_upgrade path in these deployments), crashlooping the db until manually rolled back.

Adds a `packageRule` disabling major updates for the `postgres` docker image (datasource `docker`, package `postgres`) so majors require a deliberate manual migration plan. Minor/patch and all other deps are unaffected.

Verification: `renovate.json` parses as valid JSON; the rule's `matchDatasources`/`matchPackageNames` match every postgres reference in the repo (three compose files + helm values).

Refs #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)