### PR TITLE
docs: clarify SMTP powers all transactional email, not just password reset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,8 +121,11 @@ SESSION_SECRET=please-change-me
 # ENABLE_REGISTRATION=open
 
 # =============================================================================
-# SMTP (Password Reset)
+# SMTP (Transactional Email)
 # =============================================================================
+# Enables all transactional email flows: password reset, registration email
+# verification, email-change verification, and 2FA reset. Without SMTP, none
+# of these flows can deliver their codes.
 
 # SMTP_HOST=
 # SMTP_PORT=587

--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ Photo-based nutrition estimation with support for OpenAI, Claude, and Ollama.
 
 **Note:** Ollama models must be downloaded before use. The docker-compose setup automatically pulls the model specified in `AI_MODEL`. Models specified only in API requests will fail if not pre-downloaded.
 
-### SMTP (Password Reset)
+### SMTP (Transactional Email)
+
+Configuring SMTP enables all transactional email flows: password reset, registration email verification, email-change verification, and 2FA reset. Without SMTP configured, none of these flows can deliver their codes.
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/helm/schautrack/README.md
+++ b/helm/schautrack/README.md
@@ -177,7 +177,9 @@ ai:
 
 > **Note:** Ollama models must be downloaded before use. Models specified in API requests will fail if not pre-downloaded on your Ollama server.
 
-### Enabling SMTP (password reset)
+### Enabling SMTP (transactional email)
+
+Configuring SMTP enables all transactional email flows: password reset, registration email verification, email-change verification, and 2FA reset. Without SMTP configured, none of these flows can deliver their codes.
 
 ```yaml
 smtp:


### PR DESCRIPTION
Both the root README and the helm README labelled SMTP as "(Password Reset)" only, but the email service also sends registration email verification, email-change verification, and 2FA-reset emails — self-hosters could skip SMTP without realizing those flows depend on it.

Renamed the sections to "Transactional Email" and listed all four flows in README.md, .env.example, and helm/schautrack/README.md.

Verified against `internal/service/email.go` (SendPasswordResetEmail, SendVerificationEmail, SendEmailChangeVerification, Send2FAResetEmail) and their handler call sites (auth_password.go, auth.go, auth_email.go, auth_helpers.go) — all four flows require a configured SMTP server.

Refs #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)