### PR TITLE
fix(a11y): raise disclosure/attribution text to AA contrast

### DIFF
--- a/client/src/pages/Dashboard/AIPhotoModal.tsx
+++ b/client/src/pages/Dashboard/AIPhotoModal.tsx
@@ -328,7 +328,7 @@ export default function AIPhotoModal({ isOpen, onClose, onResult, enabledMacros:
             )}
 
             {providerName && (
-              <div className="text-center text-[10px] text-muted-foreground/60">
+              <div className="text-center text-[10px] text-muted-foreground">
                 Your photo will be sent to {providerName} for analysis
               </div>
             )}

--- a/client/src/pages/Dashboard/BarcodeScanModal.tsx
+++ b/client/src/pages/Dashboard/BarcodeScanModal.tsx
@@ -437,7 +437,7 @@ export default function BarcodeScanModal({ isOpen, onClose, onResult, enabledMac
 
             {/* Attribution */}
             {(phase === 'result' || phase === 'scanning') && (
-              <div className="text-center text-[10px] text-muted-foreground/60">
+              <div className="text-center text-[10px] text-muted-foreground">
                 Barcode data is sent to and provided by{' '}
                 <a href="https://world.openfoodfacts.org" target="_blank" rel="noopener noreferrer" className="underline hover:text-muted-foreground">
                   Open Food Facts

--- a/client/src/pages/Dashboard/SavedFoodsModal.tsx
+++ b/client/src/pages/Dashboard/SavedFoodsModal.tsx
@@ -336,7 +336,7 @@ function SavedFoodRow({ food, enabledMacros, caloriesEnabled, selectedDate, onCh
         </span>
 
         {food.use_count > 0 && (
-          <span className="text-[10px] tabular-nums text-muted-foreground/60 shrink-0">{food.use_count}×</span>
+          <span className="text-[10px] tabular-nums text-muted-foreground shrink-0">{food.use_count}×</span>
         )}
 
         {selectedDate && (


### PR DESCRIPTION
The AI-photo disclosure, barcode Open Food Facts attribution, and saved-food use-count used `text-muted-foreground/60` at 10px, giving ~4.3:1 contrast on the card — below the 4.5:1 WCAG AA minimum for small text. Dropping the `/60` opacity renders `#c4cad4` at full opacity (~11:1 on `#0c1320`), passing AA comfortably without changing size or layout.

Verified: `cd client && npm run build` (tsc typecheck + vite build) succeeds. No lint script exists in client/. e2e not run.

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)