### PR TITLE
test(todos): cover streak and missed-since algorithm

### DIFF
--- a/internal/handler/todos.go
+++ b/internal/handler/todos.go
@@ -314,53 +314,10 @@ func (h *TodosHandler) DayTodos(w http.ResponseWriter, r *http.Request) {
 				datesByTodo[tid] = append(datesByTodo[tid], d)
 			}
 			for _, t := range scheduled {
-				dates := datesByTodo[t.ID]
-				streak := 0
-				start, _ := time.Parse("2006-01-02", dateStr)
-				for i := 0; i < 365; i++ {
-					d := start.AddDate(0, 0, -i).Format("2006-01-02")
-					if !service.IsScheduledForDate(t.Schedule, d) {
-						continue
-					}
-					found := false
-					for _, cd := range dates {
-						if cd == d {
-							found = true
-							break
-						}
-					}
-					if found {
-						streak++
-					} else {
-						break
-					}
-				}
+				streak, ms := service.ComputeStreak(t.Schedule, datesByTodo[t.ID], dateStr)
 				streaks[t.ID] = streak
-
-				// Compute missed_since: walk backwards from the day before dateStr
-				// to find the earliest consecutive missed scheduled day
-				if !completions[t.ID] {
-					earliest := ""
-					for i := 1; i <= 30; i++ {
-						d := start.AddDate(0, 0, -i).Format("2006-01-02")
-						if !service.IsScheduledForDate(t.Schedule, d) {
-							continue
-						}
-						found := false
-						for _, cd := range dates {
-							if cd == d {
-								found = true
-								break
-							}
-						}
-						if found {
-							break
-						}
-						earliest = d
-					}
-					if earliest != "" {
-						missedSince[t.ID] = earliest
-					}
+				if ms != "" {
+					missedSince[t.ID] = ms
 				}
 			}
 		}

--- a/internal/service/todos.go
+++ b/internal/service/todos.go
@@ -46,6 +46,71 @@ func IsScheduledForDate(scheduleJSON json.RawMessage, dateStr string) bool {
 	return false
 }
 
