### PR TITLE
perf(client): load Noto Sans web font asynchronously to unblock first paint

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -10,7 +10,8 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <!-- Noto Sans is loaded asynchronously from main.tsx so it never blocks first paint. -->
+    <noscript><link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" /></noscript>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -6,6 +6,17 @@ import ErrorBoundary from '@/components/ErrorBoundary';
 import App from './App';
 import '@/styles/global.css';
 
+// Load the Noto Sans web font stylesheet asynchronously instead of as a
+// render-blocking <link> in index.html, so first paint isn't delayed by the
+// DNS+TLS round trips to fonts.googleapis.com/fonts.gstatic.com. Injecting it
+// from the bundle (script-src 'self') keeps the CSP intact — the inline
+// media=print/onload swap would be blocked by our script-src policy.
+const fontStylesheet = document.createElement('link');
+fontStylesheet.rel = 'stylesheet';
+fontStylesheet.href =
+  'https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&display=swap';
+document.head.appendChild(fontStylesheet);
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {


### PR DESCRIPTION
Removes the render-blocking Google Fonts `<link rel="stylesheet">` from `client/index.html` and injects the Noto Sans stylesheet from `main.tsx` instead, so first paint no longer waits on DNS+TLS to fonts.googleapis.com/gstatic.com. Preconnect hints are kept and a `<noscript>` fallback preserves the font without JS. The dependency itself is intentionally kept (self-hosting is #150 item #07's scope); the CSP is unchanged because `script-src 'self'` rules out the inline `media=print/onload` swap, so bundling the injection stays policy-compliant.

Verified with `cd client && npm run build`: the emitted `dist/index.html` has no render-blocking Google Fonts `<link>` in the critical path (only the `<noscript>` fallback) and the font URL now ships in the JS bundle.

Refs #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)