### PR TITLE
ci: add build concurrency group and gate create-tag on the image build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,14 @@ on:
       - 'helm/**'
       - '.github/workflows/build.yml'
 
+# Serialize runs per ref so two quick merges to the same branch cannot race:
+# without this, both runs compute the same next version from the same latest
+# tag and clobber each other's image/tag. Queue rather than cancel so an
+# in-flight image push is never interrupted.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -128,7 +136,10 @@ jobs:
 
   create-tag:
     runs-on: ${{ github.ref == 'refs/heads/staging' && 'arc-runner' || 'ubuntu-latest' }}
-    needs: compute-version
+    # Only push the git tag once the image artifact actually exists, so a build
+    # failure (e.g. a client tsc error caught inside the Docker build) never
+    # leaves a dangling version tag with no corresponding image or release.
+    needs: [compute-version, create-manifest]
     if: needs.compute-version.outputs.should_tag == 'true'
     permissions:
       contents: write
@@ -270,7 +281,10 @@ jobs:
 
   create-release:
     runs-on: ${{ github.ref == 'refs/heads/staging' && 'arc-runner' || 'ubuntu-latest' }}
-    needs: [compute-version, create-manifest]
+    # Runs after create-tag so the release always references a tag that was
+    # pushed only after the image artifact exists (create-tag needs the
+    # manifest, so this transitively runs after create-manifest too).
+    needs: [compute-version, create-tag]
     if: needs.compute-version.outputs.should_tag == 'true'
     permissions:
       contents: write


### PR DESCRIPTION
Fixes audit #146 item #01. build.yml had no `concurrency:` block and `create-tag` only `needs: compute-version`, so it ran in parallel with the build — two quick merges could compute the same version and clobber each other's image/tag, and a tag could be pushed for a build that later failed inside the Docker step.

- Add workflow-level `concurrency: build-${{ github.ref }}` with `cancel-in-progress: false` (queue, don't cancel in-flight pushes).
- `create-tag` now `needs: [compute-version, create-manifest]` — the git tag is pushed only after the image artifact exists.
- `create-release` now `needs: [compute-version, create-tag]` — the release follows the tag (and transitively the manifest).

Verified: YAML parses cleanly (`yaml.safe_load`); the needs graph is acyclic (`test → compute-version → build-and-push → create-manifest → create-tag → create-release`); `create-tag`/`create-release` keep their matching `if: should_tag == 'true'` guards so they skip together on staging; the per-ref concurrency group can't deadlock tag-triggered runs (distinct group). Did not run the docker e2e suite.

Refs #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)