### PR TITLE
perf(dashboard): eliminate double refetch of /api/dashboard on entry mutations

### DIFF
--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import { useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { useRequireAuth } from '@/hooks/useAuth';
 import { getDashboard, getDayEntries } from '@/api/entries';
 import { getWeightDay } from '@/api/weight';
@@ -17,7 +17,6 @@ import NoteEditor from './NoteEditor';
 export default function Dashboard() {
   const { user, isLoading: authLoading } = useRequireAuth();
   const { selectedDate, currentUserId, currentLabel, canEdit, rangePreset, rangeStart, rangeEnd, selectUser, selectDay } = useDashboardStore();
-  const queryClient = useQueryClient();
 
   // Fetch dashboard data
   const { data: dashboard, isLoading } = useQuery({
@@ -125,9 +124,11 @@ export default function Dashboard() {
             aiProviderName={dashboard.aiProviderName}
             barcodeEnabled={dashboard.barcodeEnabled}
             onSubmit={() => {
-              queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-              queryClient.invalidateQueries({ queryKey: ['day-entries'] });
-              queryClient.invalidateQueries({ queryKey: ['weight'] });
+              // Refresh is driven by the entry-change SSE echo (useSSE): the
+              // server broadcasts entry-change to this user's own sessions too,
+              // so invalidating here as well would double-fetch the heavy
+              // /api/dashboard endpoint. Relying solely on the echo also keeps
+              // the user's other tabs/devices (and linked users) in sync.
             }}
           />
         </>

--- a/client/src/pages/Dashboard/EntryList.tsx
+++ b/client/src/pages/Dashboard/EntryList.tsx
@@ -34,8 +34,11 @@ export default function EntryList({ entries, canEdit, enabledMacros, caloriesEna
           caloriesEnabled={caloriesEnabled}
           autoCalcCalories={autoCalcCalories}
           onUpdate={() => {
-            queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-            queryClient.invalidateQueries({ queryKey: ['day-entries'] });
+            // Refresh is driven by the entry-change SSE echo (useSSE): the
+            // server broadcasts entry-change to this user's own sessions too,
+            // so invalidating here as well would double-fetch the heavy
+            // /api/dashboard endpoint. Relying solely on the echo also keeps
+            // the user's other tabs/devices (and linked users) in sync.
           }}
           onSaveAsFood={() => {
             queryClient.invalidateQueries({ queryKey: ['savedFoods'] });


### PR DESCRIPTION
Every entry add/edit/delete refetched the heavy `/api/dashboard` endpoint twice: the mutation's manual `invalidateQueries` plus, milliseconds later, the client's own entry-change SSE echo (the broker includes the source user in its broadcast targets). This drops the manual `onSubmit`/`onUpdate` invalidations in `Dashboard`/`EntryForm` and `EntryList` and relies solely on the SSE echo, which invalidates the same keys (`dashboard`, `day-entries`, `weight`).

All entry mutations (create/update/delete) broadcast `entry-change` unconditionally on success, so exactly one refetch still occurs (no stale UI). Relying on the echo preserves multi-device sync — the user's other tabs/devices and linked users refresh through the same path — which suppressing the self-echo would have broken.

Verified: `cd client && npm run build` passes (`tsc -b` strict typecheck + `vite build`); reasoned through single-refetch and cross-device SSE correctness.

Refs #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)