### PR TITLE
fix(compose): bind production port to loopback to prevent IP spoofing

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -14,7 +14,12 @@ services:
     image: ghcr.io/schaurian/schautrack:latest
     env_file: .env
     ports:
-      - "8080:3000"
+      # Bind to loopback only: this file assumes a reverse proxy in front, and
+      # the app trusts X-Forwarded-For by default (TRUST_PROXY=true). Exposing
+      # the raw port on 0.0.0.0 would let clients spoof their apparent IP and
+      # defeat the rate limiters. If you deploy without a proxy, change this to
+      # "8080:3000" and set TRUST_PROXY=false in .env.
+      - "127.0.0.1:8080:3000"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Production `compose.yml` published port 8080 on all interfaces (0.0.0.0) while the app trusts `X-Forwarded-For` by default (`TRUST_PROXY` defaults to true, `config.go:133`). Anyone reaching the raw port could spoof `X-Forwarded-For` to rotate their apparent IP and defeat the auth/strict rate limiters. This binds the mapping to `127.0.0.1` (the file already assumes a reverse proxy) and documents how to override for proxy-less deployments.

Verified: `docker compose -f compose.yml config` parses and reports the web port as `host_ip: 127.0.0.1, published: 8080, target: 3000`.

Refs #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)