### PR TITLE
perf(sse): cache linked-user targets instead of querying the DB per broadcast

### DIFF
--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -751,6 +751,11 @@ func (h *LinksHandler) LinkRespond(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// The accepted-links set of both parties just changed; drop their cached
+		// broadcast targets so entry updates start flowing across the new link
+		// immediately instead of after the broker cache TTL.
+		h.Broker.InvalidateLinks(user.ID, requesterID)
+
 		h.Broker.BroadcastLinkChange(requesterID, "accepted", map[string]any{
 			"linkId": body.RequestID, "userId": user.ID, "email": user.Email,
 		})
@@ -797,6 +802,11 @@ func (h *LinksHandler) LinkRemove(w http.ResponseWriter, r *http.Request) {
 	if delRequesterID != user.ID {
 		otherID = delRequesterID
 	}
+
+	// Removing (or cancelling) a link changes the accepted-links set of both
+	// parties; drop their cached broadcast targets so updates stop crossing the
+	// removed link immediately instead of after the broker cache TTL.
+	h.Broker.InvalidateLinks(user.ID, otherID)
 
 	if delStatus == "accepted" {
 		h.Broker.BroadcastLinkChange(otherID, "removed", map[string]any{"linkId": body.LinkID})

--- a/internal/sse/broker.go
+++ b/internal/sse/broker.go
@@ -14,17 +14,30 @@ import (
 	"schautrack/internal/service"
 )
 
+// linkCacheEntry holds a resolved set of accepted-link user IDs for one source
+// user together with its expiry.
+type linkCacheEntry struct {
+	linked  []int
+	expires time.Time
+}
+
 // Broker manages SSE connections per user.
 type Broker struct {
 	mu      sync.RWMutex
 	clients map[int]map[chan []byte]struct{}
 	pool    *pgxpool.Pool
+
+	// linkMu guards linkCache, a short-TTL cache of each user's accepted-link
+	// target IDs so a burst of broadcasts does not repeat the same DB lookup.
+	linkMu    sync.Mutex
+	linkCache map[int]linkCacheEntry
 }
 
 func NewBroker(pool *pgxpool.Pool) *Broker {
 	b := &Broker{
-		clients: make(map[int]map[chan []byte]struct{}),
-		pool:    pool,
+		clients:   make(map[int]map[chan []byte]struct{}),
+		pool:      pool,
+		linkCache: make(map[int]linkCacheEntry),
 	}
 	go b.cleanupLoop()
 	return b
@@ -184,19 +197,77 @@ func (b *Broker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// linkCacheTTL bounds how long a resolved accepted-links set is reused between
+// broadcasts. It absorbs bursts of rapid mutations — which would otherwise each
+// issue an identical link lookup — while keeping staleness small even if an
+// explicit invalidation were ever missed. Link accept/remove call
+// InvalidateLinks, so newly (un)linked users take effect immediately.
+const linkCacheTTL = 5 * time.Second
+
 func (b *Broker) getTargets(sourceUserID int) []int {
-	targets := []int{sourceUserID}
+	// If nobody at all is connected, no event can be delivered to any user, so
+	// resolving link targets would be pure waste — e.g. mutations from the
+	// mobile app or API while no dashboard is open.
+	b.mu.RLock()
+	anyClients := len(b.clients) > 0
+	b.mu.RUnlock()
+	if !anyClients {
+		return nil
+	}
+
+	// Serve the linked-user set from the cache while it is fresh.
+	if linked, ok := b.cachedLinks(sourceUserID); ok {
+		return append([]int{sourceUserID}, linked...)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	links, err := service.GetAcceptedLinkUsers(ctx, b.pool, sourceUserID)
 	if err != nil {
+		// Don't cache failures — fall back to just the source user.
 		slog.Error("failed to load linked users for broadcast", "error", err)
-		return targets
+		return []int{sourceUserID}
 	}
+	linked := make([]int, 0, len(links))
 	for _, link := range links {
-		targets = append(targets, link.UserID)
+		linked = append(linked, link.UserID)
 	}
-	return targets
+	b.storeLinks(sourceUserID, linked)
+	return append([]int{sourceUserID}, linked...)
+}
+
+// cachedLinks returns the cached accepted-link target IDs for userID when a
+// fresh entry exists. The returned slice is owned by the cache and must not be
+// mutated by callers (getTargets only ever appends it onto a fresh slice).
+func (b *Broker) cachedLinks(userID int) ([]int, bool) {
+	b.linkMu.Lock()
+	defer b.linkMu.Unlock()
+	entry, ok := b.linkCache[userID]
+	if !ok || time.Now().After(entry.expires) {
+		return nil, false
+	}
+	return entry.linked, true
+}
+
+func (b *Broker) storeLinks(userID int, linked []int) {
+	b.linkMu.Lock()
+	defer b.linkMu.Unlock()
+	if b.linkCache == nil {
+		b.linkCache = make(map[int]linkCacheEntry)
+	}
+	b.linkCache[userID] = linkCacheEntry{linked: linked, expires: time.Now().Add(linkCacheTTL)}
+}
+
+// InvalidateLinks drops any cached accepted-links set for the given users so the
+// next broadcast re-resolves it from the database. Callers in the link handlers
+// invoke this whenever a user's set of accepted links changes (accept/remove),
+// which keeps real-time delivery correct without waiting for the TTL.
+func (b *Broker) InvalidateLinks(userIDs ...int) {
+	b.linkMu.Lock()
+	defer b.linkMu.Unlock()
+	for _, id := range userIDs {
+		delete(b.linkCache, id)
+	}
 }
 
 func (b *Broker) cleanupLoop() {

--- a/internal/sse/broker_test.go
+++ b/internal/sse/broker_test.go
@@ -198,6 +198,74 @@ func TestConcurrentSubscribeUnsubscribeSendEvent(t *testing.T) {
 	}
 }
 
+func TestGetTargetsShortCircuitsWithNoClients(t *testing.T) {
+	// The test broker has a nil pool: if getTargets reached the DB it would
+	// panic. With no subscribers, it must short-circuit before the lookup.
+	b := newTestBroker()
+	if got := b.getTargets(1); got != nil {
+		t.Fatalf("expected nil targets when no clients are connected, got %v", got)
+	}
+}
+
+func TestGetTargetsUsesCacheWithoutQueryingDB(t *testing.T) {
+	// nil pool: reaching the DB would panic. A subscribed client pushes
+	// getTargets past the short-circuit, so a pre-seeded cache must satisfy it.
+	b := newTestBroker()
+	ch := b.Subscribe(1)
+	defer b.Unsubscribe(1, ch)
+
+	b.storeLinks(1, []int{2, 3})
+	got := b.getTargets(1)
+
+	if len(got) != 3 || got[0] != 1 {
+		t.Fatalf("expected [1 2 3] with source first, got %v", got)
+	}
+	seen := map[int]bool{}
+	for _, id := range got {
+		seen[id] = true
+	}
+	if !seen[1] || !seen[2] || !seen[3] {
+		t.Fatalf("expected targets to include 1,2,3; got %v", got)
+	}
+}
+
+func TestGetTargetsDoesNotAliasCache(t *testing.T) {
+	b := newTestBroker()
+	ch := b.Subscribe(1)
+	defer b.Unsubscribe(1, ch)
+
+	b.storeLinks(1, []int{2})
+	got := b.getTargets(1)
+	got[len(got)-1] = 999 // mutating the returned slice must not corrupt the cache
+
+	linked, ok := b.cachedLinks(1)
+	if !ok || len(linked) != 1 || linked[0] != 2 {
+		t.Fatalf("cache was mutated through the returned slice: %v", linked)
+	}
+}
+
+func TestInvalidateLinksForcesRefresh(t *testing.T) {
+	b := newTestBroker()
+	b.storeLinks(1, []int{2})
+	if _, ok := b.cachedLinks(1); !ok {
+		t.Fatal("expected a fresh cache entry after storeLinks")
+	}
+	b.InvalidateLinks(1)
+	if _, ok := b.cachedLinks(1); ok {
+		t.Fatal("expected a cache miss after InvalidateLinks")
+	}
+}
+
+func TestCachedLinksExpires(t *testing.T) {
+	b := newTestBroker()
+	b.linkCache = map[int]linkCacheEntry{
+		1: {linked: []int{2}, expires: time.Now().Add(-time.Second)},
+	}
+	if _, ok := b.cachedLinks(1); ok {
+		t.Fatal("expected an expired cache entry to miss")
+	}
+}
+
 func TestServeHTTPRejectsNilContext(t *testing.T) {
 	b := newTestBroker()
 	req := httptest.NewRequest("GET", "/events", nil)


### PR DESCRIPTION
The SSE broker ran the `GetAcceptedLinkUsers` JOIN on every entry/todo/saved-food/note broadcast — including when no client was subscribed at all, and once per mutation during rapid bursts. `getTargets` now short-circuits when the broker has zero subscribers and caches each user's linked-target IDs for a short 5s TTL so bursts share one lookup. Link accept/remove call the new `Broker.InvalidateLinks` so newly (un)linked users take effect immediately; the TTL bounds staleness if an invalidation is ever missed. The cache has its own mutex and returned slices are never aliased.

Verified: `go build ./...`, `go vet ./...`, `go test ./...`, and `go test -race ./internal/sse/...` all pass, including new tests for the short-circuit, cache hit, no-alias guarantee, invalidation, and TTL expiry.

Refs #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)