### PR TITLE
docs(i18n): internationalization design note and phased migration plan

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,260 @@
+# Internationalization (i18n) — design note
+
+**Status:** proposal / not yet implemented
+**Scope:** how Schautrack should adopt internationalization across the React client, the
+Go backend, and transactional email. This is a design note, not an implementation — it
+exists so the actual migration is a series of small, reviewable PRs instead of one risky
+rewrite.
+
+Refs: issue #150, item #08 ("Internationalization: zero i18n infrastructure").
+
+---
+
+## 1. Current state (assessed)
+
+There is **no i18n infrastructure anywhere**. Every user-facing string is a hardcoded
+English literal, in three separate places:
+
+### Client (`client/src`)
+- React 19 SPA, ~8.4k LOC across ~80 files (`pages/`, `components/`, `hooks/`, `stores/`,
+  `lib/`). No i18n dependency in `client/package.json` — no `i18next`, `react-intl`,
+  `lingui`, `@formatjs`, or `paraglide`.
+- Strings are embedded directly:
+  - **JSX text**, e.g. `App.tsx` `LoadingScreen` renders `Loading...`; `Footer.tsx`
+    renders `One day at a time`, `Imprint`, `Privacy`, `Terms`.
+  - **Toast/alert messages** passed as string literals, e.g.
+    `addToast('error', 'Failed to update setting')`, `addToast('success', 'API key saved')`
+    (see `stores/toastStore.ts` and its call sites across `pages/`).
+  - **A hand-written message map**, `lib/oidcMessages.ts`, that already centralizes ~20
+    OIDC redirect messages into `Record<string, string>` objects — the closest thing the
+    codebase has to a translation catalog, and a natural first thing to convert.
+  - **`title` / `aria-label` attributes**, e.g. `Footer.tsx` `title="Get the Android app"`.
+- **Locale-sensitive formatting is ad-hoc and hardcoded**: dates/times are formatted with
+  fixed locales rather than the user's — `dashboardStore.ts` uses
+  `toLocaleDateString('en-CA')`, `Dashboard/TodoList.tsx` uses `'en-CA'` and `'en-GB'`,
+  and several components call `new Date(...).toLocaleDateString()` with no locale at all.
+  There is **no date library** (no `date-fns`/`dayjs`/`luxon`) — formatting is all raw
+  `Intl`/`Date`.
+- `client/index.html` hardcodes `<html lang="en">` and a static `<title>Schautrack</title>`.
+
+### Backend (`internal/`)
+- Go handlers return English strings, e.g. `http.Error(w, "Unauthorized", ...)`,
+  `http.Error(w, "Streaming not supported", ...)`, and JSON error bodies like
+  `"Account already exists."`. A rough grep of title-cased quoted strings in
+  `internal/handler` returns a few hundred hits — but **most are not user-facing**
+  (timezone identifiers like `"America/New_York"`, admin-setting descriptions, test
+  fixtures). The genuinely user-facing subset — auth/validation error messages — is far
+  smaller, on the order of a few dozen.
+- **Transactional emails** are fully hardcoded English in `internal/service/email.go`:
+  `SendVerificationEmail`, `SendEmailChangeVerification`, `SendPasswordResetEmail`,
+  `Send2FAResetEmail` each build a subject + text + HTML body via `fmt.Sprintf`.
+
+### Where a user's language would live
+The `User` model (`internal/model/models.go`) already carries per-user preferences of
+exactly the right shape — `WeightUnit string`, `Timezone *string`, `TimezoneManual bool`.
+A `language`/`locale` preference fits this pattern one-for-one (new nullable column via the
+in-code migration pattern in `internal/database/migrations.go`, exposed through
+`/settings/preferences`). There is no such field today.
+
+### Why this matters for *this* app specifically
+Schautrack explicitly targets German-law self-hosted deployments — it ships Impressum /
+imprint machinery (`internal/handler/legal.go`, `IMPRINT_*` env vars) and German legal
+tooling. Yet the UI a German operator's users see is English-only. i18n (starting with a
+German locale) is the missing half of that "built for German deployments" story.
+
+> **Aside (same issue bullet):** the bullet also flags dead release tooling —
+> `scripts/bump-version.sh` and `scripts/generate-changelog.sh` duplicate the CI version
+> logic and are referenced by nothing. That is unrelated to i18n; it is tracked here only
+> so it is not lost, and should be handled as its own cleanup, not folded into this work.
+
+---
+
+## 2. Recommended approach
+
+### 2.1 Client library: `react-i18next`
+
+Adopt **[`i18next`](https://www.i18next.com/) + `react-i18next`** for the SPA.
+
+Rationale:
+- De-facto standard for React SPAs; mature, actively maintained, and **React 19
+  compatible** (react-i18next 15+; latest at time of writing is react-i18next 17 /
+  i18next 25). Works with Vite with zero special config.
+- Runtime catalogs are plain JSON — trivial to diff, review, and hand to a translator, and
+  they map cleanly onto the existing `oidcMessages.ts` `Record<string,string>` style.
+- Rich feature set the app will need: **ICU-style pluralization** (calorie/entry counts),
+  **interpolation** (`{{email}} wants to link with you`), namespaces (code-split catalogs),
+  and a **language detector** (`i18next-browser-languagedetector`).
+- Extraction tooling exists (`i18next-parser`) so keys can be pulled from source
+  automatically instead of maintained by hand.
+
+**Alternatives considered:**
+- **Lingui** — excellent compile-time extraction and smaller runtime, but its macro/Babel
+  pipeline is a heavier fit for this Vite + SWC setup, and its message-as-id model is a
+  bigger conceptual jump. Reasonable, but more upfront friction.
+- **react-intl (FormatJS)** — solid ICU support but more verbose API (`<FormattedMessage>`
+  everywhere) and heavier than i18next for a small app.
+- **Paraglide (inlang)** — compile-time, type-safe, very small runtime; attractive but
+  younger/less battle-tested. Worth revisiting later, not for the first migration.
+
+**Do not** hand-roll a bespoke context/`Record` solution — it re-implements pluralization,
+interpolation, fallback, and detection badly. The existing `oidcMessages.ts` is fine as a
+stopgap but should be *migrated into* i18next, not used as the pattern to expand.
+
+### 2.2 Formatting: standardize on `Intl`
+
+Locale-aware number/date/time formatting should go through the browser's `Intl` API,
+driven by the *active* i18next language (not a hardcoded `'en-CA'`/`'en-GB'`). Wrap the
+handful of formatting call sites in small helpers (e.g. `lib/format.ts` →
+`formatDate(iso, locale)`, `formatTime(...)`) so the migration is one edit per helper, not
+one per component. i18next can format via `Intl` inside interpolation, which keeps
+formatting choices in the catalog.
+
+> **Care point:** the calorie amount input **must** keep `inputmode="tel"` (per CLAUDE.md);
+> i18n must not touch input modes or introduce locale-grouped number *input* parsing that
+> breaks the existing `lib/mathParser.ts`. Localize *display*, not the numeric input path.
+
+### 2.3 File layout
+
+```
+client/src/
+  i18n/
+    index.ts               # i18next init (detector + resources + config)
+    locales/
+      en/
+        common.json        # shared: buttons, nav, footer, generic errors
+        auth.json           # login/register/reset/2fa
+        dashboard.json      # entries, weight, todos, notes
+        settings.json       # settings + admin
+      de/                   # added in a later phase, same key structure
+        common.json
+        ...
+```
+
+- **Namespaces per feature area** (`common`, `auth`, `dashboard`, `settings`) so catalogs
+  can be lazy-loaded and reviewed independently.
+- **English (`en`) is the source-of-truth locale and the fallback** (`fallbackLng: 'en'`).
+- Keys are semantic and dotted, e.g. `footer.tagline`, `settings.ai.keySaved`,
+  `auth.oidc.errors.invalid_state` (the OIDC map's existing keys carry over verbatim).
+
+### 2.4 Language detection & persistence
+
+1. **Logged-in users:** the new `User.language` preference wins. Server sends it in the
+   user payload; client sets `i18n.changeLanguage(user.language)` on load.
+2. **Anonymous / pre-login:** `i18next-browser-languagedetector` → `navigator.language`,
+   with a `localStorage` override for an explicit in-UI language switch.
+3. **`<html lang>`:** set dynamically from the active language (replaces the static
+   `lang="en"`), so screen readers and SEO see the right value.
+
+### 2.5 Backend (Go)
+
+The backend has two concerns; keep them **separate** from the client library but
+**consistent** in language selection:
+
+- **Language negotiation:** parse `Accept-Language` (via `golang.org/x/text/language`
+  matcher) *and* honor the logged-in user's `language` preference (preference > header >
+  default `en`). Put this in a small middleware that stashes the resolved
+  `language.Tag` on the request context. `golang.org/x/text` is already in the module
+  graph today (an indirect dependency in `go.mod`), so this adds no new third-party
+  surface — only a direct import.
+- **API error messages:** move the user-facing subset (auth/validation strings) behind a
+  tiny message catalog keyed the same way as the client. `golang.org/x/text/message` +
+  `catalog` is the idiomatic choice; a plain `map[language.Tag]map[string]string` is an
+  acceptable lighter-weight start. **Structured error responses** (a stable `code` field
+  the client can translate itself) are the cleanest long-term contract — the client already
+  proves this works with `oidcMessages.ts` mapping server codes to localized text. Prefer
+  returning **codes**, and let the client own presentation, wherever the API is
+  fetch-driven; reserve server-side rendered messages for the redirect/email paths where
+  the client can't intervene.
+- **Emails** (`internal/service/email.go`): externalize the four templates into per-locale
+  template files (Go `text/template` + `html/template`), selected by the recipient user's
+  `language`. This is self-contained and a good early backend phase because emails are
+  render-only and heavily English-hardcoded today.
+
+---
+
+## 3. Phased migration plan
+
+Each phase is independently shippable, reviewable, and leaves the app fully working. **No
+phase half-converts a screen.**
+
+| Phase | Deliverable | Risk |
+|------|-------------|------|
+| **0. Scaffold** | Add `i18next` + `react-i18next` + `i18next-browser-languagedetector`; create `i18n/index.ts`, `locales/en/common.json`; wrap `<App>` with the provider; convert **one** small component (e.g. `Footer.tsx`) as a proof-of-concept. Build + typecheck green. No behavior change. | Very low |
+| **1. Catalog the low-hanging maps** | Migrate `lib/oidcMessages.ts` and the toast/alert literals into `en` catalogs. These are already centralized-ish, so churn is contained. | Low |
+| **2. Formatting helpers** | Introduce `lib/format.ts`; route the ad-hoc `toLocale*` calls through it, driven by active locale. | Low–medium |
+| **3. Feature-area sweeps** | One PR per namespace/area — `auth`, then `dashboard`, then `settings`/`admin`, then `Landing`/`Legal`. Extract strings with `i18next-parser`; review the generated `en` catalog. | Medium (mechanical but broad) |
+| **4. User language preference** | Add `User.language` column + migration + `/settings/preferences` control + `<html lang>` sync + language switcher UI. | Medium |
+| **5. Backend negotiation + errors** | `Accept-Language`/preference middleware; move user-facing API errors to codes/catalog. | Medium |
+| **6. Localized emails** | Per-locale email templates in `internal/service/email.go`. | Low–medium |
+| **7. Add German (`de`)** | First real translation, exercising the whole pipeline; validates the German-deployment thesis. | Low (additive) |
+
+Ordering rationale: phases 0–2 stand up the machinery with near-zero blast radius; the
+broad sweeps (phase 3) only start once the pattern is proven; backend/email (5–6) are
+decoupled and can proceed in parallel with client sweeps.
+
+---
+
+## 4. Extraction & CI workflow
+
+- Add `i18next-parser` (dev dependency) with a config that scans `client/src` and writes/
+  updates `locales/en/*.json`. Run it via an `npm run i18n:extract` script.
+- **CI guardrail:** a lint step that fails if (a) extraction produces a diff (i.e. a new
+  literal was added without a key) or (b) a non-`en` locale is missing keys present in
+  `en`. This is what keeps the migration from silently regressing after it lands. It slots
+  into the existing GitHub Actions `test`/build pipeline (`.github/workflows/build.yml`).
+- Keep catalogs as committed JSON (no external TMS to start). A translation-management
+  service can be layered on later without changing the runtime.
+
+---
+
+## 5. Non-goals / explicit scope limits
+
+- **Not** rewriting the app in one PR. The value here is the *plan*; the migration is many
+  small PRs.
+- **Not** localizing user-generated content (entry names, notes) — those are the user's own
+  text and stay as entered.
+- **Not** RTL layout work — no target RTL locale today; revisit if Arabic/Hebrew is added.
+- **Not** touching the calorie input mode or `mathParser` numeric input path (see 2.2).
+- **Not** bundling the dead `scripts/bump-version.sh` / `generate-changelog.sh` cleanup
+  into this work — noted in §1, handled separately.
+
+---
+
+## 6. Concrete before/after (proof of the approach)
+
+Today (`components/Layout/Footer.tsx`):
+
+```tsx
+<div className="text-sm font-semibold text-foreground">
+  One day at a time
+</div>
+...
+<a href="/imprint" ...>Imprint</a>
+```
+
+After phase 0 (`locales/en/common.json` → `{ "footer": { "tagline": "One day at a time", "imprint": "Imprint" } }`):
+
+```tsx
+const { t } = useTranslation('common');
+...
+<div className="text-sm font-semibold text-foreground">
+  {t('footer.tagline')}
+</div>
+...
+<a href="/imprint" ...>{t('footer.imprint')}</a>
+```
+
+And the existing OIDC map becomes catalog entries instead of a bespoke `Record`:
+
+```ts
+// before: lib/oidcMessages.ts
+invalid_state: 'Login failed: invalid state. Please try again.',
+
+// after: locales/en/auth.json
+"oidc": { "errors": { "invalid_state": "Login failed: invalid state. Please try again." } }
+// lookup: t(`oidc.errors.${code}`, { ns: 'auth' })
+```
+
+The rendered output is byte-for-byte identical in English; only the source of the string
+changes. That property — English output unchanged until a real translation is added — is
+what makes every phase safe to ship.


### PR DESCRIPTION
Addresses issue #150 item #08 (zero i18n infrastructure). A full i18n migration of the ~8.4k-LOC SPA plus the Go handler strings and email templates is too large and risky for a single PR, so this delivers the architectural design — grounded in the actual code — rather than a half-migration.

**Delivered:** a new `docs/i18n.md` design note that (1) assesses the current state with file-level references (hardcoded English in client JSX, toasts, the `lib/oidcMessages.ts` map, ad-hoc `Intl` date formatting, Go handler error strings, and the four `internal/service/email.go` templates), (2) recommends `react-i18next` for the client with rationale versus lingui / react-intl / paraglide, plus backend `Accept-Language` negotiation via `golang.org/x/text` (already an indirect dependency) and localized emails, (3) proposes a file layout, namespace strategy, and a per-user `language` preference that mirrors the existing `WeightUnit`/`Timezone` pattern, and (4) includes a concrete before/after using `Footer.tsx` and the OIDC map.

**Phased follow-up:** an 8-phase plan (scaffold → migrate the existing maps → formatting helpers → per-area sweeps → user language preference → backend negotiation/errors → localized emails → add German), where every phase ships independently and leaves English output byte-for-byte unchanged until a real translation lands.

**Verification:** docs-only change (no build impact). Every concrete claim in the note was grep-verified against the codebase — Footer/LoadingScreen literals, the two cited toast call sites, `http.Error`/`ErrorJSON` strings, the four email functions, `migrations.go`, and the `golang.org/x/text` dependency. Re-read end-to-end for accuracy and coherence.

Refs #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)