### PR TITLE
feat(version): add UPDATE_CHECK_ENABLED opt-out for the GitHub update check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,11 @@ SESSION_SECRET=please-change-me
 # Enable barcode scanning via OpenFoodFacts (default: true, set 'false' to disable)
 # ENABLE_BARCODE=true
 
+# Check GitHub for a newer release so the footer can flag an outdated instance
+# (default: true). Set 'false' to opt out of the outbound request to
+# api.github.com — recommended for privacy-sensitive or air-gapped self-hosts.
+# UPDATE_CHECK_ENABLED=true
+
 # =============================================================================
 # OIDC / SSO
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Photo-based nutrition estimation with support for OpenAI, Claude, and Ollama.
 |----------|---------|-------------|
 | `ENABLE_BARCODE` | `true` | Enable barcode scanning via OpenFoodFacts. Set `false` to disable. |
 | `ENABLE_REGISTRATION` | `open` | `open` (anyone can register) or `false` / `invite` (requires invite code). Also configurable via `/admin`. |
+| `UPDATE_CHECK_ENABLED` | `true` | Check GitHub (`api.github.com`) for a newer release so the footer can flag an outdated instance. Set `false` to opt out of the outbound request — recommended for privacy-sensitive or air-gapped self-hosts. |
 
 ### OIDC (Single Sign-On)
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -129,7 +129,7 @@ func main() {
 	// API routes
 	r.Route("/api", func(r chi.Router) {
 		r.Get("/health", handler.Health(pool, cfg.BuildVersion))
-		r.Get("/latest-version", handler.LatestVersion())
+		r.Get("/latest-version", handler.LatestVersion(cfg.UpdateCheckEnabled))
 		r.Get("/csrf", handler.CsrfToken)
 		r.Get("/me", handler.Me(pool, cfg.AdminEmail, settingsCache, cfg))
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	// Features
 	EnableBarcode      bool
 	EnableRegistration string
+	UpdateCheckEnabled bool
 
 	// Rate limiting
 	RateLimitAuth   int
@@ -127,6 +128,7 @@ func Load() (*Config, error) {
 
 		EnableBarcode:      os.Getenv("ENABLE_BARCODE") != "false",
 		EnableRegistration: os.Getenv("ENABLE_REGISTRATION"),
+		UpdateCheckEnabled: os.Getenv("UPDATE_CHECK_ENABLED") != "false",
 
 		RateLimitAuth:   rateLimitAuth,
 		RateLimitStrict: rateLimitStrict,

--- a/internal/handler/version.go
+++ b/internal/handler/version.go
@@ -25,16 +25,21 @@ type latestVersionCache struct {
 
 var latestVersion latestVersionCache
 
-func LatestVersion() http.HandlerFunc {
+// LatestVersion reports the newest published release so the footer can flag an
+// outdated instance. When enabled is false the handler never contacts GitHub and
+// always reports no update — this is the opt-out for self-hosted/air-gapped
+// deployments that don't want the outbound phone-home (UPDATE_CHECK_ENABLED=false).
+func LatestVersion(enabled bool) http.HandlerFunc {
 	client := &http.Client{Timeout: 5 * time.Second}
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "public, max-age=600")
 
-		tag := latestVersion.lookup(r.Context(), client)
 		var payload any
-		if tag != "" {
-			payload = tag
+		if enabled {
+			if tag := latestVersion.lookup(r.Context(), client); tag != "" {
+				payload = tag
+			}
 		}
 		json.NewEncoder(w).Encode(map[string]any{"latest": payload})
 	}

--- a/internal/handler/version_test.go
+++ b/internal/handler/version_test.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestLatestVersionDisabled_NoPhoneHome verifies the UPDATE_CHECK_ENABLED=false
+// opt-out: the handler reports no update and never performs the upstream lookup,
+// so no request is made to GitHub.
+func TestLatestVersionDisabled_NoPhoneHome(t *testing.T) {
+	// Reset the shared cache so we can assert the disabled handler never touches it.
+	latestVersion = latestVersionCache{}
+
+	h := LatestVersion(false)
+	r := httptest.NewRequest("GET", "/api/latest-version", nil)
+	w := httptest.NewRecorder()
+	h(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if v, ok := resp["latest"]; !ok || v != nil {
+		t.Errorf("latest = %v, want nil", v)
+	}
+
+	// The disabled handler must not have performed the upstream lookup — the
+	// cache stays pristine, proving no outbound request was attempted.
+	if !latestVersion.fetchedAt.IsZero() {
+		t.Errorf("cache was touched (fetchedAt=%v); update check ran despite being disabled", latestVersion.fetchedAt)
+	}
+}


### PR DESCRIPTION
Adds an `UPDATE_CHECK_ENABLED` env var (parsed in `internal/config`, default `true` to preserve current behavior) that gates the `/api/latest-version` phone-home. When set to `false`, `handler.LatestVersion` short-circuits and returns `{"latest": null}` without ever contacting `api.github.com` — no request, no 5-minute retry loop. The footer already degrades gracefully on a null response, so no client change was needed. Documented in README and `.env.example`.

Verification: `go build ./...` and `go vet ./...` clean; new hermetic test `TestLatestVersionDisabled_NoPhoneHome` confirms the disabled path makes no upstream lookup (cache stays pristine); full `go test ./internal/handler/` passes; ran the real `config.Load()` to confirm unset→true, `false`→false, `true`→true.

Refs #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)