### PR TITLE
docs: correct RATE_LIMIT_AUTH window to 15 minutes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,7 +167,7 @@ POSTGRES_PASSWORD=schautrack
 # Set to 'false' if the app is directly exposed without a proxy
 # TRUST_PROXY=true
 
-# Max authentication attempts per minute per IP (default: 10)
+# Max authentication attempts per 15 minutes per IP (default: 10)
 # RATE_LIMIT_AUTH=10
 
 # Step-up auth grace window — how long after primary login (or a fresh

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ WebAuthn-based passwordless login with biometric verification. Users can registe
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TRUST_PROXY` | `true` | Trust `X-Forwarded-For` / `X-Real-Ip` headers for rate limiting. Set `false` for direct-access deployments without a reverse proxy. |
-| `RATE_LIMIT_AUTH` | `10` | Max authentication attempts per minute per IP |
+| `RATE_LIMIT_AUTH` | `10` | Max authentication attempts per 15 minutes per IP |
 | `STEP_UP_TTL` | `30m` | Grace window after fresh primary auth during which sensitive auth-method changes (delete passkey, disable 2FA, change password/email, etc.) are accepted without re-prompting. Any `time.ParseDuration` value. |
 
 ### Legal Pages


### PR DESCRIPTION
Fix the RATE_LIMIT_AUTH description in README.md and .env.example: they said 'per minute' but the auth limiter uses a 15-minute window.

Verified in `cmd/server/main.go:69`: `middleware.NewRateLimiter(cfg.RateLimitAuth, 15*time.Minute, cfg.TrustProxy)` — the second arg to `NewRateLimiter(max, window, ...)` (internal/middleware/ratelimit.go:28) is the window. Both docs now read 'per 15 minutes per IP'.

Refs #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)