### PR TITLE
chore(docker): exclude client/node_modules from the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-node_modules
+**/node_modules
 .env
 .env.*
 .DS_Store
@@ -11,4 +11,10 @@ CLAUDE.md
 .idea
 .dockerignore
 Dockerfile
-docker-compose.yml
+compose*.yml
+server
+test-results
+playwright-report
+e2e
+helm
+.github


### PR DESCRIPTION
The bare `node_modules` pattern in `.dockerignore` is anchored to the context root, so `client/node_modules` (present on dev machines) was sent in the build context and `COPY client/ ./` layered it over the deterministic `npm ci` install, making local image builds non-reproducible. Switches to `**/node_modules` and also excludes the compiled `server` binary, `test-results`, `playwright-report`, `e2e`, `helm`, `.github`; replaces the stale `docker-compose.yml` entry with `compose*.yml`.

Verified with a real `docker build` against a synthetic context: `client/node_modules` and the other new entries are excluded, while every path the Dockerfile actually COPYs (`client/src`, `client/package.json`, `cmd/`, `internal/`, `public/`, `go.mod`) remains present — no over-exclusion.

Refs #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)