### PR TITLE
feat(observability): structured HTTP access-logging middleware

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -115,6 +115,10 @@ func main() {
 
 	// Router
 	r := chi.NewRouter()
+	// AccessLog is outermost so it observes the final committed status (including
+	// Recovery's 500s) and emits one structured request log — the only source of
+	// request rates, latencies and error counts this deployment has.
+	r.Use(middleware.AccessLog(cfg.TrustProxy))
 	r.Use(middleware.Recovery)
 	r.Use(middleware.MaxBodySize(15 << 20)) // 15MB global limit
 	r.Use(middleware.SecurityHeaders)

--- a/internal/middleware/accesslog.go
+++ b/internal/middleware/accesslog.go
@@ -1,0 +1,111 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"schautrack/internal/clientip"
+)
+
+// AccessLog emits one structured slog record per HTTP request with the method,
+// path, status, byte count, latency and client IP. It gives operators the
+// request rates, latencies and error counts the deployment otherwise exposes
+// nowhere (there is no metrics/pprof endpoint), so problems like SSE kills or
+// rate-limit abuse can be diagnosed from the pod logs.
+//
+// It is meant to sit at the very top of the chi middleware chain so it observes
+// the final committed status, including responses written by the Recovery
+// middleware. The response wrapper is deliberately transparent: it forwards
+// Flush and exposes Unwrap so long-lived SSE streams and
+// http.NewResponseController (used by the SSE handler to clear its write
+// deadline) keep working.
+//
+// The path is logged without its query string on purpose: query strings carry
+// OIDC authorization codes and other short-lived secrets that must not land in
+// logs. The health endpoint is skipped so Kubernetes liveness/readiness probes
+// do not drown the access log.
+func AccessLog(trustProxy bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/health" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			start := time.Now()
+			lw := &accessLogWriter{ResponseWriter: w}
+			next.ServeHTTP(lw, r)
+
+			status := lw.status
+			if status == 0 {
+				// Handler flushed/closed without an explicit WriteHeader or
+				// Write (e.g. a hijacked or immediately-closed connection).
+				status = http.StatusOK
+			}
+
+			attrs := []any{
+				"method", r.Method,
+				"path", r.URL.Path,
+				"status", status,
+				"bytes", lw.bytes,
+				"duration_ms", time.Since(start).Milliseconds(),
+				"ip", clientip.FromRequest(r, trustProxy),
+			}
+
+			switch {
+			case status >= 500:
+				slog.Error("http request", attrs...)
+			case status >= 400:
+				slog.Warn("http request", attrs...)
+			default:
+				slog.Info("http request", attrs...)
+			}
+		})
+	}
+}
+
+// accessLogWriter records the response status and byte count while forwarding
+// everything else to the wrapped ResponseWriter. It implements Flush and Unwrap
+// so it stays invisible to SSE flushing and http.NewResponseController.
+type accessLogWriter struct {
+	http.ResponseWriter
+	status      int
+	bytes       int
+	wroteHeader bool
+}
+
+func (w *accessLogWriter) WriteHeader(code int) {
+	if !w.wroteHeader {
+		w.status = code
+		w.wroteHeader = true
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *accessLogWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.status = http.StatusOK
+		w.wroteHeader = true
+	}
+	n, err := w.ResponseWriter.Write(b)
+	w.bytes += n
+	return n, err
+}
+
+// Flush forwards to the underlying Flusher so SSE streams keep working.
+func (w *accessLogWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		if !w.wroteHeader {
+			w.status = http.StatusOK
+			w.wroteHeader = true
+		}
+		f.Flush()
+	}
+}
+
+// Unwrap lets http.NewResponseController reach the underlying writer (the SSE
+// handler uses it to clear the per-response write deadline).
+func (w *accessLogWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}

