### PR TITLE
fix(compose): expand db healthcheck vars in-container, not at parse time

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -54,7 +54,9 @@ services:
       - TZ=UTC
       - PGTZ=UTC
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      # Escape as $$ so the variables expand inside the container (from
+      # env_file), not at compose parse time from the host env / auto-loaded .env.
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/compose.yml
+++ b/compose.yml
@@ -37,7 +37,9 @@ services:
     networks:
       - app-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      # Escape as $$ so the variables expand inside the container (from
+      # env_file), not at compose parse time from the host env / auto-loaded .env.
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
The db healthcheck used single-dollar `$POSTGRES_USER`/`$POSTGRES_DB`, which docker compose interpolates at parse time from the host env / auto-loaded `.env` rather than from the container's `env_file`. Escaping to `$$POSTGRES_USER`/`$$POSTGRES_DB` makes the `CMD-SHELL` expand them inside the container where the values are guaranteed present. Applied to `compose.yml` (cited) and the identical healthcheck in `compose.dev.yml`; `compose.test.yml` uses literal values and is unaffected.

Verified with `docker compose config`: before, values leaked at parse time (`-U PARSE_TIME_LEAK_USER`) and unset vars produced `"variable is not set"` warnings with an empty `-U  -d`; after, the healthcheck passes through literal `$POSTGRES_USER`/`$POSTGRES_DB` with no warnings and exit 0. Stack was not brought up.

Refs #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)