### PR TITLE
feat(client): add SEO and social metadata to SPA shell

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,6 +5,34 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <meta name="theme-color" content="#070d1a" />
     <title>Schautrack</title>
+    <meta
+      name="description"
+      content="Schautrack is a self-hostable, open-source nutrition tracker — log calories, macros, and weight, set goals, and share progress with friends."
+    />
+    <link rel="canonical" href="https://schautrack.com/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Schautrack" />
+    <meta property="og:url" content="https://schautrack.com/" />
+    <meta property="og:title" content="Schautrack — Self-hosted nutrition tracker" />
+    <meta
+      property="og:description"
+      content="Self-hostable, open-source nutrition tracker — log calories, macros, and weight, set goals, and share progress with friends."
+    />
+    <meta property="og:image" content="https://schautrack.com/og-image.jpg" />
+    <meta property="og:image:alt" content="Schautrack — self-hosted nutrition tracker" />
+    <meta property="og:locale" content="en" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Schautrack — Self-hosted nutrition tracker" />
+    <meta
+      name="twitter:description"
+      content="Self-hostable, open-source nutrition tracker — log calories, macros, and weight, set goals, and share progress with friends."
+    />
+    <meta name="twitter:image" content="https://schautrack.com/og-image.jpg" />
+
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />


### PR DESCRIPTION
Adds the missing SEO/social meta tags to the SPA shell (`client/index.html`): a meta description, Open Graph tags (type, site_name, url, title, description, image, image:alt, locale), a Twitter `summary_large_image` card, and a canonical link. This wires up the previously orphaned `public/og-image.jpg` (served at `/og-image.jpg` from `public/`) so search snippets and link previews for the landing page render correctly.

Verified: `cd client && npm run build` succeeds and `client/dist/index.html` contains all the new tags; confirmed `public/og-image.jpg` exists and is served at web root by the Go SPA fallback handler.

Refs #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)