### PR TITLE
docs: document RATE_LIMIT_STRICT env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -170,6 +170,10 @@ POSTGRES_PASSWORD=schautrack
 # Max authentication attempts per minute per IP (default: 10)
 # RATE_LIMIT_AUTH=10
 
+# Max requests per 5-minute window per IP on sensitive endpoints — password-reset
+# request/confirm, 2FA reset, email-change request, and AI estimate (default: 5)
+# RATE_LIMIT_STRICT=5
+
 # Step-up auth grace window — how long after primary login (or a fresh
 # step-up) sensitive auth-method changes are accepted without re-prompting
 # the user (delete passkey, disable 2FA, change password/email, etc.).

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ WebAuthn-based passwordless login with biometric verification. Users can registe
 |----------|---------|-------------|
 | `TRUST_PROXY` | `true` | Trust `X-Forwarded-For` / `X-Real-Ip` headers for rate limiting. Set `false` for direct-access deployments without a reverse proxy. |
 | `RATE_LIMIT_AUTH` | `10` | Max authentication attempts per minute per IP |
+| `RATE_LIMIT_STRICT` | `5` | Max requests per 5-minute window per IP on sensitive endpoints (password-reset request/confirm, 2FA reset, email-change request, AI estimate) |
 | `STEP_UP_TTL` | `30m` | Grace window after fresh primary auth during which sensitive auth-method changes (delete passkey, disable 2FA, change password/email, etc.) are accepted without re-prompting. Any `time.ParseDuration` value. |
 
 ### Legal Pages


### PR DESCRIPTION
Documents the previously-undocumented `RATE_LIMIT_STRICT` env var. Adds it to the README Security table and `.env.example` next to the other rate-limit vars, with its real default (5) and 5-minute window, and lists the endpoints the strict limiter guards.

Verified against code: default 5 is set in `internal/config/config.go:96-99`; the 5-minute window and guarded endpoints (forgot/reset-password, reset-2fa, email-change request, AI estimate) come from `cmd/server/main.go:70` and the `strictLimiter.Middleware` route registrations.

Refs #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)