### PR TITLE
docs(contributing): add build/test instructions and fix branch workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,78 @@
 
 Thanks for your interest in contributing!
 
-## How to Contribute
+## Branch Workflow
 
-1. Fork the repository
-2. Create a feature branch from `main`
-3. Make your changes
-4. Submit a merge request to `main`
+This project integrates through `staging`, not `main`:
+
+1. Fork the repository (or, if you have push access, create a topic branch).
+2. Create a feature branch from `staging` (e.g. `fix-entry-validation`).
+3. Make your changes and commit them.
+4. Open a **pull request against `staging`**.
+
+`staging` is the integration branch: it builds a `staging-*` container image and
+publishes the Helm chart to the staging channel. Releases flow from `staging` to
+`main` — merging to `main` auto-computes a semver tag, publishes the stable Helm
+chart, and creates a GitHub Release. Do **not** target `main` directly with
+feature PRs.
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) prefixes
+(`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, …) — CI derives the release
+version from them.
+
+## Development Setup
+
+Prerequisites: Docker + Docker Compose, Go (version pinned in `go.mod`), and
+Node.js + npm (for the client build and the end-to-end suite).
+
+Run the app locally with the dev compose stack (app + PostgreSQL):
+
+```bash
+docker compose -f compose.dev.yml up -d --build
+```
+
+The web app is then available at http://localhost:3000. Environment variables
+are read from a local `.env` file — copy `.env.example` to `.env` and adjust as
+needed.
+
+The React client lives in `client/`. To iterate on the frontend with hot reload:
+
+```bash
+cd client
+npm install
+npm run dev      # Vite dev server
+npm run build    # type-check (tsc -b) + production build
+```
+
+## Running Tests
+
+**Go backend** — unit/integration tests run with the standard toolchain (this is
+the same `test` job that gates CI):
+
+```bash
+go test ./...
+```
+
+**End-to-end (Playwright)** — the root `package.json` is a thin test harness. Its
+`test:e2e` script builds and starts the full stack defined in `compose.test.yml`
+(app on port 3001, PostgreSQL, Mailpit), seeds a test user, then runs the
+Playwright suite in `e2e/`:
+
+```bash
+npm install                       # installs @playwright/test + tsx (root deps)
+npx playwright install chromium   # one-time: download the browser
+npm run test:e2e
+```
+
+Related scripts:
+
+- `npm run test:e2e:ui` — run the suite with the Playwright UI.
+- `npm run test:e2e:setup` — bring the test stack up and seed the user, then
+  leave it running (useful for iterating on individual specs).
+- `npm run test:e2e:down` — tear the test stack down and remove its volumes.
+
+Please add or update tests for any behavior you change, and run both `go test
+./...` and the e2e suite before opening a pull request.
 
 ## Copyright Assignment
 


### PR DESCRIPTION
Expands CONTRIBUTING.md with real build/test instructions and corrects the branch workflow. Documents the compose.dev.yml dev setup (app at localhost:3000), the client dev/build scripts, `go test ./...`, and the `npm run test:e2e` harness (root package.json driving compose.test.yml + Playwright). Fixes the workflow to feature branch -> PR into `staging` (releases flow staging -> main) and replaces the GitLab "merge request" wording with "pull request".

Verification: every documented command was checked against source — `go test ./...` (CI `test` job + go.mod Go 1.26), `test:e2e`/`:ui`/`:setup`/`:down` (root package.json), `compose.dev.yml` port 3000 and `compose.test.yml` port 3001, client `dev`/`build` (client/package.json), chromium browser (playwright.config.ts). Branch target confirmed by recent PRs #157–#171 all basing on `staging`, with #159 promoting staging -> main.

Refs #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)