### PR TITLE
fix(client): announce toasts to screen readers, linger error/undo toasts

### DIFF
--- a/client/src/components/ui/Toaster.tsx
+++ b/client/src/components/ui/Toaster.tsx
@@ -2,14 +2,27 @@ import { useToastStore } from '@/stores/toastStore';
 import { cn } from '@/lib/utils';
 
 export default function Toaster() {
-  const { toasts, removeToast } = useToastStore();
-  if (toasts.length === 0) return null;
+  const { toasts, removeToast, pauseToast, resumeToast } = useToastStore();
 
+  // The live-region container is always rendered so screen readers observe it
+  // before toasts are inserted. Non-error toasts inherit polite; error toasts
+  // override to an assertive alert.
   return (
-    <div className="fixed bottom-4 right-4 z-[200] flex flex-col gap-2 max-w-sm">
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="false"
+      className="fixed bottom-4 right-4 z-[200] flex flex-col gap-2 max-w-sm"
+    >
       {toasts.map((toast) => (
         <div
           key={toast.id}
+          role={toast.type === 'error' ? 'alert' : undefined}
+          aria-live={toast.type === 'error' ? 'assertive' : undefined}
+          onMouseEnter={() => pauseToast(toast.id)}
+          onMouseLeave={() => resumeToast(toast.id)}
+          onFocus={() => pauseToast(toast.id)}
+          onBlur={() => resumeToast(toast.id)}
           className={cn(
             'flex items-center gap-3 rounded-md border px-4 py-3 text-sm shadow-lg animate-in slide-in-from-right-5 fade-in',
             toast.type === 'success' && 'bg-card border-success/30 text-green-400',
@@ -33,6 +46,7 @@ export default function Toaster() {
           )}
           <button
             type="button"
+            aria-label="Dismiss"
             className="bg-transparent border-0 text-muted-foreground hover:text-foreground cursor-pointer text-lg leading-none p-0"
             onClick={() => removeToast(toast.id)}
           >&times;</button>

--- a/client/src/stores/toastStore.ts
+++ b/client/src/stores/toastStore.ts
@@ -5,29 +5,73 @@ export interface ToastAction {
   onClick: () => void;
 }
 
+type ToastType = 'success' | 'error' | 'info';
+
 interface Toast {
   id: number;
-  type: 'success' | 'error' | 'info';
+  type: ToastType;
   message: string;
   action?: ToastAction;
+  duration: number;
 }
 
 interface ToastState {
   toasts: Toast[];
-  addToast: (type: 'success' | 'error' | 'info', message: string, action?: ToastAction) => void;
+  addToast: (type: ToastType, message: string, action?: ToastAction) => void;
   removeToast: (id: number) => void;
+  pauseToast: (id: number) => void;
+  resumeToast: (id: number) => void;
 }
+
+const DEFAULT_DURATION = 5000;
+// Errors and toasts carrying an action (e.g. Undo) linger longer so users with
+// motor or cognitive impairments have time to read and act on them.
+const LONG_DURATION = 10000;
+
+// Timer handles live outside the store so pausing/resuming (on hover/focus)
+// doesn't trigger re-renders.
+const timers = new Map<number, ReturnType<typeof setTimeout>>();
 
 let nextId = 0;
 
-export const useToastStore = create<ToastState>((set) => ({
-  toasts: [],
-  addToast: (type, message, action) => {
-    const id = nextId++;
-    set((state) => ({ toasts: [...state.toasts, { id, type, message, action }] }));
-    setTimeout(() => {
+export const useToastStore = create<ToastState>((set, get) => {
+  const schedule = (id: number, duration: number) => {
+    const handle = setTimeout(() => {
+      timers.delete(id);
       set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
-    }, 5000);
-  },
-  removeToast: (id) => set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
-}));
+    }, duration);
+    timers.set(id, handle);
+  };
+
+  const clear = (id: number) => {
+    const handle = timers.get(id);
+    if (handle !== undefined) {
+      clearTimeout(handle);
+      timers.delete(id);
+    }
+  };
+
+  return {
+    toasts: [],
+    addToast: (type, message, action) => {
+      const id = nextId++;
+      const duration = type === 'error' || action ? LONG_DURATION : DEFAULT_DURATION;
+      set((state) => ({ toasts: [...state.toasts, { id, type, message, action, duration }] }));
+      schedule(id, duration);
+    },
+    removeToast: (id) => {
+      clear(id);
+      set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
+    },
+    // Pause auto-dismiss while the toast is hovered or focused.
+    pauseToast: (id) => {
+      clear(id);
+    },
+    // Restart the auto-dismiss timer once the pointer/focus leaves.
+    resumeToast: (id) => {
+      if (timers.has(id)) return;
+      const toast = get().toasts.find((t) => t.id === id);
+      if (toast) schedule(id, toast.duration);
+    },
+  };
+});


### PR DESCRIPTION
Makes toast notifications accessible. The Toaster is now a persistent `role="status"` `aria-live="polite"` region (`aria-atomic="false"`), with error toasts overriding to an assertive `role="alert"`; the dismiss `×` button gets `aria-label="Dismiss"`. Error and Undo-carrying toasts now linger 10s (instead of a flat 5s) and pause auto-dismiss on hover/focus so motor/cognitive users can read and act.

Verified: `cd client && npm run build` (tsc typecheck + vite build) passes clean; no lint script exists in client/package.json; `addToast` signature is unchanged so all existing callers are unaffected.

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)