### PR TITLE
perf(dashboard): single-scan totals and concurrent self-view queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	golang.org/x/crypto v0.53.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.21.0
 )
 
 require (
@@ -29,7 +30,6 @@ require (
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/tinylib/msgp v1.6.4 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 )

--- a/internal/handler/entries.go
+++ b/internal/handler/entries.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/sync/errgroup"
 
 	"schautrack/internal/config"
 	"schautrack/internal/database"
@@ -94,19 +95,77 @@ func (h *EntriesHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	mu := service.ParseMacroUser(user.MacrosEnabled, user.MacroGoals, user.DailyGoal, user.GoalThreshold)
-	totalsByDate, err := getTotalsByDate(r, h.Pool, user.ID, oldest, newest)
-	if err != nil {
+	macroModes := service.GetMacroModes(mu)
+	enabledMacros := service.GetEnabledMacros(mu)
+	macroGoals := service.GetMacroGoals(mu)
+	dailyGoal := service.GetCalorieGoal(mu)
+
+	// Resolve AI availability up front (user key / global settings — no DB round
+	// trip) so the usage lookup can join the concurrent batch below.
+	hasAiEnabled := user.AIKey != nil && *user.AIKey != ""
+	usingGlobalKey := false
+	if !hasAiEnabled {
+		globalKey := h.Settings.GetEffectiveSetting(r.Context(), "ai_key", h.Cfg.AIKey)
+		hasAiEnabled = globalKey.Value != nil && *globalKey.Value != ""
+		if hasAiEnabled {
+			usingGlobalKey = true
+		}
+	}
+
+	// The viewer's own dashboard data is a set of independent reads over the same
+	// user; run them concurrently (the linked-user views below already are). Only
+	// the totals scan is fatal — the rest degrade to empty/zero exactly like the
+	// previous sequential `_`-swallowed calls did.
+	var (
+		totalsByDate    map[string]int
+		macroTotalsAll  map[string]map[string]int
+		entries         []map[string]any
+		acceptedLinks   []service.LinkUser
+		weightEntry     *service.WeightResult
+		lastWeightEntry *service.WeightResult
+		aiUsedToday     int
+	)
+	g, gctx := errgroup.WithContext(r.Context())
+	g.Go(func() error {
+		var err error
+		totalsByDate, macroTotalsAll, err = getTotalsAndMacrosByDate(gctx, h.Pool, user.ID, oldest, newest)
+		return err
+	})
+	g.Go(func() error {
+		entries = getEntriesForDate(r, h.Pool, user.ID, selectedDate, enabledMacros, userTz)
+		return nil
+	})
+	g.Go(func() error {
+		acceptedLinks, _ = service.GetAcceptedLinkUsers(gctx, h.Pool, user.ID)
+		return nil
+	})
+	g.Go(func() error {
+		weightEntry, _ = service.GetWeightEntry(gctx, h.Pool, user.ID, selectedDate)
+		return nil
+	})
+	g.Go(func() error {
+		lastWeightEntry, _ = service.GetLastWeightEntry(gctx, h.Pool, user.ID, selectedDate)
+		return nil
+	})
+	if hasAiEnabled {
+		g.Go(func() error {
+			aiUsedToday, _ = service.GetAIUsageToday(gctx, h.Pool, user.ID)
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
 		slog.Error("dashboard: failed to load calorie totals", "error", err)
 		ErrorJSON(w, http.StatusInternalServerError, "Failed to load entries")
 		return
 	}
+
 	todayTotal := totalsByDate[todayStr]
-	macroModes := service.GetMacroModes(mu)
-	enabledMacros := service.GetEnabledMacros(mu)
-	macroGoals := service.GetMacroGoals(mu)
+	// Only expose macro totals downstream when macros are enabled, preserving the
+	// prior behaviour where macroTotalsByDate stayed nil (so todayMacroTotals and
+	// the JSON payload are identical for macro-disabled users).
 	var macroTotalsByDate map[string]map[string]int
 	if len(enabledMacros) > 0 {
-		macroTotalsByDate, _ = service.GetMacroTotalsByDate(r.Context(), h.Pool, user.ID, oldest, newest)
+		macroTotalsByDate = macroTotalsAll
 	}
 	todayMacroTotals := map[string]int{}
 	if macroTotalsByDate != nil {
@@ -114,7 +173,6 @@ func (h *EntriesHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 			todayMacroTotals = t
 		}
 	}
-	dailyGoal := service.GetCalorieGoal(mu)
 
 	dailyStats := buildDailyStats(dayOptions, totalsByDate, dailyGoal, enabledMacros, macroGoals, macroModes, macroTotalsByDate, mu.GoalThreshold)
 
@@ -146,9 +204,6 @@ func (h *EntriesHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 		goalDelta = &d
 	}
 
-	// Fetch entries for selected date
-	entries := getEntriesForDate(r, h.Pool, user.ID, selectedDate, enabledMacros, userTz)
-
 	// Macro statuses
 	macroStatuses := map[string]service.MacroStatus{}
 	for _, key := range enabledMacros {
@@ -161,12 +216,7 @@ func (h *EntriesHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 		macroStatuses[key] = service.ComputeMacroStatus(total, goalPtr, macroModes[key], mu.GoalThreshold)
 	}
 
-	// Links
-	acceptedLinks, _ := service.GetAcceptedLinkUsers(r.Context(), h.Pool, user.ID)
-
 	// Weight
-	weightEntry, _ := service.GetWeightEntry(r.Context(), h.Pool, user.ID, selectedDate)
-	lastWeightEntry, _ := service.GetLastWeightEntry(r.Context(), h.Pool, user.ID, selectedDate)
 	var viewWeight any
 	if weightEntry != nil {
 		timeFormatted := service.FormatTimeInTz(weightEntry.UpdatedAt, userTz)
@@ -209,7 +259,7 @@ func (h *EntriesHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 			linkOldest := linkDayOptions[len(linkDayOptions)-1]
 			linkNewest := linkDayOptions[0]
 			linkGoal := service.GetCalorieGoal(lmu)
-			linkTotals, err := getTotalsByDate(r, h.Pool, link.UserID, linkOldest, linkNewest)
+			linkTotals, linkMacroAll, err := getTotalsAndMacrosByDate(r.Context(), h.Pool, link.UserID, linkOldest, linkNewest)
 			if err != nil {
 				// Skip this link's card rather than rendering all-zero
 				// totals as if they were real data.
@@ -221,7 +271,7 @@ func (h *EntriesHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 			linkMacroModes := service.GetMacroModes(lmu)
 			var linkMacroTotals map[string]map[string]int
 			if len(linkEnabledMacros) > 0 {
-				linkMacroTotals, _ = service.GetMacroTotalsByDate(r.Context(), h.Pool, link.UserID, linkOldest, linkNewest)
+				linkMacroTotals = linkMacroAll
 			}
 			stats := buildDailyStats(linkDayOptions, linkTotals, linkGoal, linkEnabledMacros, linkMacroGoals, linkMacroModes, linkMacroTotals, lmu.GoalThreshold)
 			label := link.Email
@@ -243,21 +293,11 @@ func (h *EntriesHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// AI status: show button if user has personal key OR global key is available
-	hasAiEnabled := user.AIKey != nil && *user.AIKey != ""
-	usingGlobalKey := false
-	if !hasAiEnabled {
-		globalKey := h.Settings.GetEffectiveSetting(r.Context(), "ai_key", h.Cfg.AIKey)
-		hasAiEnabled = globalKey.Value != nil && *globalKey.Value != ""
-		if hasAiEnabled {
-			usingGlobalKey = true
-		}
-	}
-
-	// Compute AI usage for display
+	// Compute AI usage for display. hasAiEnabled/usingGlobalKey were resolved and
+	// the usage count (aiUsedToday) was fetched in the concurrent batch above.
 	var aiUsage any
 	if hasAiEnabled {
-		usedToday, _ := service.GetAIUsageToday(r.Context(), h.Pool, user.ID)
+		usedToday := aiUsedToday
 		var dailyLimit int
 		if usingGlobalKey {
 			dailyLimitSetting := h.Settings.GetEffectiveSetting(r.Context(), "ai_daily_limit", os.Getenv("AI_DAILY_LIMIT"))
@@ -303,8 +343,8 @@ func (h *EntriesHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 			"totpEnabled": user.TOTPEnabled, "macrosEnabled": macrosEnabledAny,
 			"macroGoals": macroGoalsAny, "goalThreshold": mu.GoalThreshold,
 			"preferredAiProvider": user.PreferredAIProvider,
-			"hasAiKey": user.AIKey != nil && *user.AIKey != "",
-			"aiModel": user.AIModel, "aiDailyLimit": user.AIDailyLimit,
+			"hasAiKey":            user.AIKey != nil && *user.AIKey != "",
+			"aiModel":             user.AIModel, "aiDailyLimit": user.AIDailyLimit,
 			"todosEnabled": user.TodosEnabled,
 		},
 		"dailyGoal": dailyGoal, "todayTotal": todayTotal,
@@ -312,10 +352,10 @@ func (h *EntriesHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 		"dailyStats": dailyStats, "dayOptions": dayOptions, "selectedDate": selectedDate,
 		"recentEntries": entries, "sharedViews": sharedViews,
 		"weightUnit": user.WeightUnit, "timeZone": userTz, "todayStr": todayStrTz,
-		"range": map[string]any{"start": oldest, "end": newest, "days": len(dayOptions), "preset": nilInt(rangePreset)},
+		"range":       map[string]any{"start": oldest, "end": newest, "days": len(dayOptions), "preset": nilInt(rangePreset)},
 		"weightEntry": viewWeight, "lastWeightEntry": lastWeightEntry,
 		"hasAiEnabled": hasAiEnabled, "aiUsage": aiUsage, "aiProviderName": h.getAIProviderName(r, user),
-		"barcodeEnabled": h.isBarcodeEnabled(r.Context()),
+		"barcodeEnabled":  h.isBarcodeEnabled(r.Context()),
 		"caloriesEnabled": caloriesEnabled, "autoCalcCalories": autoCalcCalories,
 		"enabledMacros": enabledMacros, "macroGoals": macroGoals,
 		"todayMacroTotals": todayMacroTotals, "macroLabels": service.MacroLabels,

--- a/internal/handler/entries_helpers.go
+++ b/internal/handler/entries_helpers.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"log/slog"
 	"math"
 	"net/http"
@@ -88,6 +89,50 @@ func getTotalsByDate(r *http.Request, pool *pgxpool.Pool, userID int, oldest, ne
 		return nil, err
 	}
 	return result, nil
+}
+
+// getTotalsAndMacrosByDate scans the calorie_entries range a single time and
+// returns both the per-day calorie totals and the per-day macro totals. It
+// replaces the two separate range scans (getTotalsByDate + GetMacroTotalsByDate)
+// on the Dashboard's hot path. The macro map is always populated; callers with
+// no macros enabled simply ignore it. The results are byte-for-byte identical to
+// the two-query version (SUM(amount) and the COALESCE'd macro SUMs, grouped by
+// entry_date over the same user_id/date range).
+func getTotalsAndMacrosByDate(ctx context.Context, pool *pgxpool.Pool, userID int, oldest, newest string) (map[string]int, map[string]map[string]int, error) {
+	rows, err := pool.Query(ctx, `
+		SELECT entry_date,
+			SUM(amount) AS total,
+			COALESCE(SUM(protein_g), 0) AS protein,
+			COALESCE(SUM(carbs_g), 0) AS carbs,
+			COALESCE(SUM(fat_g), 0) AS fat,
+			COALESCE(SUM(fiber_g), 0) AS fiber,
+			COALESCE(SUM(sugar_g), 0) AS sugar
+		FROM calorie_entries
+		WHERE user_id = $1 AND entry_date BETWEEN $2 AND $3
+		GROUP BY entry_date`, userID, oldest, newest)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+
+	totals := map[string]int{}
+	macros := make(map[string]map[string]int)
+	for rows.Next() {
+		var date string
+		var total, protein, carbs, fat, fiber, sugar int
+		if err := rows.Scan(&date, &total, &protein, &carbs, &fat, &fiber, &sugar); err != nil {
+			continue
+		}
+		totals[date] = total
+		macros[date] = map[string]int{
+			"protein": protein, "carbs": carbs, "fat": fat, "fiber": fiber, "sugar": sugar,
+		}
+	}
+	// Propagate mid-iteration errors instead of returning partial totals.
+	if err := rows.Err(); err != nil {
+		return nil, nil, err
+	}
+	return totals, macros, nil
 }
 
 func buildDailyStats(dayOptions []string, totalsByDate map[string]int, dailyGoal *int, enabledMacros []string, macroGoals map[string]int, macroModes map[string]string, macroTotalsByDate map[string]map[string]int, threshold int) []dailyStat {


### PR DESCRIPTION
Collapses the Dashboard's duplicate `calorie_entries` range scan into a single grouped query (`getTotalsAndMacrosByDate`, used by both the self view and the per-link views) and runs the viewer's independent self-view reads (totals, entries, links, weight, last-weight, AI-usage) concurrently via `errgroup` — the linked-user views already were. Results are preserved exactly: only the totals scan is fatal, the other reads still degrade to empty/zero, and macro totals are exposed downstream only when macros are enabled so the JSON payload is byte-for-byte identical. Overview is left untouched (out of scope).

Verified: `go build ./...`, `go vet ./...`, `go test ./...` all pass; diff reviewed for identical output and correct error/cancellation handling.

Refs #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)