### PR TITLE
perf(client): code-split barcode/AI modals and route pages

### DIFF
--- a/client/src/components/Layout/Layout.tsx
+++ b/client/src/components/Layout/Layout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { Outlet } from 'react-router';
 import Header from './Header';
 import Footer from './Footer';
@@ -7,7 +8,9 @@ export default function Layout() {
     <div className="flex min-h-screen flex-col overflow-x-hidden">
       <Header />
       <main className="mx-auto w-full max-w-[1100px] flex-1 px-4 pt-2 pb-8 overflow-x-hidden">
-        <Outlet />
+        <Suspense fallback={null}>
+          <Outlet />
+        </Suspense>
       </main>
       <Footer />
     </div>

--- a/client/src/pages/Dashboard/EntryForm.tsx
+++ b/client/src/pages/Dashboard/EntryForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef, lazy, Suspense } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import type { AIUsage } from '@/types';
 import { createEntry } from '@/api/entries';
@@ -8,8 +8,12 @@ import { parseAmount } from '@/lib/mathParser';
 import { Button } from '@/components/ui/Button';
 import { QuantityStepper } from '@/components/ui/QuantityStepper';
 import { useToastStore } from '@/stores/toastStore';
-import AIPhotoModal from './AIPhotoModal';
-import BarcodeScanModal from './BarcodeScanModal';
+
+// Lazy-loaded so their chunks (BarcodeScanModal pulls in the heavy quagga2
+// barcode decoder) are only fetched when a user first opens a scanner, rather
+// than eagerly on every page load.
+const AIPhotoModal = lazy(() => import('./AIPhotoModal'));
+const BarcodeScanModal = lazy(() => import('./BarcodeScanModal'));
 
 interface Props {
   selectedDate: string;
@@ -37,6 +41,14 @@ export default function EntryForm({ selectedDate, caloriesEnabled, autoCalcCalor
   const [savingFood, setSavingFood] = useState(false);
   const [localAiUsage, setLocalAiUsage] = useState<AIUsage | null>(aiUsage);
   const queryClient = useQueryClient();
+
+  // Once a modal has been opened it stays mounted (kept alive by these latches)
+  // so its existing close-cleanup effects keep running; it just isn't mounted —
+  // and its chunk isn't fetched — until the first open.
+  const aiModalMounted = useRef(false);
+  const barcodeModalMounted = useRef(false);
+  if (aiModalOpen) aiModalMounted.current = true;
+  if (barcodeModalOpen) barcodeModalMounted.current = true;
 
   useEffect(() => {
     setLocalAiUsage(aiUsage);
@@ -314,27 +326,35 @@ export default function EntryForm({ selectedDate, caloriesEnabled, autoCalcCalor
         </div>
       </form>
 
-      <AIPhotoModal
-        isOpen={aiModalOpen}
-        onClose={() => setAiModalOpen(false)}
-        onResult={(result) => {
-          applyResult(result);
-          setLocalAiUsage((u) => u && u.limit > 0 ? { ...u, used: u.used + 1, remaining: Math.max(0, u.remaining - 1) } : u);
-          setAiModalOpen(false);
-        }}
-        enabledMacros={enabledMacros}
-        providerName={aiProviderName}
-      />
+      {aiModalMounted.current && (
+        <Suspense fallback={null}>
+          <AIPhotoModal
+            isOpen={aiModalOpen}
+            onClose={() => setAiModalOpen(false)}
+            onResult={(result) => {
+              applyResult(result);
+              setLocalAiUsage((u) => u && u.limit > 0 ? { ...u, used: u.used + 1, remaining: Math.max(0, u.remaining - 1) } : u);
+              setAiModalOpen(false);
+            }}
+            enabledMacros={enabledMacros}
+            providerName={aiProviderName}
+          />
+        </Suspense>
+      )}
 
-      <BarcodeScanModal
-        isOpen={barcodeModalOpen}
-        onClose={() => setBarcodeModalOpen(false)}
-        onResult={(result) => {
-          applyResult(result);
-          setBarcodeModalOpen(false);
-        }}
-        enabledMacros={enabledMacros}
-      />
+      {barcodeModalMounted.current && (
+        <Suspense fallback={null}>
+          <BarcodeScanModal
+            isOpen={barcodeModalOpen}
+            onClose={() => setBarcodeModalOpen(false)}
+            onResult={(result) => {
+              applyResult(result);
+              setBarcodeModalOpen(false);
+            }}
+            enabledMacros={enabledMacros}
+          />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -1,3 +1,4 @@
+import { lazy } from 'react';
 import { Routes, Route, Navigate } from 'react-router';
 import { useAuthStore } from '@/stores/authStore';
 import Layout from '@/components/Layout/Layout';
@@ -7,14 +8,17 @@ import Register from '@/pages/Register/Register';
 import ForgotPassword from '@/pages/ForgotPassword/ForgotPassword';
 import ResetPassword from '@/pages/ResetPassword/ResetPassword';
 import VerifyEmail from '@/pages/VerifyEmail/VerifyEmail';
-import Dashboard from '@/pages/Dashboard/Dashboard';
-import Settings from '@/pages/Settings/Settings';
-import Admin from '@/pages/Admin/Admin';
-import Privacy from '@/pages/Legal/Privacy';
-import Terms from '@/pages/Legal/Terms';
-import Imprint from '@/pages/Legal/Imprint';
-import DeleteAccount from '@/pages/Delete/DeleteAccount';
-import VerifyEmailChange from '@/pages/VerifyEmailChange/VerifyEmailChange';
+
+// The authenticated and legal pages are code-split into their own chunks so
+// the initial (unauthenticated) load no longer ships the entire app.
+const Dashboard = lazy(() => import('@/pages/Dashboard/Dashboard'));
+const Settings = lazy(() => import('@/pages/Settings/Settings'));
+const Admin = lazy(() => import('@/pages/Admin/Admin'));
+const Privacy = lazy(() => import('@/pages/Legal/Privacy'));
+const Terms = lazy(() => import('@/pages/Legal/Terms'));
+const Imprint = lazy(() => import('@/pages/Legal/Imprint'));
+const DeleteAccount = lazy(() => import('@/pages/Delete/DeleteAccount'));
+const VerifyEmailChange = lazy(() => import('@/pages/VerifyEmailChange/VerifyEmailChange'));
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { user, isLoading } = useAuthStore();


### PR DESCRIPTION
Lazy-loads the barcode scanner and AI-photo modals (via React.lazy) so quagga2 lands in its own chunk fetched only when the scanner first opens, and code-splits the authenticated/legal route pages behind a Suspense boundary. Behaviour-preserving: a mount latch keeps each modal mounted after first open so the existing camera/scanner cleanup effects still run.

Verification (`cd client && npm run build`):
- Before: single `index-*.js` = 669.58 kB (gzip 192.26 kB)
- After: main `index-*.js` = 229.01 kB (gzip 69.71 kB), with quagga2 isolated in `BarcodeScanModal-*.js` = 163.94 kB (gzip 45.92 kB); grep confirms 0 quagga references in the main chunk and index.html no longer preloads it. The >500 kB chunk warning is gone.

Refs #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)