### PR TITLE
fix(email): enforce SMTP TLS and add a send timeout

### DIFF
--- a/internal/service/email.go
+++ b/internal/service/email.go
@@ -2,13 +2,25 @@ package service
 
 import (
 	"crypto/rand"
+	"crypto/tls"
 	"fmt"
 	"log"
 	"math/big"
+	"net"
 	"net/smtp"
+	"strconv"
 	"strings"
+	"time"
 
 	"schautrack/internal/config"
+)
+
+// SMTP timeouts bound the whole send so a hung or slow mail server can never
+// block the synchronous auth handlers (registration / password-reset / 2FA-reset)
+// that call SendEmail. Declared as vars so tests can shrink them.
+var (
+	smtpDialTimeout = 10 * time.Second
+	smtpDeadline    = 30 * time.Second
 )
 
 type EmailService struct {
@@ -31,16 +43,7 @@ func (es *EmailService) SendEmail(to, subject, text, html string) error {
 	from := es.cfg.SMTPFrom
 	msg := buildMimeMessage(from, to, subject, text, html)
 
-	addr := fmt.Sprintf("%s:%d", es.cfg.SMTPHost, es.cfg.SMTPPort)
-
-	// Only use auth when SMTP credentials are provided (e.g., MailPit doesn't support AUTH)
-	var auth smtp.Auth
-	if es.cfg.SMTPUser != "" {
-		auth = smtp.PlainAuth("", es.cfg.SMTPUser, es.cfg.SMTPPass, es.cfg.SMTPHost)
-	}
-
-	err := smtp.SendMail(addr, auth, from, []string{to}, []byte(msg))
-	if err != nil {
+	if err := es.send(from, to, []byte(msg)); err != nil {
 		// Log the raw SMTP detail server-side only; callers must surface a
 		// generic message. Swallowing the error here made every caller
 		// report success even when nothing was sent — combined with the
@@ -49,6 +52,92 @@ func (es *EmailService) SendEmail(to, subject, text, html string) error {
 		return fmt.Errorf("email send failed: %w", err)
 	}
 	return nil
+}
+
+// send delivers a single message with a bounded timeout and TLS handling driven
+// by the existing SMTP config contract:
+//
+//   - SMTPSecure=true  → implicit TLS from the first byte (SMTPS, typically :465).
+//   - SMTPSecure=false → STARTTLS on a plaintext connection (typically :587).
+//     STARTTLS is opportunistic for credential-less dev servers (MailPit, which
+//     advertises neither STARTTLS nor AUTH) but *mandatory* whenever credentials
+//     are configured, so codes/credentials are never sent over an unencrypted
+//     link just because the server failed to advertise STARTTLS.
+//
+// It mirrors smtp.SendMail but adds a dial + full-exchange deadline; the stdlib
+// helper has neither, so a stalled server would wedge the calling auth handler.
+func (es *EmailService) send(from, to string, msg []byte) error {
+	host := es.cfg.SMTPHost
+	addr := net.JoinHostPort(host, strconv.Itoa(es.cfg.SMTPPort))
+
+	// Only use auth when SMTP credentials are provided (e.g., MailPit doesn't support AUTH)
+	var auth smtp.Auth
+	if es.cfg.SMTPUser != "" {
+		auth = smtp.PlainAuth("", es.cfg.SMTPUser, es.cfg.SMTPPass, host)
+	}
+
+	dialer := &net.Dialer{Timeout: smtpDialTimeout}
+
+	var conn net.Conn
+	var err error
+	if es.cfg.SMTPSecure {
+		conn, err = tls.DialWithDialer(dialer, "tcp", addr, &tls.Config{ServerName: host})
+	} else {
+		conn, err = dialer.Dial("tcp", addr)
+	}
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	// Bound the whole SMTP exchange (greeting, EHLO, TLS, auth, data) so a
+	// stalled server cannot block the caller indefinitely.
+	if err := conn.SetDeadline(time.Now().Add(smtpDeadline)); err != nil {
+		return err
+	}
+
+	c, err := smtp.NewClient(conn, host)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	if !es.cfg.SMTPSecure {
+		if ok, _ := c.Extension("STARTTLS"); ok {
+			if err := c.StartTLS(&tls.Config{ServerName: host}); err != nil {
+				return err
+			}
+		} else if auth != nil {
+			return fmt.Errorf("SMTP server %s does not advertise STARTTLS; refusing to send credentials over an unencrypted connection", host)
+		}
+	}
+
+	if auth != nil {
+		if ok, _ := c.Extension("AUTH"); !ok {
+			return fmt.Errorf("SMTP server %s does not support AUTH", host)
+		}
+		if err := c.Auth(auth); err != nil {
+			return err
+		}
+	}
+
+	if err := c.Mail(from); err != nil {
+		return err
+	}
+	if err := c.Rcpt(to); err != nil {
+		return err
+	}
+	w, err := c.Data()
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(msg); err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	return c.Quit()
 }
 
 func (es *EmailService) SendVerificationEmail(email, code string) error {

--- a/internal/service/email_test.go
+++ b/internal/service/email_test.go
@@ -1,11 +1,42 @@
 package service
 
 import (
+	"bufio"
+	"fmt"
+	"io"
 	"net"
+	"strings"
 	"testing"
+	"time"
 
 	"schautrack/internal/config"
 )
+
+// startFakeSMTP starts a minimal in-process SMTP server that runs handle for
+// each accepted connection, and returns a config pointing at it. The listener
+// is torn down when the test ends.
+func startFakeSMTP(t *testing.T, handle func(net.Conn)) *config.Config {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go handle(conn)
+		}
+	}()
+	return &config.Config{
+		SMTPHost: "127.0.0.1",
+		SMTPPort: ln.Addr().(*net.TCPAddr).Port,
+		SMTPFrom: "noreply@example.com",
+	}
+}
 
 // closedPortConfig returns an SMTP config pointing at a local port that is
 // guaranteed to be closed (we bind it, learn the number, then release it), so
@@ -37,6 +68,59 @@ func TestSendEmail_SMTPFailureReturnsError(t *testing.T) {
 	err := es.SendEmail("to@example.com", "subject", "text body", "<p>html</p>")
 	if err == nil {
 		t.Fatal("SendEmail against a closed SMTP port returned nil, want error")
+	}
+}
+
+// A credentialed send against a server that does not advertise STARTTLS must
+// fail rather than silently transmit credentials/codes over plaintext.
+func TestSendEmail_RequiresStartTLSWhenAuthenticated(t *testing.T) {
+	cfg := startFakeSMTP(t, func(conn net.Conn) {
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		fmt.Fprint(conn, "220 fake ESMTP\r\n")
+		if _, err := br.ReadString('\n'); err != nil { // EHLO
+			return
+		}
+		// Advertise neither STARTTLS nor AUTH.
+		fmt.Fprint(conn, "250-fake\r\n250 SIZE 10240000\r\n")
+		io.Copy(io.Discard, br) // drain until the client hangs up
+	})
+	cfg.SMTPUser = "user"
+	cfg.SMTPPass = "pass"
+
+	es := NewEmailService(cfg)
+	err := es.SendEmail("to@example.com", "s", "t", "")
+	if err == nil {
+		t.Fatal("SendEmail with credentials against a non-TLS server returned nil, want error")
+	}
+	if !strings.Contains(err.Error(), "STARTTLS") {
+		t.Errorf("error = %v, want it to mention refusing to send without STARTTLS", err)
+	}
+}
+
+// A hung SMTP server (accepts the connection but never speaks) must not block
+// the caller indefinitely — the deadline has to fire.
+func TestSendEmail_TimesOutOnHungServer(t *testing.T) {
+	orig := smtpDeadline
+	smtpDeadline = 150 * time.Millisecond
+	t.Cleanup(func() { smtpDeadline = orig })
+
+	cfg := startFakeSMTP(t, func(conn net.Conn) {
+		defer conn.Close()
+		time.Sleep(2 * time.Second) // never send the greeting
+	})
+
+	es := NewEmailService(cfg)
+	done := make(chan error, 1)
+	go func() { done <- es.SendEmail("to@example.com", "s", "t", "") }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("SendEmail against a hung server returned nil, want a timeout error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("SendEmail did not return within the deadline; the send is not time-bounded")
 	}
 }
 


### PR DESCRIPTION
Addresses issue #150 item #03 (SMTP transport security and robustness). Wires up the previously-ignored `SMTPSecure` config field: `SMTPSecure=true` now uses implicit TLS (:465), and `SMTPSecure=false` keeps STARTTLS on :587 but makes it **mandatory whenever credentials are configured** so codes/credentials are never sent in plaintext. Adds a dial + full-exchange deadline so a hung SMTP server can no longer block the synchronous registration/password-reset/2FA-reset handlers.

Remaining follow-up (out of scope here): moving email sends off the request goroutine entirely (async/queued) and configurable per-message retries; the other #150 subsystem items are separate.

Verification: `go build ./...`, `go vet ./...` (clean), `go test ./...` (all pass) including new tests for STARTTLS enforcement and the timeout. Reasoned through the happy path: protonmail :587/STARTTLS with auth and MailPit dev (no auth/no TLS) both still send.

Refs #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)