### PR TITLE
test(e2e): isolate password.spec from the shared test user

### DIFF
--- a/e2e/password.spec.ts
+++ b/e2e/password.spec.ts
@@ -1,9 +1,33 @@
-import { test, expect } from './fixtures/auth';
-import { login } from './fixtures/auth';
+import { test, expect } from '@playwright/test';
+import { createIsolatedUser } from './fixtures/helpers';
 import { completeStepUp } from './fixtures/stepup';
 
+const baseURL = process.env.E2E_BASE_URL || 'http://localhost:3001';
+let user: { email: string; password: string; id: string };
+
+// This spec mutates its user's password. It must run against an isolated user
+// (not the shared test@test.com session) so it can't corrupt the fixed password
+// that the auth/2fa/stepup projects log in with concurrently. Both tests share
+// the isolated user and run serially so they can't clobber each other's logins.
 test.describe('Password Change', () => {
-  test('mismatched passwords are rejected client-side (no step-up triggered)', async ({ page }) => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeAll(() => {
+    user = createIsolatedUser('password');
+  });
+
+  async function login(page: import('@playwright/test').Page) {
+    await page.goto(`${baseURL}/login`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.getByLabel('Email').fill(user.email);
+    await page.getByLabel('Password').fill(user.password);
+    await page.getByRole('button', { name: 'Log In' }).click();
+    await page.waitForURL(/\/dashboard/, { timeout: 15000 });
+  }
+
+  test('mismatched passwords are rejected client-side (no step-up triggered)', async ({ browser }) => {
+    const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+    const page = await ctx.newPage();
     await login(page);
     await page.goto('/settings');
     await page.waitForURL('/settings');
@@ -20,12 +44,21 @@ test.describe('Password Change', () => {
     await expect(page.getByText(/not match|mismatch/i)).toBeVisible({ timeout: 5000 });
     // Step-up modal should not have appeared — we caught the mismatch locally.
     await expect(page.getByRole('dialog', { name: /confirm it's you/i })).not.toBeVisible();
+
+    await ctx.close();
   });
 
-  test('password change goes through step-up and round-trips', async ({ page }) => {
+  test('password change goes through step-up and round-trips', async ({ browser }) => {
+    const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+    const page = await ctx.newPage();
     await login(page);
     await page.goto('/settings');
     await page.waitForURL('/settings');
+
+    // A fresh login grants the step-up grace window (login doubles as step-up).
+    // STEP_UP_TTL=10s in compose.test.yml — wait it out so the password change
+    // actually triggers the step-up modal we want to exercise here.
+    await page.waitForTimeout(12000);
 
     const passwordHeading = page.getByText('Change Password');
     await passwordHeading.scrollIntoViewIfNeeded();
@@ -34,14 +67,16 @@ test.describe('Password Change', () => {
     await page.getByLabel('New Password').fill('newtest1234test');
     await page.getByLabel('Confirm Password').fill('newtest1234test');
     await page.getByRole('button', { name: 'Update Password' }).click();
-    await completeStepUp(page, 'test1234test');
+    await completeStepUp(page, user.password);
     await expect(page.getByText(/password updated/i).first()).toBeVisible({ timeout: 5000 });
 
-    // Change it back — should land within the step-up grace window from the
-    // first change, so no second modal expected.
-    await page.getByLabel('New Password').fill('test1234test');
-    await page.getByLabel('Confirm Password').fill('test1234test');
+    // Change it back — should land within the fresh step-up grace from the
+    // change we just completed, so no second modal expected.
+    await page.getByLabel('New Password').fill(user.password);
+    await page.getByLabel('Confirm Password').fill(user.password);
     await page.getByRole('button', { name: 'Update Password' }).click();
     await expect(page.getByText(/password updated/i).first()).toBeVisible({ timeout: 5000 });
+
+    await ctx.close();
   });
 });


### PR DESCRIPTION
password.spec mutated the shared `test@test.com` password mid-run (change to `newtest1234test` then back) while the `auth`/`2fa`/`stepup` projects log in with the fixed password concurrently, causing intermittent login failures. This switches the spec to `createIsolatedUser('password')` with fresh-context logins and serial mode — matching stepup/settings/timezone — so the shared session is never touched. Because a fresh login grants the step-up grace window, it now waits out `STEP_UP_TTL` before the gated change so the step-up modal still triggers.

Verification: `npx playwright test --list` resolves cleanly (both password tests enumerated under the `chromium` project, no transpile errors); repo has no tsconfig so `--list` is the type/transpile gate. Docker-backed e2e run not executed.

Refs #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)