### PR TITLE
feat(android): serve Digital Asset Links at /.well-known/assetlinks.json

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,3 +182,18 @@ POSTGRES_PASSWORD=schautrack
 
 # Set to 'true' to allow search engine indexing (default: noindex for self-hosters)
 # ROBOTS_INDEX=true
+
+# --- Android App Links (Digital Asset Links) ---
+# Binds this domain to the published Android app so https:// links to it open
+# in the app (App Links verification / TWA validation). Served at
+# /.well-known/assetlinks.json — the endpoint 404s until a fingerprint is set.
+#
+# Android package name (default: to.schauer.schautrack — the published app)
+# ANDROID_PACKAGE_NAME=to.schauer.schautrack
+#
+# SHA-256 signing-certificate fingerprint(s), comma-separated, in UPPER:CO:LON
+# form. DEPLOYMENT-SPECIFIC — do not copy someone else's. Get it from the Play
+# Console (Test and release → App integrity → App signing) or from your keystore:
+#   keytool -list -v -keystore <keystore.jks> -alias <alias>
+# Leave blank to disable the endpoint. NEVER ship a placeholder/fake value.
+# ANDROID_CERT_FINGERPRINTS=AA:BB:CC:DD:...:FF

--- a/README.md
+++ b/README.md
@@ -39,6 +39,23 @@ Schautrack is built to stay out of your way. Log calories and macros, set goals,
 
 Source code available at [schautrack-android](https://github.com/schaurian/schautrack-android).
 
+### Android App Links
+
+The server serves a [Digital Asset Links](https://developers.google.com/digital-asset-links/v1/getting-started)
+file at `/.well-known/assetlinks.json` so that `https://` links to your domain
+open directly in the app (App Links verification; also used for TWA validation).
+
+The endpoint stays disabled (404) until you provide your app's SHA-256
+signing-certificate fingerprint(s), which are **specific to your build** and must
+not be copied from elsewhere:
+
+- `ANDROID_CERT_FINGERPRINTS` — comma-separated fingerprint(s) in `AA:BB:...:FF`
+  form. Find them in the Play Console under **Test and release → App integrity →
+  App signing**, or from your keystore with
+  `keytool -list -v -keystore <keystore> -alias <alias>`.
+- `ANDROID_PACKAGE_NAME` — defaults to `to.schauer.schautrack`; override for a
+  fork with a different published package.
+
 ## Quickstart (Docker)
 
 ```bash
@@ -200,6 +217,8 @@ WebAuthn-based passwordless login with biometric verification. Users can registe
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ROBOTS_INDEX` | `false` | Set to `true` to allow search engine indexing (default: noindex for self-hosters) |
+| `ANDROID_PACKAGE_NAME` | `to.schauer.schautrack` | Package name published in `/.well-known/assetlinks.json` for Android App Links. |
+| `ANDROID_CERT_FINGERPRINTS` | *(empty)* | Comma-separated SHA-256 signing-cert fingerprint(s) (UPPER:CO:LON form) for App Links. **Deployment-specific** — see [Android App Links](#android-app-links). Empty disables `/.well-known/assetlinks.json`. |
 
 ## Contributing
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -126,6 +126,10 @@ func main() {
 	r.Get("/robots.txt", handler.RobotsTxt(cfg))
 	r.Get("/sitemap.xml", handler.SitemapXml(cfg))
 
+	// Android App Links (Digital Asset Links). 404s until a signing-cert
+	// fingerprint is configured (ANDROID_CERT_FINGERPRINTS).
+	r.Get("/.well-known/assetlinks.json", handler.AssetLinks(cfg))
+
 	// API routes
 	r.Route("/api", func(r chi.Router) {
 		r.Get("/health", handler.Health(pool, cfg.BuildVersion))

--- a/helm/schautrack/README.md
+++ b/helm/schautrack/README.md
@@ -221,6 +221,8 @@ smtp:
 | `config.trustProxy` | Trust X-Forwarded-For headers for rate limiting | `""` (true) |
 | `config.robotsIndex` | Allow search engine indexing | `false` |
 | `config.baseUrl` | Base URL for SEO meta tags (auto-detects if empty) | `""` |
+| `config.androidPackageName` | Package name for Android App Links (`/.well-known/assetlinks.json`) | `to.schauer.schautrack` |
+| `config.androidCertFingerprints` | Comma-separated SHA-256 signing-cert fingerprint(s) for App Links (**deployment-specific**; empty disables the endpoint) | `""` |
 
 ### AI
 

--- a/helm/schautrack/templates/configmap.yaml
+++ b/helm/schautrack/templates/configmap.yaml
@@ -63,6 +63,12 @@ data:
   {{- if .Values.config.baseUrl }}
   BASE_URL: {{ .Values.config.baseUrl | quote }}
   {{- end }}
+  {{- if .Values.config.androidPackageName }}
+  ANDROID_PACKAGE_NAME: {{ .Values.config.androidPackageName | quote }}
+  {{- end }}
+  {{- if .Values.config.androidCertFingerprints }}
+  ANDROID_CERT_FINGERPRINTS: {{ .Values.config.androidCertFingerprints | quote }}
+  {{- end }}
   {{- if .Values.config.stepUpTTL }}
   STEP_UP_TTL: {{ .Values.config.stepUpTTL | quote }}
   {{- end }}

--- a/helm/schautrack/values.yaml
+++ b/helm/schautrack/values.yaml
@@ -102,6 +102,14 @@ config:
   robotsIndex: false
   # Base URL for SEO meta tags (leave empty to auto-detect from request)
   baseUrl: ""
+  # Android App Links (Digital Asset Links) — binds the domain to the published
+  # Android app so https:// links open in the app. Served at
+  # /.well-known/assetlinks.json only when androidCertFingerprints is set.
+  androidPackageName: "to.schauer.schautrack"
+  # SHA-256 signing-cert fingerprint(s), comma-separated in UPPER:CO:LON form.
+  # DEPLOYMENT-SPECIFIC — from Play Console → App signing (or keytool -list -v).
+  # Empty = endpoint disabled. Never commit a placeholder/fake value.
+  androidCertFingerprints: ""
 
 # SMTP configuration (for password reset emails)
 # ⚠️  SECURITY WARNING: SMTP credentials are sensitive! 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,10 @@ type Config struct {
 	RobotsIndex bool
 	BaseURL     string
 
+	// Android App Links (Digital Asset Links)
+	AndroidPackageName      string
+	AndroidCertFingerprints []string
+
 	// Legal
 	ImprintURL     string
 	ImprintAddress string
@@ -112,6 +116,9 @@ func Load() (*Config, error) {
 
 		RobotsIndex: os.Getenv("ROBOTS_INDEX") == "true",
 		BaseURL:     os.Getenv("BASE_URL"),
+
+		AndroidPackageName:      envOr("ANDROID_PACKAGE_NAME", "to.schauer.schautrack"),
+		AndroidCertFingerprints: parseCSV(os.Getenv("ANDROID_CERT_FINGERPRINTS")),
 
 		ImprintURL:     envOr("IMPRINT_URL", "/imprint"),
 		ImprintAddress: os.Getenv("IMPRINT_ADDRESS"),

--- a/internal/handler/legal.go
+++ b/internal/handler/legal.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
@@ -74,6 +75,53 @@ func SitemapXml(cfg *config.Config) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/xml")
 		w.Write([]byte(sb.String()))
+	}
+}
+
+// AssetLinks serves GET /.well-known/assetlinks.json — the Digital Asset Links
+// file that binds this domain to the published Android app so Android App Links
+// verification (and TWA validation, if the app is a wrapper) can open https://
+// links to this domain inside the app.
+//
+// The SHA-256 signing-certificate fingerprint(s) are DEPLOYMENT-SPECIFIC and
+// must be supplied via ANDROID_CERT_FINGERPRINTS (comma-separated, e.g. the
+// Play App Signing key and, if used, the upload key). Until at least one
+// fingerprint is configured the endpoint 404s: a statement with an empty or
+// placeholder fingerprint is rejected by Android's verifier anyway, and we never
+// ship a fake value.
+func AssetLinks(cfg *config.Config) http.HandlerFunc {
+	type target struct {
+		Namespace              string   `json:"namespace"`
+		PackageName            string   `json:"package_name"`
+		SHA256CertFingerprints []string `json:"sha256_cert_fingerprints"`
+	}
+	type statement struct {
+		Relation []string `json:"relation"`
+		Target   target   `json:"target"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if cfg.AndroidPackageName == "" || len(cfg.AndroidCertFingerprints) == 0 {
+			http.NotFound(w, r)
+			return
+		}
+
+		body := []statement{{
+			Relation: []string{"delegate_permission/common.handle_all_urls"},
+			Target: target{
+				Namespace:              "android_app",
+				PackageName:            cfg.AndroidPackageName,
+				SHA256CertFingerprints: cfg.AndroidCertFingerprints,
+			},
+		}}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(body); err != nil {
+			http.Error(w, "failed to encode asset links", http.StatusInternalServerError)
+		}
 	}
 }
 

--- a/internal/handler/legal_test.go
+++ b/internal/handler/legal_test.go
@@ -1,0 +1,75 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"schautrack/internal/config"
+)
+
+func TestAssetLinks_UnconfiguredReturns404(t *testing.T) {
+	// No fingerprint configured -> endpoint is disabled and must 404 rather
+	// than serve a statement with an empty/placeholder fingerprint.
+	cfg := &config.Config{AndroidPackageName: "to.schauer.schautrack"}
+	h := AssetLinks(cfg)
+
+	r := httptest.NewRequest(http.MethodGet, "/.well-known/assetlinks.json", nil)
+	w := httptest.NewRecorder()
+	h(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestAssetLinks_ConfiguredServesValidStatement(t *testing.T) {
+	fp := "14:6D:E9:83:C5:73:06:50:D8:EE:B9:95:2F:34:FC:64:16:A0:83:42:E6:1D:BE:A8:8A:04:96:B2:3F:CF:44:E5"
+	cfg := &config.Config{
+		AndroidPackageName:      "to.schauer.schautrack",
+		AndroidCertFingerprints: []string{fp},
+	}
+	h := AssetLinks(cfg)
+
+	r := httptest.NewRequest(http.MethodGet, "/.well-known/assetlinks.json", nil)
+	w := httptest.NewRecorder()
+	h(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	// Must be a valid Digital Asset Links array with the expected shape.
+	var stmts []struct {
+		Relation []string `json:"relation"`
+		Target   struct {
+			Namespace              string   `json:"namespace"`
+			PackageName            string   `json:"package_name"`
+			SHA256CertFingerprints []string `json:"sha256_cert_fingerprints"`
+		} `json:"target"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &stmts); err != nil {
+		t.Fatalf("response is not valid JSON: %v\nbody: %s", err, w.Body.String())
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("statements = %d, want 1", len(stmts))
+	}
+
+	s := stmts[0]
+	if len(s.Relation) != 1 || s.Relation[0] != "delegate_permission/common.handle_all_urls" {
+		t.Errorf("relation = %v, want [delegate_permission/common.handle_all_urls]", s.Relation)
+	}
+	if s.Target.Namespace != "android_app" {
+		t.Errorf("namespace = %q, want android_app", s.Target.Namespace)
+	}
+	if s.Target.PackageName != "to.schauer.schautrack" {
+		t.Errorf("package_name = %q, want to.schauer.schautrack", s.Target.PackageName)
+	}
+	if len(s.Target.SHA256CertFingerprints) != 1 || s.Target.SHA256CertFingerprints[0] != fp {
+		t.Errorf("sha256_cert_fingerprints = %v, want [%s]", s.Target.SHA256CertFingerprints, fp)
+	}
+}


### PR DESCRIPTION
Serves the Android Digital Asset Links file at `/.well-known/assetlinks.json` via a new Go handler registered as an explicit chi route (before the SPA catch-all, so it isn't shadowed by index.html). This binds the domain to the published app `to.schauer.schautrack` for App Links verification / TWA validation — previously the router served no such endpoint.

**Fingerprint caveat:** the SHA-256 signing-certificate fingerprint is deployment-specific, so it is NOT hardcoded. It's configurable via `ANDROID_CERT_FINGERPRINTS` (comma-separated) with the package name via `ANDROID_PACKAGE_NAME` (default `to.schauer.schautrack`). No placeholder/fake value is shipped — the endpoint 404s until a real fingerprint is set (a statement with an empty/placeholder fingerprint is rejected by Android anyway). Documented in `.env.example`, `README.md`, and the Helm chart (values, configmap, README).

**Verification:** `go build ./...` and `go vet ./...` pass; new handler tests pass (404 when unconfigured, valid statement when configured); rendered output validated as correct Digital Asset Links JSON via `jq`; confirmed the explicit route wins over the SPA `/*` catch-all. Docker e2e suite not run per instructions.

Refs #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)