### PR TITLE
ci(cleanup): prune SHA-tagged branch/PR images from GHCR

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,6 +15,7 @@ jobs:
       PACKAGE: schautrack
       OWNER: ${{ github.repository_owner }}
       KEEP_STAGING: 5
+      KEEP_SHA_DAYS: 7
     steps:
       - name: Delete untagged images older than 1 day
         env:
@@ -101,3 +102,51 @@ jobs:
               2>/dev/null && DELETED=$((DELETED + 1)) || echo "  Failed to delete $ID"
           done
           echo "Deleted $DELETED staging images (kept newest ${KEEP_STAGING})"
+
+      - name: Delete SHA-tagged branch/PR images older than ${{ env.KEEP_SHA_DAYS }} days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "=== Cleaning up SHA-tagged branch/PR images ==="
+          # build.yml tags images built for non-main/non-staging refs (PRs and
+          # other branches) with the 8-char commit SHA (VERSION="${GITHUB_SHA::8}"),
+          # and these accumulate in GHCR forever. Delete versions whose *every* tag
+          # is an 8-hex-char lowercase SHA and that are older than the cutoff.
+          # Release tags (semver like "2.3.5"), "latest", and "staging-*" all
+          # contain dots/letters/dashes and never match ^[0-9a-f]{8}$, so they are
+          # preserved; a SHA-tagged version that also carries a kept tag is skipped.
+          CUTOFF=$(date -u -d "${KEEP_SHA_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
+
+          PAGE=1
+          DELETED=0
+          while true; do
+            VERSIONS=$(gh api \
+              "/users/${OWNER}/packages/container/${PACKAGE}/versions?per_page=100&page=${PAGE}" \
+              2>/dev/null) || break
+
+            COUNT=$(echo "$VERSIONS" | jq length)
+            [ "$COUNT" -eq 0 ] && break
+
+            # Select versions whose tags are all 8-hex-char SHAs (and non-empty),
+            # older than the cutoff.
+            IDS=$(echo "$VERSIONS" | jq -r \
+              --arg cutoff "$CUTOFF" \
+              '.[]
+               | select(.metadata.container.tags | length > 0 and all(test("^[0-9a-f]{8}$")))
+               | select(.updated_at < $cutoff)
+               | .id')
+
+            for ID in $IDS; do
+              TAGS=$(echo "$VERSIONS" | jq -r \
+                --argjson id "$ID" \
+                '.[] | select(.id == $id) | .metadata.container.tags | join(", ")')
+              echo "Deleting SHA-tagged version $ID ($TAGS)"
+              gh api --method DELETE \
+                "/users/${OWNER}/packages/container/${PACKAGE}/versions/${ID}" \
+                2>/dev/null && DELETED=$((DELETED + 1)) || echo "  Failed to delete $ID"
+            done
+
+            [ "$COUNT" -lt 100 ] && break
+            PAGE=$((PAGE + 1))
+          done
+          echo "Deleted $DELETED SHA-tagged images (older than ${KEEP_SHA_DAYS} days)"


### PR DESCRIPTION
The weekly image cleanup only deleted untagged versions and old `staging-*` images. Every non-main/non-staging build (PRs and other branches) is tagged with the 8-char commit SHA, so those versions accumulated in GHCR forever. This adds a third pass that deletes versions whose tags are *all* 8-hex-char lowercase SHAs and older than `KEEP_SHA_DAYS` (7 days).

Verification: `python3 yaml.safe_load` validates the workflow; the jq filter was tested against a broad tag set — pure-SHA versions are selected while release semver (`2.3.5`/`latest`), `staging-*`, untagged, uppercase, 7/9-char, and recent-within-cutoff versions are all preserved (a SHA version that also carries a kept tag is skipped). Cleanup not actually run.

Refs #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)