### PR TITLE
test: make admin-settings e2e project run after the chromium project

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -70,12 +70,15 @@ export default defineConfig({
       },
       dependencies: ['admin-setup'],
     },
-    // Tests that modify admin_settings — run last to avoid interference
+    // Tests that modify admin_settings — must run after ALL shared-state specs
+    // finish, so depend on both `admin` and `chromium`. Without `chromium` these
+    // specs (which flip global admin_settings like enable_registration and
+    // enable_barcode) run concurrently with the chromium project and corrupt it.
     {
       name: 'admin-settings',
       testMatch: [/barcode-extended\.spec\.ts/, /legal\.spec\.ts/, /invite-code\.spec\.ts/],
       use: { ...devices['Desktop Chrome'] },
-      dependencies: ['admin'],
+      dependencies: ['admin', 'chromium'],
     },
     // Graceful shutdown — runs LAST after all other tests (kills the container)
     {


### PR DESCRIPTION
The `admin-settings` Playwright project (barcode-extended, legal, invite-code) flips global admin_settings like `enable_registration` and `enable_barcode`, but only declared `dependencies: ['admin']`. Playwright runs projects with satisfied dependencies concurrently, so these specs raced the parallel `chromium` project despite the "run last" comment. Adding `chromium` to the dependencies makes it genuinely run after all shared-state specs finish, mirroring the `shutdown` project.

Verification: `npx playwright test --list` loads the config cleanly (exit 0), resolves all 11 `admin-settings` tests, and reports no dependency-cycle error. Full docker-backed suite not run per scope.

Refs #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)