### PR TITLE
ci: gate the pipeline on an explicit client typecheck

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,29 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Run tests
+      - name: Run Go tests
         run: go test ./...
+
+      # Client type errors were previously caught only inside the Docker build
+      # (client "build" is "tsc -b && vite build"), which runs after
+      # compute-version and in parallel with create-tag — so a type regression
+      # could still get a git tag pushed with no matching image. Gate on an
+      # explicit client typecheck here in the test job, which every downstream
+      # job (compute-version -> create-tag / build-and-push) already depends on.
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install client dependencies
+        run: npm ci
+        working-directory: client
+
+      - name: Typecheck client
+        run: npm run typecheck
+        working-directory: client
 
   compute-version:
     runs-on: ${{ github.ref == 'refs/heads/staging' && 'arc-runner' || 'ubuntu-latest' }}

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "typecheck": "tsc -b --force",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
The `test` job only ran `go test ./...`; client type errors were caught only implicitly inside the Docker build (`tsc -b && vite build`), which runs after `compute-version` and in parallel with `create-tag` — so a client type regression could push a git tag with no matching image. This adds a `typecheck` script (`tsc -b --force`) to the client and runs it in the `test` job (Node 24 + `npm ci`). Since `compute-version` → `create-tag` / `build-and-push` all depend on `test`, both release paths are now gated on the client typecheck.

Verification: `yaml.safe_load` on build.yml passes; `cd client && npm ci && npm run typecheck` exits 0 on current code and exits 1 with `TS2322` on an injected type error, proving the gate actually fails on a regression. The Playwright e2e suite was intentionally not wired into CI (heavy/flaky Docker-Compose stack); the smallest reliable gating step was chosen per the issue's guidance.

Refs #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)