--- a/internal/middleware/accesslog_test.go
+++ b/internal/middleware/accesslog_test.go
@@ -1,0 +1,135 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// captureLogs redirects slog to a buffer for the duration of fn and returns the
+// decoded JSON records that were emitted.
+func captureLogs(t *testing.T, fn func()) []map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	fn()
+
+	var recs []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("bad log line %q: %v", line, err)
+		}
+		recs = append(recs, m)
+	}
+	return recs
+}
+
+func TestAccessLogRecordsStatusAndLevel(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    int
+		wantLevel string
+	}{
+		{"ok", http.StatusOK, "INFO"},
+		{"client error", http.StatusBadRequest, "WARN"},
+		{"server error", http.StatusInternalServerError, "ERROR"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := AccessLog(false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(c.status)
+				_, _ = w.Write([]byte("hi"))
+			}))
+
+			var recs []map[string]any
+			captureFn := func() {
+				rec := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodGet, "/entries", nil)
+				h.ServeHTTP(rec, req)
+			}
+			recs = captureLogs(t, captureFn)
+
+			if len(recs) != 1 {
+				t.Fatalf("want 1 log record, got %d", len(recs))
+			}
+			m := recs[0]
+			if m["level"] != c.wantLevel {
+				t.Errorf("level = %v, want %v", m["level"], c.wantLevel)
+			}
+			if got := int(m["status"].(float64)); got != c.status {
+				t.Errorf("status = %d, want %d", got, c.status)
+			}
+			if got := int(m["bytes"].(float64)); got != 2 {
+				t.Errorf("bytes = %d, want 2", got)
+			}
+			if m["method"] != http.MethodGet || m["path"] != "/entries" {
+				t.Errorf("method/path = %v %v, want GET /entries", m["method"], m["path"])
+			}
+		})
+	}
+}
+
+func TestAccessLogSkipsHealth(t *testing.T) {
+	h := AccessLog(false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	recs := captureLogs(t, func() {
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/health", nil))
+	})
+	if len(recs) != 0 {
+		t.Fatalf("health probe should not be logged, got %d records", len(recs))
+	}
+}
+
+// flushRecorder is an httptest.ResponseRecorder that also reports whether Flush
+// was called, so we can assert the wrapper forwards flushes (required for SSE).
+type flushRecorder struct {
+	*httptest.ResponseRecorder
+	flushed bool
+}
+
+func (f *flushRecorder) Flush() { f.flushed = true }
+
+func TestAccessLogWriterPreservesFlushAndUnwrap(t *testing.T) {
+	fr := &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
+	var seenFlusher, seenUnwrap bool
+
+	h := AccessLog(false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if f, ok := w.(http.Flusher); ok {
+			seenFlusher = true
+			f.Flush()
+		}
+		type unwrapper interface{ Unwrap() http.ResponseWriter }
+		if u, ok := w.(unwrapper); ok {
+			seenUnwrap = true
+			if u.Unwrap() != fr {
+				t.Errorf("Unwrap did not return the underlying writer")
+			}
+		}
+	}))
+
+	captureLogs(t, func() {
+		h.ServeHTTP(fr, httptest.NewRequest(http.MethodGet, "/events/entries", nil))
+	})
+
+	if !seenFlusher {
+		t.Error("wrapper does not expose http.Flusher — SSE would break")
+	}
+	if !seenUnwrap {
+		t.Error("wrapper does not expose Unwrap — http.NewResponseController would break")
+	}
+	if !fr.flushed {
+		t.Error("Flush was not forwarded to the underlying writer")
+	}
+}


### PR DESCRIPTION
Addresses issue #150 item #01 (observability gap). The chi middleware stack had no request-logging middleware and the app exposes no metrics/pprof/expvar, so a Helm-deployed instance surfaced no request rates, latencies, error counts, or access logs — operators could not diagnose issues like SSE kills or rate-limit abuse.

**Delivered:** an `AccessLog` middleware, wired as the outermost entry in the chi chain, that emits one structured slog record per request (`method`, `path`, `status`, `bytes`, `duration_ms`, `ip`) with the log level keyed off the status class (5xx→Error, 4xx→Warn, else Info) so error counts are greppable. The response wrapper forwards `Flush()` and exposes `Unwrap()` so SSE streams and `http.NewResponseController` (which the SSE handler uses to clear its write deadline) keep working. The query string is dropped on purpose (avoids logging OIDC auth codes/tokens) and `/api/health` is skipped to avoid Kubernetes probe spam. Ships with unit tests covering status/level mapping, the health skip, and the Flush/Unwrap chain.

**Follow-up (out of scope for this focused slice):** a Prometheus `/metrics` endpoint and a flag-gated `/debug/pprof` are still absent — the remaining halves of this observability item.

**Verification:** `go build ./...` and `go vet ./...` clean; `go test ./internal/middleware/ ./internal/session/ ./internal/sse/ ./internal/clientip/` all pass (new access-log tests included). Docker e2e not run.

Refs #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)