### PR TITLE
perf(middleware): skip session + full-user fetch for static asset requests

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -118,8 +118,13 @@ func main() {
 	r.Use(middleware.Recovery)
 	r.Use(middleware.MaxBodySize(15 << 20)) // 15MB global limit
 	r.Use(middleware.SecurityHeaders)
-	r.Use(session.Middleware(sessionStore))
-	r.Use(middleware.AttachUser(pool))
+	// Static asset requests (Vite build output, favicons, logos, fonts) never
+	// read the session or the current user, so skip the session load + full
+	// 19-column users SELECT for them — a single page load fans out to ~a dozen
+	// such requests. Authenticated /api/ and /events/ routes are never
+	// classified static and keep the full session + user pipeline.
+	r.Use(middleware.SkipStaticAssets(session.Middleware(sessionStore)))
+	r.Use(middleware.SkipStaticAssets(middleware.AttachUser(pool)))
 	r.Use(middleware.RememberClientTimezone)
 
 	// SEO routes

--- a/internal/middleware/static.go
+++ b/internal/middleware/static.go
@@ -1,0 +1,68 @@
+package middleware
+
+import (
+	"net/http"
+	"path"
+	"strings"
+)
+
+// staticAssetExts are file extensions for assets the SPA file server returns
+// verbatim (Vite build output, favicons, logos, fonts, imprint SVGs). None of
+// these paths are handled by a route that reads the session or the current
+// user, so bypassing the auth middlewares for them is safe. Notably absent are
+// generic extensions like .json / .html that could collide with dynamic
+// content — being conservative here only forgoes an optimization, never
+// weakens auth.
+var staticAssetExts = map[string]bool{
+	".js": true, ".mjs": true, ".css": true, ".map": true,
+	".png": true, ".jpg": true, ".jpeg": true, ".gif": true,
+	".webp": true, ".avif": true, ".ico": true, ".svg": true,
+	".woff": true, ".woff2": true, ".ttf": true, ".otf": true, ".eot": true,
+	".webmanifest": true,
+}
+
+// IsStaticAsset reports whether r is a safe-to-bypass request for a static
+// asset — Vite build output under /assets/, or a root file with a static
+// extension (favicons, logos, fonts). Such requests are served by the SPA file
+// server (or the settings-only imprint SVG handlers) and never consult the
+// session or the current user.
+//
+// Only GET/HEAD requests match, and never anything under /api/ or /events/, so
+// every authenticated API route and the SSE stream keep their full session +
+// user pipeline. Misclassifying here can only skip an optimization, not expose
+// a protected route: RequireLogin/RequireAdmin still run on their own groups
+// and would reject a request that reached them without a user.
+func IsStaticAsset(r *http.Request) bool {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		return false
+	}
+	p := r.URL.Path
+	if strings.HasPrefix(p, "/api/") || strings.HasPrefix(p, "/events/") {
+		return false
+	}
+	if strings.HasPrefix(p, "/assets/") {
+		return true
+	}
+	return staticAssetExts[strings.ToLower(path.Ext(p))]
+}
+
+// SkipStaticAssets wraps a middleware so it is bypassed for static asset
+// requests (see IsStaticAsset). Static files are served without ever reading
+// the session or the current user, so running the session SELECT + the
+// full 19-column users SELECT for each one just multiplies DB round trips per
+// page view — a single dashboard load fans out to ~a dozen such requests.
+//
+// Non-static requests run the wrapped middleware unchanged, preserving the
+// exact ordering and behavior of the original chain.
+func SkipStaticAssets(mw func(http.Handler) http.Handler) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		wrapped := mw(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if IsStaticAsset(r) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			wrapped.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/static_test.go
+++ b/internal/middleware/static_test.go
@@ -1,0 +1,96 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsStaticAsset(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		want   bool
+	}{
+		// Static assets that should bypass the auth middlewares.
+		{"vite asset js", http.MethodGet, "/assets/index-DOugxfrc.js", true},
+		{"vite asset css", http.MethodGet, "/assets/index-abc123.css", true},
+		{"vite asset nested", http.MethodGet, "/assets/fonts/noto.woff2", true},
+		{"root favicon 32", http.MethodGet, "/favicon-32.png", true},
+		{"root favicon 16", http.MethodGet, "/favicon-16.png", true},
+		{"apple touch icon", http.MethodGet, "/apple-touch-icon.png", true},
+		{"logo", http.MethodGet, "/logo.png", true},
+		{"og image jpg", http.MethodGet, "/og-image.jpg", true},
+		{"oidc logo svg", http.MethodGet, "/oidc-logos/google.svg", true},
+		{"imprint svg", http.MethodGet, "/imprint/address.svg", true},
+		{"uppercase extension", http.MethodGet, "/LOGO.PNG", true},
+		{"head request for asset", http.MethodHead, "/assets/index-DOugxfrc.js", true},
+
+		// Dynamic / authenticated routes that must keep the full pipeline.
+		{"api dashboard", http.MethodGet, "/api/dashboard", false},
+		{"api me", http.MethodGet, "/api/me", false},
+		{"api asset-looking path", http.MethodGet, "/api/report.png", false},
+		{"sse stream", http.MethodGet, "/events/entries", false},
+		{"spa root", http.MethodGet, "/", false},
+		{"spa client route", http.MethodGet, "/dashboard", false},
+		{"index html not classified", http.MethodGet, "/index.html", false},
+		{"top-level overview", http.MethodGet, "/overview", false},
+		{"barcode lookup", http.MethodGet, "/api/barcode/12345", false},
+
+		// Non-GET/HEAD methods are never static, even for asset-looking paths.
+		{"post to asset path", http.MethodPost, "/assets/index.js", false},
+		{"post to logo", http.MethodPost, "/logo.png", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(tt.method, tt.path, nil)
+			if got := IsStaticAsset(r); got != tt.want {
+				t.Errorf("IsStaticAsset(%s %s) = %v, want %v", tt.method, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSkipStaticAssets(t *testing.T) {
+	// Marker middleware records whether it ran and forwards the request.
+	newMarker := func(ran *bool) func(http.Handler) http.Handler {
+		return func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				*ran = true
+				next.ServeHTTP(w, r)
+			})
+		}
+	}
+
+	t.Run("bypasses wrapped middleware for static asset", func(t *testing.T) {
+		var mwRan, handlerRan bool
+		final := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { handlerRan = true })
+		h := SkipStaticAssets(newMarker(&mwRan))(final)
+
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/assets/app.js", nil))
+
+		if mwRan {
+			t.Error("wrapped middleware ran for a static asset request; want bypass")
+		}
+		if !handlerRan {
+			t.Error("downstream handler did not run for a static asset request")
+		}
+	})
+
+	t.Run("runs wrapped middleware for dynamic route", func(t *testing.T) {
+		var mwRan, handlerRan bool
+		final := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { handlerRan = true })
+		h := SkipStaticAssets(newMarker(&mwRan))(final)
+
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/dashboard", nil))
+
+		if !mwRan {
+			t.Error("wrapped middleware did not run for a dynamic route; auth would be skipped")
+		}
+		if !handlerRan {
+			t.Error("downstream handler did not run for a dynamic route")
+		}
+	})
+}


### PR DESCRIPTION
`AttachUser` and `session.Middleware` were applied globally, so a logged-in user paid a session SELECT plus a 19-column `users` SELECT on every static asset request (each JS/CSS chunk, favicon, logo) — ~a dozen redundant DB round trips per page load that the file server never consumes.

This adds `IsStaticAsset` (GET/HEAD only, never `/api/` or `/events/`, only `/assets/` or a whitelisted static extension) and a `SkipStaticAssets` wrapper, and routes both DB-heavy middlewares through it. Authenticated API and SSE routes are never classified static, so their full session + user pipeline is unchanged; `RequireLogin`/`RequireAdmin` still gate their own groups.

Verification: `go build ./...`, `go vet ./...`, and `go test ./...` all pass; added table tests for the classifier and the wrapper bypass/passthrough.

Refs #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)