### PR TITLE
docs: correct AI_DAILY_LIMIT default to unlimited

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,8 @@ SESSION_SECRET=please-change-me
 # Specify AI model to use (e.g., gpt-4o, claude-sonnet-4-5-20250929, gemma3:12b). Required for OpenAI and Claude.
 # AI_MODEL=
 
-# Daily limit for AI requests per user when using global key (0 = unlimited, default: 10)
+# Daily limit for AI requests per user when using the global key (0 = unlimited).
+# Default when unset: unlimited (no cap). The Helm chart sets this to 10 by default.
 # AI_DAILY_LIMIT=10
 
 # Note: Ollama models must be downloaded before use. The docker-compose setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ The CI automatically computes semantic versions based on commit message prefixes
   2. Global admin API key (set in admin panel or environment variable)
   3. Environment variable fallback
 - **Custom endpoints:** Users can override default API endpoints for proxies or self-hosted deployments
-- **Rate limiting:** Global API key usage is limited per user per day (configurable via `AI_DAILY_LIMIT`)
+- **Rate limiting:** Global API key usage can be capped per user per day (configurable via `AI_DAILY_LIMIT`; unlimited by default)
 
 ## Environment Variables
 
@@ -198,7 +198,7 @@ AI Configuration (Global Fallbacks):
 - `AI_KEY_ENCRYPTION_SECRET`: Random 32-byte hex string used to encrypt user API keys in the database
 - `AI_ENDPOINT`: Optional custom endpoint override (leave blank to use provider defaults)
 - `AI_MODEL`: Optional model override (e.g., `gpt-4o`, `claude-sonnet-4-5-20250929`, `gemma3:12b`)
-- `AI_DAILY_LIMIT`: Daily AI request limit per user when using global key (default: unlimited)
+- `AI_DAILY_LIMIT`: Daily AI request limit per user when using global key (default: unlimited; the Helm chart sets it to 10)
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Photo-based nutrition estimation with support for OpenAI, Claude, and Ollama.
 | `AI_KEY_ENCRYPTION_SECRET` | *(empty)* | Random 32-byte hex string for encrypting user API keys |
 | `AI_ENDPOINT` | *(empty)* | Custom endpoint override (e.g., `http://your-ollama-host:11434/v1`). Leave blank to use provider defaults. |
 | `AI_MODEL` | *(empty)* | Specify AI model to use (e.g., `gpt-4o`, `claude-sonnet-4-5-20250929`, `gemma3:12b`). Required for OpenAI and Claude. |
-| `AI_DAILY_LIMIT` | `10` | Daily limit for AI requests per user when using global key (0 = unlimited) |
+| `AI_DAILY_LIMIT` | *(unset → unlimited)* | Daily limit for AI requests per user when using global key (`0` or unset = unlimited). The app applies **no** limit unless this is set via env or the admin panel. Note: the Helm chart sets this to `10` by default. |
 
 **Note:** Ollama models must be downloaded before use. The docker-compose setup automatically pulls the model specified in `AI_MODEL`. Models specified only in API requests will fail if not pre-downloaded.
 

--- a/helm/schautrack/README.md
+++ b/helm/schautrack/README.md
@@ -231,7 +231,7 @@ smtp:
 | `ai.keyEncryptionSecret` | Secret for encrypting user API keys | `""` |
 | `ai.endpoint` | Custom API endpoint | `""` |
 | `ai.model` | Model override (e.g., `gpt-4o`, `claude-sonnet-4-5-20250929`, `gemma3:12b`) | `""` |
-| `ai.dailyLimit` | Daily requests per user (0 = unlimited) | `10` |
+| `ai.dailyLimit` | Daily requests per user (0 = unlimited). The app defaults to unlimited; this chart sets `10`. | `10` |
 
 ### SMTP
 


### PR DESCRIPTION
Fix the documented default for `AI_DAILY_LIMIT`. The app applies **no** per-user AI request cap unless the var is set via env or the admin panel — `internal/config/config.go:89` parses it with no fallback (unlike `RATE_LIMIT_AUTH`), and `internal/handler/ai.go` only enforces a limit when `dailyLimit > 0`. The value `10` only exists in the Helm chart's `values.yaml`.

Verified against the code and aligned all four docs (README, .env.example, CLAUDE.md, Helm README) to agree: app default = unlimited (0), Helm chart = 10.

Refs #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)