### PR TITLE
fix(settings): confirm before destructive data import

### DIFF
--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
 import { useSearchParams } from 'react-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRequireAuth } from '@/hooks/useAuth';
@@ -30,6 +31,7 @@ export default function Settings() {
   const [importLoading, setImportLoading] = useState(false);
   const [importMessage, setImportMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
+  const [confirmImportOpen, setConfirmImportOpen] = useState(false);
   const [exportLoading, setExportLoading] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const addToast = useToastStore((s) => s.addToast);
@@ -77,6 +79,7 @@ export default function Settings() {
   };
 
   const handleImport = async () => {
+    setConfirmImportOpen(false);
     const file = fileInputRef.current?.files?.[0];
     if (!file) return;
     setImportLoading(true);
@@ -204,7 +207,7 @@ export default function Settings() {
                 <Button
                   variant="destructive"
                   className="w-full"
-                  onClick={handleImport}
+                  onClick={() => setConfirmImportOpen(true)}
                   loading={importLoading}
                   disabled={!selectedFileName}
                 >
@@ -214,6 +217,45 @@ export default function Settings() {
             </div>
           </Card>
         </div>
+
+        {/* Import is destructive — it wipes every existing entry. Step-up has a
+            grace window, so gating on re-auth alone lets a user who just
+            authenticated for any other setting replace their whole history with
+            one mis-click. Require an explicit in-app confirmation, independent
+            of step-up state. */}
+        <Dialog.Root open={confirmImportOpen} onOpenChange={setConfirmImportOpen}>
+          <Dialog.Portal>
+            <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60" />
+            <Dialog.Content
+              className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-md border border-border bg-card p-6 text-card-foreground shadow-lg focus:outline-none"
+            >
+              <Dialog.Title className="text-base font-semibold mb-1 text-destructive">Replace all entries?</Dialog.Title>
+              <Dialog.Description className="text-sm text-muted-foreground mb-4">
+                Importing{selectedFileName ? <> <span className="font-medium text-foreground">{selectedFileName}</span></> : ''} will permanently delete all of your existing entries and replace them with the contents of this file. This cannot be undone.
+              </Dialog.Description>
+              <div className="flex flex-col gap-2">
+                <Button
+                  variant="destructive"
+                  className="w-full"
+                  onClick={handleImport}
+                  loading={importLoading}
+                >
+                  Replace all entries
+                </Button>
+                <Dialog.Close asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="w-full border border-border hover:border-foreground/40"
+                  >
+                    Cancel
+                  </Button>
+                </Dialog.Close>
+              </div>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
         <div className="break-inside-avoid">
           <Card>
             <h3 className="text-sm font-semibold mb-2 text-destructive">Danger Zone</h3>


### PR DESCRIPTION
Data import replaces every existing entry, but its only guard is the server-side step-up gate — which has a grace window, so a user who just re-authenticated for any other setting can wipe their whole history with one mis-click on the wrong file. This adds an explicit in-app confirmation dialog (Radix Dialog, matching the app's other modals) that names the selected file and requires a deliberate second click, independent of step-up state.

Verified: `cd client && npm run build` (tsc typecheck + vite build) passes clean; no lint script exists in the client. Not exercised via the docker e2e suite per task constraints.

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)