### PR TITLE
fix(helm): wire up ServiceAccount so its values are no longer dead config

### DIFF
--- a/helm/schautrack/templates/deployment.yaml
+++ b/helm/schautrack/templates/deployment.yaml
@@ -25,6 +25,8 @@ spec:
       labels:
         {{- include "schautrack.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "schautrack.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/schautrack/templates/serviceaccount.yaml
+++ b/helm/schautrack/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "schautrack.serviceAccountName" . }}
+  labels:
+    {{- include "schautrack.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/schautrack/values.yaml
+++ b/helm/schautrack/values.yaml
@@ -25,8 +25,15 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
+  # Specifies whether a service account should be created
   create: false
+  # Automatically mount the ServiceAccount's API credentials into the pod.
+  # The app does not talk to the Kubernetes API, so this is disabled by default.
+  automount: false
+  # Annotations to add to the service account
   annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
   name: ""
 
 podAnnotations: {}


### PR DESCRIPTION
The chart exposed `serviceAccount.create/annotations/name` and a `schautrack.serviceAccountName` helper but shipped no ServiceAccount template and never set `serviceAccountName` on the Deployment, so the values were dead config and the pod always ran under the namespace `default` SA with its token automounted.

Adds `templates/serviceaccount.yaml` (gated on `serviceAccount.create`) and wires `serviceAccountName` + `automountServiceAccountToken` onto the pod spec. Introduces `serviceAccount.automount` (default `false`) since the app never talks to the Kubernetes API, so the token is no longer mounted.

Verified: `helm lint` passes; `helm template` shows create=false → default SA, token unmounted, no SA object; create=true → SA object created and referenced, with name/annotations/automount toggles propagating to both objects.

Refs #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)