### PR TITLE
test(service): cover parseAIResponse edge cases directly

### DIFF
--- a/internal/service/ai_test.go
+++ b/internal/service/ai_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -222,4 +223,220 @@ func keys(m map[string]any) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// openaiEnvelope wraps a raw model output string in the OpenAI/Ollama
+// chat-completions response shape, letting each test case state the model's
+// content verbatim while json.Marshal handles the escaping.
+func openaiEnvelope(content string) string {
+	b, _ := json.Marshal(map[string]any{
+		"choices": []map[string]any{{"message": map[string]any{"content": content}}},
+	})
+	return string(b)
+}
+
+// claudeEnvelope wraps a raw model output string in the Anthropic messages
+// response shape.
+func claudeEnvelope(text string) string {
+	b, _ := json.Marshal(map[string]any{
+		"content": []map[string]any{{"text": text}},
+	})
+	return string(b)
+}
+
+// TestParseAIResponse exercises parseAIResponse directly across the edge cases
+// that were previously only reached indirectly through CallAIProvider: markdown-
+// fenced and prose-wrapped JSON, the NO_FOOD_DETECTED sentinel, empty/absent
+// content, malformed provider envelopes, and the first-'{'/last-'}' slicing
+// weaknesses (two objects, trailing brace). These assertions pin *current*
+// behavior — including the known-fragile brace slicing — so a future refactor
+// becomes a deliberate, visible change rather than a silent regression.
+func TestParseAIResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		body     string
+		want     *AIResult // expected result when wantErr == ""
+		wantErr  string    // substring the error must contain; "" => expect success
+	}{
+		// --- happy paths ---
+		{
+			name:     "openai plain json",
+			provider: "openai",
+			body:     openaiEnvelope(`{"calories":250,"food":"banana","confidence":"high","macros":{"protein":3}}`),
+			want:     &AIResult{Calories: 250, Food: "banana", Confidence: "high", Macros: map[string]int{"protein": 3}},
+		},
+		{
+			name:     "claude plain json",
+			provider: "claude",
+			body:     claudeEnvelope(`{"calories":300,"food":"toast","confidence":"medium"}`),
+			want:     &AIResult{Calories: 300, Food: "toast", Confidence: "medium"},
+		},
+		{
+			name:     "ollama uses the choices envelope",
+			provider: "ollama",
+			body:     openaiEnvelope(`{"calories":90,"food":"celery"}`),
+			want:     &AIResult{Calories: 90, Food: "celery"},
+		},
+		{
+			name:     "unknown provider falls back to the choices envelope",
+			provider: "gemini",
+			body:     openaiEnvelope(`{"calories":42,"food":"olive"}`),
+			want:     &AIResult{Calories: 42, Food: "olive"},
+		},
+		{
+			name:     "markdown-fenced json is unwrapped by brace slicing",
+			provider: "openai",
+			body:     openaiEnvelope("```json\n{\"calories\":100,\"food\":\"apple\"}\n```"),
+			want:     &AIResult{Calories: 100, Food: "apple"},
+		},
+		{
+			name:     "prose-wrapped json is extracted",
+			provider: "openai",
+			body:     openaiEnvelope(`Sure! Here is the estimate: {"calories":55,"food":"grape"} Hope that helps.`),
+			want:     &AIResult{Calories: 55, Food: "grape"},
+		},
+		{
+			name:     "missing food field defaults to empty string",
+			provider: "openai",
+			body:     openaiEnvelope(`{"calories":120}`),
+			want:     &AIResult{Calories: 120},
+		},
+		{
+			name:     "unknown json fields are ignored",
+			provider: "openai",
+			body:     openaiEnvelope(`{"calories":75,"food":"kiwi","serving":"1 cup","extra":true}`),
+			want:     &AIResult{Calories: 75, Food: "kiwi"},
+		},
+		{
+			name:     "out-of-range calories pass through unclamped (range checks live in the caller)",
+			provider: "openai",
+			body:     openaiEnvelope(`{"calories":999999,"food":"cake"}`),
+			want:     &AIResult{Calories: 999999, Food: "cake"},
+		},
+		{
+			name:     "zero calories with non-sentinel food is a valid result",
+			provider: "openai",
+			body:     openaiEnvelope(`{"calories":0,"food":"Water"}`),
+			want:     &AIResult{Calories: 0, Food: "Water"},
+		},
+
+		// --- NO_FOOD_DETECTED sentinel ---
+		{
+			name:     "no-food sentinel returns NO_FOOD_DETECTED",
+			provider: "openai",
+			body:     openaiEnvelope(`{"calories":0,"food":"No food detected"}`),
+			wantErr:  "NO_FOOD_DETECTED",
+		},
+		{
+			name:     "sentinel food with non-zero calories is not treated as no-food",
+			provider: "openai",
+			body:     openaiEnvelope(`{"calories":10,"food":"No food detected"}`),
+			want:     &AIResult{Calories: 10, Food: "No food detected"},
+		},
+
+		// --- empty / absent content ---
+		{
+			name:     "empty content string",
+			provider: "openai",
+			body:     openaiEnvelope(""),
+			wantErr:  "empty AI response",
+		},
+		{
+			name:     "empty choices array",
+			provider: "openai",
+			body:     `{"choices":[]}`,
+			wantErr:  "empty AI response",
+		},
+		{
+			name:     "absent choices field",
+			provider: "openai",
+			body:     `{}`,
+			wantErr:  "empty AI response",
+		},
+		{
+			name:     "empty claude content array",
+			provider: "claude",
+			body:     `{"content":[]}`,
+			wantErr:  "empty AI response",
+		},
+		{
+			name:     "whitespace-only content is not valid JSON",
+			provider: "openai",
+			body:     openaiEnvelope("   \n\t "),
+			wantErr:  "failed to parse AI JSON",
+		},
+
+		// --- malformed provider envelopes ---
+		{
+			name:     "malformed openai envelope",
+			provider: "openai",
+			body:     `not json at all`,
+			wantErr:  "failed to parse AI response",
+		},
+		{
+			name:     "malformed claude envelope",
+			provider: "claude",
+			body:     `<html>gateway error</html>`,
+			wantErr:  "failed to parse Claude response",
+		},
+
+		// --- malformed inner JSON ---
+		{
+			name:     "content with no JSON object",
+			provider: "openai",
+			body:     openaiEnvelope("I can't identify any food in this image."),
+			wantErr:  "failed to parse AI JSON",
+		},
+		{
+			name:     "invalid inner JSON (trailing comma)",
+			provider: "openai",
+			body:     openaiEnvelope(`{"calories":100,"food":"x",}`),
+			wantErr:  "failed to parse AI JSON",
+		},
+		{
+			name:     "fractional macro rejected by int map",
+			provider: "openai",
+			body:     openaiEnvelope(`{"calories":100,"food":"x","macros":{"protein":3.5}}`),
+			wantErr:  "failed to parse AI JSON",
+		},
+
+		// --- documented first-'{'/last-'}' slicing weaknesses (pinned, not fixed) ---
+		{
+			name:     "two JSON objects break brace slicing (known weakness)",
+			provider: "openai",
+			body:     openaiEnvelope(`{"calories":100,"food":"a"} {"calories":200,"food":"b"}`),
+			wantErr:  "failed to parse AI JSON",
+		},
+		{
+			name:     "trailing brace breaks slicing (known weakness)",
+			provider: "openai",
+			body:     openaiEnvelope(`{"calories":100,"food":"a"}}`),
+			wantErr:  "failed to parse AI JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAIResponse(tt.provider, []byte(tt.body))
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("parseAIResponse() error = nil, want error containing %q (got result %+v)", tt.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("parseAIResponse() error = %q, want substring %q", err.Error(), tt.wantErr)
+				}
+				if got != nil {
+					t.Errorf("parseAIResponse() result = %+v, want nil on error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseAIResponse() unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseAIResponse() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Adds a direct table-driven unit test for `parseAIResponse` in `internal/service/ai.go`, which was previously only reached indirectly through `CallAIProvider`. Covers markdown-fenced/prose-wrapped JSON extraction, the `NO_FOOD_DETECTED` sentinel, empty/absent content, malformed openai vs claude envelopes, invalid inner JSON, and the known first-'{'/last-'}' brace-slicing weaknesses (two objects, trailing brace) — pinning current behavior rather than changing it.

Verification: `go test ./...` passes (24 new subtests execute); `go vet ./...` clean. Test-only change, no production code touched.

Refs #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)