+// ComputeStreak calculates the current completion streak and the earliest
+// consecutive missed scheduled day for a single todo, walking backwards from
+// asOf (an "YYYY-MM-DD" date). completionDates is the set of dates on which the
+// todo was completed (order and duplicates do not matter); callers pass every
+// completion on or before asOf.
+//
+// streak is the number of consecutive *scheduled* days ending at asOf
+// (inclusive) that have a completion, looking back up to 365 days. Days on
+// which the todo is not scheduled are skipped and never break the streak. The
+// walk stops at the first scheduled day without a completion, so a todo that is
+// scheduled for asOf but not yet completed yields a streak of 0.
+//
+// missedSince is the earliest scheduled day within the previous 30 days
+// (strictly before asOf) that begins the unbroken run of missed scheduled days
+// leading up to asOf. It is only reported when asOf itself has no completion; if
+// asOf is completed, or the immediately preceding scheduled day was completed,
+// missedSince is "".
+//
+// An unparseable asOf yields (0, "").
+func ComputeStreak(scheduleJSON json.RawMessage, completionDates []string, asOf string) (streak int, missedSince string) {
+	start, err := time.Parse("2006-01-02", asOf)
+	if err != nil {
+		return 0, ""
+	}
+
+	completed := make(map[string]bool, len(completionDates))
+	for _, d := range completionDates {
+		completed[d] = true
+	}
+
+	// Streak: walk backwards from asOf (inclusive), counting consecutive
+	// scheduled days that have a completion. Stop at the first scheduled,
+	// uncompleted day. Unscheduled days are skipped.
+	for i := 0; i < 365; i++ {
+		d := start.AddDate(0, 0, -i).Format("2006-01-02")
+		if !IsScheduledForDate(scheduleJSON, d) {
+			continue
+		}
+		if completed[d] {
+			streak++
+		} else {
+			break
+		}
+	}
+
+	// missed_since: only when asOf itself is not completed. Walk backwards from
+	// the day before asOf up to 30 days, recording the earliest scheduled day in
+	// the unbroken run of missed scheduled days. Stop at the first completed
+	// scheduled day.
+	if !completed[asOf] {
+		for i := 1; i <= 30; i++ {
+			d := start.AddDate(0, 0, -i).Format("2006-01-02")
+			if !IsScheduledForDate(scheduleJSON, d) {
+				continue
+			}
+			if completed[d] {
+				break
+			}
+			missedSince = d
+		}
+	}
+
+	return streak, missedSince
+}
+
 type ValidateScheduleResult struct {
 	Ok       bool
 	Schedule json.RawMessage

--- a/internal/service/todos_test.go
+++ b/internal/service/todos_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 func TestIsScheduledForDate(t *testing.T) {
@@ -17,7 +18,7 @@ func TestIsScheduledForDate(t *testing.T) {
 	}{
 		{"daily always true", daily, "2025-03-17", true},
 		{"daily any date", daily, "2025-01-01", true},
-		{"weekday match (Monday)", weekdays, "2025-03-17", true},   // Monday
+		{"weekday match (Monday)", weekdays, "2025-03-17", true},    // Monday
 		{"weekday match (Wednesday)", weekdays, "2025-03-19", true}, // Wednesday
 		{"weekday no match (Tuesday)", weekdays, "2025-03-18", false},
 		{"weekday no match (Sunday)", weekdays, "2025-03-16", false},
@@ -95,3 +96,137 @@ func TestValidateTimeOfDay(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+func TestComputeStreak(t *testing.T) {
+	daily, _ := json.Marshal(Schedule{Type: "daily"})
+	// Mon, Wed, Fri (ISO days 1, 3, 5).
+	mwf, _ := json.Marshal(Schedule{Type: "weekdays", Days: []int{1, 3, 5}})
+
+	// Reference weekdays for the March 2025 dates used below:
+	//   2025-03-17 Mon, 03-18 Tue, 03-19 Wed, 03-20 Thu, 03-21 Fri,
+	//   03-22 Sat, 03-23 Sun, 03-24 Mon.
+
+	tests := []struct {
+		name            string
+		schedule        json.RawMessage
+		completions     []string
+		asOf            string
+		wantStreak      int
+		wantMissedSince string
+	}{
+		{
+			name:            "daily perfect streak, today completed",
+			schedule:        daily,
+			completions:     []string{"2025-03-17", "2025-03-16", "2025-03-15", "2025-03-14", "2025-03-13"},
+			asOf:            "2025-03-17",
+			wantStreak:      5,
+			wantMissedSince: "", // today completed => no missed_since
+		},
+		{
+			name:            "daily with gap, today not completed",
+			schedule:        daily,
+			completions:     []string{"2025-03-15", "2025-03-14"},
+			asOf:            "2025-03-17",
+			wantStreak:      0,            // scheduled today, not completed => break at i=0
+			wantMissedSince: "2025-03-16", // 03-16 missed, 03-15 completed stops the walk
+		},
+		{
+			name:            "today scheduled but not yet completed, yesterday done",
+			schedule:        daily,
+			completions:     []string{"2025-03-16", "2025-03-15", "2025-03-14"},
+			asOf:            "2025-03-17",
+			wantStreak:      0,  // not yet completed today => streak 0 (pins existing behavior)
+			wantMissedSince: "", // yesterday completed => nothing missed yet
+		},
+		{
+			name:            "today completed, streak of one",
+			schedule:        daily,
+			completions:     []string{"2025-03-17"},
+			asOf:            "2025-03-17",
+			wantStreak:      1,
+			wantMissedSince: "",
+		},
+		{
+			name:            "empty history, walks back 30 scheduled days for missed_since",
+			schedule:        daily,
+			completions:     nil,
+			asOf:            "2025-03-17",
+			wantStreak:      0,
+			wantMissedSince: "2025-02-15", // asOf minus 30 days
+		},
+		{
+			name:            "missed_since crosses a month boundary",
+			schedule:        daily,
+			completions:     []string{"2025-02-27"},
+			asOf:            "2025-03-02",
+			wantStreak:      0,
+			wantMissedSince: "2025-02-28", // 03-01 and 02-28 missed, 02-27 completed stops it
+		},
+		{
+			name:            "weekly schedule does not break on off-days",
+			schedule:        mwf,
+			completions:     []string{"2025-03-21", "2025-03-19", "2025-03-17", "2025-03-14"},
+			asOf:            "2025-03-21", // Friday
+			wantStreak:      4,            // Fri, Wed, Mon, Fri — Tue/Thu/Sat/Sun skipped
+			wantMissedSince: "",
+		},
+		{
+			name:            "weekly missed_since only counts scheduled days",
+			schedule:        mwf,
+			completions:     []string{"2025-03-17"}, // only Monday done
+			asOf:            "2025-03-21",           // Friday, not completed
+			wantStreak:      0,
+			wantMissedSince: "2025-03-19", // Wed missed; Thu/Tue skipped; Mon completed stops it
+		},
+		{
+			name:            "unparseable asOf yields zero values",
+			schedule:        daily,
+			completions:     []string{"2025-03-17"},
+			asOf:            "not-a-date",
+			wantStreak:      0,
+			wantMissedSince: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStreak, gotMissed := ComputeStreak(tt.schedule, tt.completions, tt.asOf)
+			if gotStreak != tt.wantStreak {
+				t.Errorf("streak = %d, want %d", gotStreak, tt.wantStreak)
+			}
+			if gotMissed != tt.wantMissedSince {
+				t.Errorf("missedSince = %q, want %q", gotMissed, tt.wantMissedSince)
+			}
+		})
+	}
+}
+
+// TestComputeStreakCapsAt365 pins the 365-day look-back window: a daily todo
+// completed every day well beyond a year still reports a streak capped at 365,
+// and a single gap exactly at the far edge of the window truncates it there.
+func TestComputeStreakCapsAt365(t *testing.T) {
+	daily, _ := json.Marshal(Schedule{Type: "daily"})
+	asOf, _ := time.Parse("2006-01-02", "2025-03-17")
+
+	// Completed for 400 consecutive days ending at asOf — more than the window.
+	var full []string
+	for i := 0; i < 400; i++ {
+		full = append(full, asOf.AddDate(0, 0, -i).Format("2006-01-02"))
+	}
+	if streak, missed := ComputeStreak(daily, full, "2025-03-17"); streak != 365 || missed != "" {
+		t.Errorf("full window: got streak=%d missed=%q, want streak=365 missed=\"\"", streak, missed)
+	}
+
+	// Completed for the whole window except the day at the far edge (asOf-364):
+	// the walk should count 0..363 (364 days) then break at i=364.
+	var gapAtEdge []string
+	for i := 0; i < 400; i++ {
+		if i == 364 {
+			continue // hole exactly at the last day the loop inspects
+		}
+		gapAtEdge = append(gapAtEdge, asOf.AddDate(0, 0, -i).Format("2006-01-02"))
+	}
+	if streak, _ := ComputeStreak(daily, gapAtEdge, "2025-03-17"); streak != 364 {
+		t.Errorf("gap at window edge: got streak=%d, want 364", streak)
+	}
+}


### PR DESCRIPTION
Extracts the inline 365-day streak / 30-day missed-since walk from the `DayTodos` handler into a pure `service.ComputeStreak(schedule, completions, asOf)` and adds table-driven tests. Behavior is preserved — the handler now delegates to the extracted function.

Tests pin: daily streaks with gaps, weekly schedules spanning off-days, today-scheduled-but-uncompleted (streak 0), empty history, missed_since crossing a month boundary, and the 365-day look-back window cap.

Verification: `go test ./...` passes (11 new streak sub-tests green, handler package still green); `go vet ./...` clean.

Refs #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)