### PR TITLE
docs: document CAPTCHA feature and CAPTCHA_BYPASS escape hatch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,6 +176,16 @@ POSTGRES_PASSWORD=schautrack
 # Any value parsed by Go's time.ParseDuration. Default: 30m.
 # STEP_UP_TTL=30m
 
+# CAPTCHA (SVG, self-hosted, no third-party service) protects login,
+# registration, and verification-email resend against brute-force abuse.
+# It is always on and needs no configuration.
+#
+# TEST-ONLY ESCAPE HATCH — DO NOT SET IN PRODUCTION.
+# When 'true', ANY non-empty CAPTCHA answer is accepted, disabling
+# brute-force protection entirely. It exists solely so the E2E test
+# suite (compose.test.yml) can drive auth flows. Default: unset (off).
+# CAPTCHA_BYPASS=true
+
 # =============================================================================
 # SEO / DEPLOYMENT
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Schautrack is built to stay out of your way. Log calories and macros, set goals,
 - Daily notes and recurring todos with streak tracking
 - Account linking to share data with friends
 - Two-factor authentication (TOTP) with backup codes
+- Brute-force protection with CAPTCHA challenges on login, registration, and verification-email resend
 - Invite-only registration mode
 - Real-time updates via Server-Sent Events (SSE)
 - Docker and Kubernetes ready (~21MB image)
@@ -185,6 +186,10 @@ WebAuthn-based passwordless login with biometric verification. Users can registe
 | `TRUST_PROXY` | `true` | Trust `X-Forwarded-For` / `X-Real-Ip` headers for rate limiting. Set `false` for direct-access deployments without a reverse proxy. |
 | `RATE_LIMIT_AUTH` | `10` | Max authentication attempts per minute per IP |
 | `STEP_UP_TTL` | `30m` | Grace window after fresh primary auth during which sensitive auth-method changes (delete passkey, disable 2FA, change password/email, etc.) are accepted without re-prompting. Any `time.ParseDuration` value. |
+
+**CAPTCHA:** A self-generated SVG CAPTCHA guards against brute-force and abuse. It is always required to complete registration and to resend a verification email, and is triggered on login after 3 failed attempts (counted per session, per account, and per client IP). No third-party CAPTCHA service or key is needed — it works out of the box.
+
+> **`CAPTCHA_BYPASS`** (default: unset) — a **test-only** escape hatch. When set to `true`, `VerifyCaptcha` accepts *any* non-empty answer, disabling CAPTCHA protection entirely. It exists so the end-to-end test suite (`compose.test.yml`) can drive auth flows headlessly. **Never set this in production** — doing so removes all brute-force protection from login and registration.
 
 ### Legal Pages
 


### PR DESCRIPTION
Documents the previously-undocumented SVG CAPTCHA and its `CAPTCHA_BYPASS` test escape hatch. The CAPTCHA guards login (after 3 failed attempts, per session/account/IP), registration (always), and verification-email resend; `CAPTCHA_BYPASS=true` makes any non-empty answer pass and was referenced only in `compose.test.yml`.

Added to README (Features + Security) and `.env.example`, with an explicit test-only / never-in-production warning.

Verification: cross-checked against `internal/service/captcha.go` (bypass reads `os.Getenv("CAPTCHA_BYPASS")`, default unset), `internal/handler/login_failures.go` (threshold 3), and the register/resend flows in `auth.go` / `auth_email.go`. Docs-only change, no code touched.

Refs #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)