### PR TITLE
fix(helm): add securityContext defaults and harden the postgres pod

### DIFF
--- a/helm/schautrack/templates/deployment.yaml
+++ b/helm/schautrack/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
       initContainers:
         - name: wait-for-postgres
           image: busybox:1.36
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           command: ['sh', '-c', 'until nc -z {{ include "schautrack.postgresql.fullname" . }} 5432; do echo waiting for postgres; sleep 2; done']
       {{- end }}
       containers:

--- a/helm/schautrack/templates/postgresql-deployment.yaml
+++ b/helm/schautrack/templates/postgresql-deployment.yaml
@@ -21,8 +21,16 @@ spec:
       labels:
         {{- include "schautrack.postgresql.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.postgresql.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: postgresql
+          {{- with .Values.postgresql.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
           ports:

--- a/helm/schautrack/values.yaml
+++ b/helm/schautrack/values.yaml
@@ -30,8 +30,25 @@ serviceAccount:
   name: ""
 
 podAnnotations: {}
-podSecurityContext: {}
-securityContext: {}
+
+# Pod-level security context for the web pod (applies to init + app containers).
+# The app image runs as the non-root UID 1000 baked in at build time.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level security context for the web (and init) containers.
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+      - ALL
 
 service:
   type: ClusterIP
@@ -140,7 +157,25 @@ postgresql:
     repository: postgres
     tag: "18-alpine"
     pullPolicy: IfNotPresent
-  # Database credentials  
+  # Pod-level security context for the postgres pod.
+  # The postgres alpine image uses UID/GID 70; fsGroup makes the mounted PVC
+  # group-writable so postgres can create/own its PGDATA subdirectory.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 70
+    runAsGroup: 70
+    fsGroup: 70
+    seccompProfile:
+      type: RuntimeDefault
+  # Container-level security context for the postgres container.
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 70
+    capabilities:
+      drop:
+        - ALL
+  # Database credentials
   # ⚠️  SECURITY WARNING: Database passwords are critical secrets!
   # Use existingSecret in production - never commit passwords to Git
   auth:


### PR DESCRIPTION
Adds restricted-PSS-compliant securityContext defaults to the chart. The web pod (init + app containers) now runs as non-root UID 1000 with dropped capabilities, no privilege escalation, and RuntimeDefault seccomp. The bundled postgres Deployment — which previously had no securityContext at all — gets the same hardening with runAsUser/fsGroup 70 (the alpine postgres user); fsGroup keeps the PVC writable and PGDATA stays a 0700 `pgdata` subdirectory so postgres starts cleanly.

Verified: `helm lint` passes and `helm template` renders without error; the rendered contexts are coherent (non-root everywhere, fsGroup on the postgres volume). Docker e2e not run.

Refs #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)