### PR TITLE
test(e2e): replace 12s step-up sleeps with deterministic grace expiry

### DIFF
--- a/e2e/bcrypt-migration.spec.ts
+++ b/e2e/bcrypt-migration.spec.ts
@@ -1,9 +1,11 @@
 import { test, expect } from '@playwright/test';
-import { psql, bcryptHash, loginUser } from './fixtures/helpers';
+import { psql, bcryptHash, loginUser, expireStepUpGrace } from './fixtures/helpers';
 
 const baseURL = process.env.E2E_BASE_URL || 'http://localhost:3001';
 const BCRYPT_EMAIL = 'e2e-bcrypt-migration@test.local';
 const BCRYPT_PASSWORD = 'bcrypttest1234';
+
+let bcryptUserId = '';
 
 test.describe.serial('Bcrypt Migration', () => {
   test.beforeAll(() => {
@@ -14,9 +16,9 @@ test.describe.serial('Bcrypt Migration', () => {
        ON CONFLICT (email) DO UPDATE SET password_hash = '${hash}', email_verified = true,
          totp_enabled = false, totp_secret = NULL`
     );
-    const uid = psql(`SELECT id FROM users WHERE email = '${BCRYPT_EMAIL}'`);
-    if (uid) {
-      psql(`DELETE FROM calorie_entries WHERE user_id = ${uid}`);
+    bcryptUserId = psql(`SELECT id FROM users WHERE email = '${BCRYPT_EMAIL}'`);
+    if (bcryptUserId) {
+      psql(`DELETE FROM calorie_entries WHERE user_id = ${bcryptUserId}`);
     }
   });
 
@@ -68,10 +70,10 @@ test.describe.serial('Bcrypt Migration', () => {
       await passwordHeading.scrollIntoViewIfNeeded();
       await expect(passwordHeading).toBeVisible({ timeout: 10000 });
 
-      // Wait past step-up grace (TTL=10s in test env) so the modal triggers,
-      // forcing a password re-verification — that's what exercises the bcrypt
-      // hash code path.
-      await page.waitForTimeout(12000);
+      // Expire the step-up grace server-side (deterministic) so the modal
+      // triggers, forcing a password re-verification — that's what exercises
+      // the bcrypt hash code path.
+      expireStepUpGrace(bcryptUserId);
 
       await page.getByLabel('New Password').fill(newPassword);
       await page.getByLabel('Confirm Password').fill(newPassword);

--- a/e2e/data-export-import.spec.ts
+++ b/e2e/data-export-import.spec.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { test, expect } from '@playwright/test';
-import { psql, createIsolatedUser } from './fixtures/helpers';
+import { psql, createIsolatedUser, expireStepUpGrace } from './fixtures/helpers';
 import { completeStepUp } from './fixtures/stepup';
 
 const baseURL = process.env.E2E_BASE_URL || 'http://localhost:3001';
@@ -38,8 +38,8 @@ test.describe('Data Export / Import', () => {
 
     await loginAndGo(page, '/settings');
 
-    // Wait past step-up grace (TTL=10s in test env) so the modal triggers.
-    await page.waitForTimeout(12000);
+    // Expire the step-up grace server-side (deterministic) so the modal triggers.
+    expireStepUpGrace(user.id);
 
     // Click Export — step-up modal gates the request.
     const exportBtn = page.getByRole('button', { name: 'Export JSON', exact: true });
@@ -142,8 +142,8 @@ test.describe('Data Export / Import', () => {
     const importBtn = page.getByRole('button', { name: 'Import', exact: true });
     await expect(importBtn).toBeEnabled({ timeout: 5000 });
 
-    // Wait past step-up grace and import — modal will gate the request.
-    await page.waitForTimeout(12000);
+    // Expire the step-up grace server-side, then import — the modal gates the request.
+    expireStepUpGrace(user.id);
     await importBtn.click();
     await completeStepUp(page, user.password);
     await expect(page.getByText(/Imported/i)).toBeVisible({ timeout: 15000 });

--- a/e2e/delete-account.spec.ts
+++ b/e2e/delete-account.spec.ts
@@ -1,24 +1,26 @@
 import { test, expect } from '@playwright/test';
-import { psql, bcryptHash } from './fixtures/helpers';
+import { psql, bcryptHash, expireStepUpGrace } from './fixtures/helpers';
 import { completeStepUp } from './fixtures/stepup';
 
 const DELETE_EMAIL = 'delete-e2e@test.com';
 const DELETE_PASSWORD = 'deletetest1234';
 
-function ensureDeleteUser() {
+let deleteUserId: string;
+
+function ensureDeleteUser(): string {
   const hash = bcryptHash(DELETE_PASSWORD);
   const exists = psql(`SELECT id FROM users WHERE email = '${DELETE_EMAIL}'`);
   if (exists) {
     psql(`UPDATE users SET password_hash = '${hash}', email_verified = true, totp_enabled = false, totp_secret = NULL WHERE email = '${DELETE_EMAIL}'`);
     psql(`DELETE FROM totp_backup_codes WHERE user_id = ${exists}`);
-  } else {
-    psql(`INSERT INTO users (email, password_hash, email_verified) VALUES ('${DELETE_EMAIL}', '${hash}', true)`);
+    return exists;
   }
+  return psql(`INSERT INTO users (email, password_hash, email_verified) VALUES ('${DELETE_EMAIL}', '${hash}', true) RETURNING id`);
 }
 
 test.describe('Delete Account', () => {
   test.beforeAll(() => {
-    ensureDeleteUser();
+    deleteUserId = ensureDeleteUser();
   });
 
   test('user can delete their own account', async ({ browser }) => {
@@ -41,8 +43,8 @@ test.describe('Delete Account', () => {
     // re-prompt is handled by the step-up modal.
     await expect(page.getByRole('heading', { name: 'Delete Account' })).toBeVisible({ timeout: 5000 });
 
-    // Wait past the step-up grace window so the modal triggers (TTL=10s in test env).
-    await page.waitForTimeout(12000);
+    // Expire the step-up grace server-side (deterministic) so the modal triggers.
+    expireStepUpGrace(deleteUserId);
 
     await page.getByRole('checkbox').check();
     await page.getByRole('button', { name: 'Delete My Account' }).click();

--- a/e2e/email-change.spec.ts
+++ b/e2e/email-change.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { psql, createIsolatedUser, fetchMailpitMessages, extractCodeFromEmail, clearMailpit } from './fixtures/helpers';
+import { psql, createIsolatedUser, expireStepUpGrace, fetchMailpitMessages, extractCodeFromEmail, clearMailpit } from './fixtures/helpers';
 import { completeStepUp } from './fixtures/stepup';
 
 const baseURL = process.env.E2E_BASE_URL || 'http://localhost:3001';
@@ -45,8 +45,8 @@ test.describe('Email Change', () => {
     const emailHeading = page.getByText('Change Email', { exact: true });
     await emailHeading.scrollIntoViewIfNeeded();
 
-    // Wait past step-up grace (TTL=10s in test env) so the modal triggers.
-    await page.waitForTimeout(12000);
+    // Expire the step-up grace server-side (deterministic) so the modal triggers.
+    expireStepUpGrace(user.id);
 
     // Fill new email and submit — step-up modal will gate the request.
     await page.getByLabel('New Email').fill(newEmail);
@@ -86,8 +86,8 @@ test.describe('Email Change', () => {
     const emailSection = page.getByText('Change Email').first();
     await emailSection.scrollIntoViewIfNeeded();
 
-    // Wait past step-up grace.
-    await page.waitForTimeout(12000);
+    // Expire the step-up grace server-side.
+    expireStepUpGrace(user.id);
 
     await page.getByLabel('New Email').fill(newEmail);
     await page.getByRole('button', { name: 'Send Verification Code' }).click();
@@ -127,8 +127,8 @@ test.describe('Email Change', () => {
     const emailSection = page.getByText('Change Email').first();
     await emailSection.scrollIntoViewIfNeeded();
 
-    // Wait past step-up grace.
-    await page.waitForTimeout(12000);
+    // Expire the step-up grace server-side.
+    expireStepUpGrace(user.id);
 
     await page.getByLabel('New Email').fill(newEmail);
     await page.getByRole('button', { name: 'Send Verification Code' }).click();

--- a/e2e/fixtures/helpers.ts
+++ b/e2e/fixtures/helpers.ts
@@ -150,6 +150,43 @@ export function createIsolatedUser(specName: string, opts: { features?: boolean 
 }
 
 /**
+ * Deterministically expire a user's step-up grace window so the very next
+ * sensitive action re-prompts immediately.
+ *
+ * This is the reliable, instant replacement for `page.waitForTimeout(12000)`
+ * (sleeping past the test-env STEP_UP_TTL). Step-up freshness is stored purely
+ * server-side as a `step_up_at` unix timestamp inside the session JSON (see
+ * internal/session/store.go: MarkStepUp / HasRecentStepUp), which is reloaded
+ * from the DB on every request. Back-dating it to the epoch makes
+ * HasRecentStepUp() return false on the next request — no wall-clock waiting,
+ * no flakiness. Every active session row for the user is updated, which is
+ * harmless for stale/prior-login rows.
+ *
+ * Pass the numeric user id (e.g. from createIsolatedUser().id).
+ */
+export function expireStepUpGrace(userId: string | number): void {
+  psql(
+    `UPDATE "session"
+     SET sess = jsonb_set(sess::jsonb, '{step_up_at}', to_jsonb(0), true)::json
+     WHERE sess->>'userId' = '${userId}'`
+  );
+}
+
+/**
+ * Deterministically refresh a user's step-up grace (set `step_up_at` to now)
+ * so an assertion that must run *inside* the grace window can't flake when UI
+ * latency would otherwise push the action past STEP_UP_TTL. The inverse of
+ * expireStepUpGrace(). Pass the numeric user id.
+ */
+export function refreshStepUpGrace(userId: string | number): void {
+  psql(
+    `UPDATE "session"
+     SET sess = jsonb_set(sess::jsonb, '{step_up_at}', to_jsonb(extract(epoch from now())::bigint), true)::json
+     WHERE sess->>'userId' = '${userId}'`
+  );
+}
+
+/**
  * Login as a specific user via the API (fast, no UI interaction).
  * Uses direct HTTP requests to get a session cookie, then creates a browser context with it.
  */

--- a/e2e/passkey.spec.ts
+++ b/e2e/passkey.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { createIsolatedUser, psql } from './fixtures/helpers';
+import { createIsolatedUser, expireStepUpGrace, psql } from './fixtures/helpers';
 import { completeStepUp } from './fixtures/stepup';
 import { attachVirtualAuthenticator } from './fixtures/webauthn';
 
@@ -40,8 +40,8 @@ test.describe('Passkeys', () => {
       await login(page);
       await page.goto('/settings');
 
-      // Wait past grace so step-up gates the registration call.
-      await page.waitForTimeout(12000);
+      // Expire grace server-side so step-up gates the registration call.
+      expireStepUpGrace(user.id);
 
       const passkeyHeading = page.getByRole('heading', { name: /passkeys/i });
       await passkeyHeading.scrollIntoViewIfNeeded();
@@ -80,7 +80,7 @@ test.describe('Passkeys', () => {
     try {
       await login(page);
       await page.goto('/settings');
-      await page.waitForTimeout(12000);
+      expireStepUpGrace(user.id);
 
       await page.getByRole('heading', { name: /passkeys/i }).scrollIntoViewIfNeeded();
       await page.getByPlaceholder(/passkey name/i).fill('Login Test');
@@ -111,7 +111,7 @@ test.describe('Passkeys', () => {
     try {
       await login(page);
       await page.goto('/settings');
-      await page.waitForTimeout(12000);
+      expireStepUpGrace(user.id);
 
       // Register one passkey (step-up).
       await page.getByRole('heading', { name: /passkeys/i }).scrollIntoViewIfNeeded();
@@ -120,8 +120,8 @@ test.describe('Passkeys', () => {
       await completeStepUp(page, user.password);
       await expect(page.getByText('To Be Deleted')).toBeVisible({ timeout: 10000 });
 
-      // Wait past grace to force the delete to require fresh step-up.
-      await page.waitForTimeout(12000);
+      // Expire grace to force the delete to require fresh step-up.
+      expireStepUpGrace(user.id);
 
       // Click Remove on the passkey row.
       const row = page.locator('div').filter({ hasText: /^To Be Deleted/ });
@@ -146,7 +146,7 @@ test.describe('Passkeys', () => {
     try {
       await login(page);
       await page.goto('/settings');
-      await page.waitForTimeout(12000);
+      expireStepUpGrace(user.id);
 
       // Register a passkey so the modal can offer the passkey path.
       await page.getByRole('heading', { name: /passkeys/i }).scrollIntoViewIfNeeded();
@@ -155,10 +155,10 @@ test.describe('Passkeys', () => {
       await completeStepUp(page, user.password);
       await expect(page.getByText('Step-up Source')).toBeVisible({ timeout: 10000 });
 
-      // Wait past grace, then trigger Export JSON — it's gated by step-up
+      // Expire grace, then trigger Export JSON — it's gated by step-up
       // but doesn't mutate persistent user state, so leftover state from a
       // failed assertion can't break later tests.
-      await page.waitForTimeout(12000);
+      expireStepUpGrace(user.id);
 
       const exportBtn = page.getByRole('button', { name: 'Export JSON', exact: true });
       await exportBtn.scrollIntoViewIfNeeded();
@@ -191,7 +191,7 @@ test.describe('Passkeys', () => {
     try {
       await login(page);
       await page.goto('/settings');
-      await page.waitForTimeout(12000);
+      expireStepUpGrace(user.id);
 
       await page.getByRole('heading', { name: /passkeys/i }).scrollIntoViewIfNeeded();
       await page.getByPlaceholder(/passkey name/i).fill('Old Name');
@@ -199,8 +199,8 @@ test.describe('Passkeys', () => {
       await completeStepUp(page, user.password);
       await expect(page.getByText('Old Name')).toBeVisible({ timeout: 10000 });
 
-      // Wait past grace so a *gated* action would prompt.
-      await page.waitForTimeout(12000);
+      // Expire grace so a *gated* action would prompt.
+      expireStepUpGrace(user.id);
 
       // Click the passkey name to enter rename mode, type, blur to save.
       await page.getByRole('button', { name: 'Old Name' }).click();

--- a/e2e/password.spec.ts
+++ b/e2e/password.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from './fixtures/auth';
 import { login } from './fixtures/auth';
 import { completeStepUp } from './fixtures/stepup';
+import { psql, refreshStepUpGrace } from './fixtures/helpers';
 
 test.describe('Password Change', () => {
   test('mismatched passwords are rejected client-side (no step-up triggered)', async ({ page }) => {
@@ -37,8 +38,12 @@ test.describe('Password Change', () => {
     await completeStepUp(page, 'test1234test');
     await expect(page.getByText(/password updated/i).first()).toBeVisible({ timeout: 5000 });
 
-    // Change it back — should land within the step-up grace window from the
-    // first change, so no second modal expected.
+    // Change it back within the step-up grace window (no second modal expected).
+    // Refresh the grace server-side (deterministic) rather than relying on the
+    // first change landing under STEP_UP_TTL — UI latency could otherwise push
+    // the second change past the window and spuriously re-prompt.
+    const userId = psql(`SELECT id FROM users WHERE email = 'test@test.com'`);
+    refreshStepUpGrace(userId);
     await page.getByLabel('New Password').fill('test1234test');
     await page.getByLabel('Confirm Password').fill('test1234test');
     await page.getByRole('button', { name: 'Update Password' }).click();

--- a/e2e/stepup.spec.ts
+++ b/e2e/stepup.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { bcryptHash, createIsolatedUser, psql } from './fixtures/helpers';
+import { bcryptHash, createIsolatedUser, expireStepUpGrace, psql } from './fixtures/helpers';
 import { completeStepUp, cancelStepUp } from './fixtures/stepup';
 
 // Each test uses a fresh login context so the storageState session age can't
@@ -69,9 +69,9 @@ test.describe('Step-up auth', () => {
     await page.goto('/settings');
     await page.waitForURL('/settings');
 
-    // STEP_UP_TTL=10s in compose.test.yml — wait long enough that the grace
-    // expires before we trigger a sensitive action.
-    await page.waitForTimeout(12000);
+    // Expire the step-up grace server-side (deterministic) instead of sleeping
+    // past STEP_UP_TTL, so the next sensitive action re-prompts immediately.
+    expireStepUpGrace(user.id);
 
     await page.getByText('Change Password').scrollIntoViewIfNeeded();
     const newPw = 'after-expiry-pw-1';
@@ -100,8 +100,8 @@ test.describe('Step-up auth', () => {
     await page.goto('/settings');
     await page.waitForURL('/settings');
 
-    // Wait past grace so the modal triggers.
-    await page.waitForTimeout(12000);
+    // Expire grace server-side so the modal triggers.
+    expireStepUpGrace(user.id);
 
     await page.getByText('Change Password').scrollIntoViewIfNeeded();
     await page.getByLabel('New Password').fill('cancel-test-pw-1');
@@ -125,7 +125,7 @@ test.describe('Step-up auth', () => {
 
     await page.goto('/settings');
     await page.waitForURL('/settings');
-    await page.waitForTimeout(12000);
+    expireStepUpGrace(user.id);
 
     await page.getByText('Change Password').scrollIntoViewIfNeeded();
     await page.getByLabel('New Password').fill('wrong-pw-test');
@@ -160,7 +160,7 @@ test.describe('Step-up auth', () => {
     const page = await ctx.newPage();
     await login(page);
     await page.goto('/settings');
-    await page.waitForTimeout(12000);
+    expireStepUpGrace(user.id);
 
     await page.getByText('Change Password').scrollIntoViewIfNeeded();
     await page.getByLabel('New Password').fill('escape-test-pw');
@@ -184,7 +184,7 @@ test.describe('Step-up auth', () => {
     const page = await ctx.newPage();
     await login(page);
     await page.goto('/settings');
-    await page.waitForTimeout(12000);
+    expireStepUpGrace(user.id);
 
     await page.getByText('Change Password').scrollIntoViewIfNeeded();
     await page.getByLabel('New Password').fill('outside-click-test-pw');

--- a/e2e/two-factor.spec.ts
+++ b/e2e/two-factor.spec.ts
@@ -1,11 +1,13 @@
 import { test, expect } from '@playwright/test';
-import { psql, generateTOTP, bcryptHash } from './fixtures/helpers';
+import { psql, generateTOTP, bcryptHash, expireStepUpGrace } from './fixtures/helpers';
 import { completeStepUp } from './fixtures/stepup';
 
 test.describe.configure({ mode: 'serial' });
 
 const EMAIL = '2fa@test.com';
 const PASSWORD = '2fa1234test';
+
+let twoFaUserId = '';
 
 let capturedSecret = '';
 let capturedBackupCodes: string[] = [];
@@ -27,10 +29,10 @@ test.describe('Two-Factor Authentication', () => {
   test.beforeAll(() => {
     // Reset 2FA state for the test user before the suite runs
     const hash = bcryptHash(PASSWORD);
-    const id = psql(`SELECT id FROM users WHERE email = '${EMAIL}'`);
-    if (id) {
-      psql(`UPDATE users SET password_hash = '${hash}', totp_enabled = false, totp_secret = NULL WHERE id = ${id}`);
-      psql(`DELETE FROM totp_backup_codes WHERE user_id = ${id}`);
+    twoFaUserId = psql(`SELECT id FROM users WHERE email = '${EMAIL}'`);
+    if (twoFaUserId) {
+      psql(`UPDATE users SET password_hash = '${hash}', totp_enabled = false, totp_secret = NULL WHERE id = ${twoFaUserId}`);
+      psql(`DELETE FROM totp_backup_codes WHERE user_id = ${twoFaUserId}`);
     }
   });
 
@@ -161,8 +163,8 @@ test.describe('Two-Factor Authentication', () => {
     await page.goto('/settings');
     await page.waitForURL('/settings');
 
-    // Wait past step-up grace (TTL=10s in test env) so the action is gated.
-    await page.waitForTimeout(12000);
+    // Expire the step-up grace server-side (deterministic) so the action is gated.
+    expireStepUpGrace(twoFaUserId);
 
     // Intercept regenerate response — set up before triggering the action so
     // the retry after step-up is captured too.
@@ -212,8 +214,8 @@ test.describe('Two-Factor Authentication', () => {
     await page.goto('/settings');
     await page.waitForURL('/settings');
 
-    // Wait past step-up grace so the disable is gated.
-    await page.waitForTimeout(12000);
+    // Expire the step-up grace server-side so the disable is gated.
+    expireStepUpGrace(twoFaUserId);
 
     // The 2FA card now just shows the "Disable 2FA" button — re-auth happens
     // in the step-up modal.


### PR DESCRIPTION
Replaces the 22 `page.waitForTimeout(12000)` hard sleeps (~4+ minutes of pure sleep per run) that the e2e suite used to wait out the 10s test-env `STEP_UP_TTL`. Step-up freshness lives purely server-side as a `step_up_at` unix timestamp in the session JSON (reloaded from the DB every request), so two new helpers — `expireStepUpGrace()` / `refreshStepUpGrace()` — set it directly via `psql` instead of sleeping. Also makes password.spec.ts's in-grace round-trip refresh the grace explicitly rather than assuming the second change lands under the TTL (the flaky "inverse assumption" the audit flagged).

Touched: passkey (8), stepup (5), email-change (3), data-export-import (2), two-factor (2), delete-account (1), bcrypt-migration (1), password (1 refresh). delete-account / bcrypt-migration / two-factor now capture their user id so the helper can target the right session rows.

Verification: `npx playwright test --list` loads all 224 tests across 57 files (exit 0). The docker-backed suite was not run per task constraints.

Remaining (out of scope for this PR): the dozens of short 300-3000ms sleeps in notes/settings/admin/account-linking/macro-threshold — those are heterogeneous and each needs an individual web-first wait-condition substitution rather than a mechanical swap.

Refs #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
