### PR TITLE
feat(client): add PWA web app manifest for installability

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,6 +8,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,19 @@
+{
+  "id": "/",
+  "name": "Schautrack",
+  "short_name": "Schautrack",
+  "description": "Self-hostable nutrition tracker — log calories, macros, and weight, set goals, and track progress.",
+  "lang": "en",
+  "dir": "ltr",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "theme_color": "#070d1a",
+  "background_color": "#070d1a",
+  "icons": [
+    { "src": "/favicon-16.png", "sizes": "16x16", "type": "image/png" },
+    { "src": "/favicon-32.png", "sizes": "32x32", "type": "image/png" },
+    { "src": "/apple-touch-icon.png", "sizes": "180x180", "type": "image/png" },
+    { "src": "/logo.png", "sizes": "512x512", "type": "image/png", "purpose": "any" }
+  ]
+}


### PR DESCRIPTION
Adds `public/manifest.webmanifest` and links it from `client/index.html`, so browsers can offer an install prompt and run Schautrack in a standalone app window. The manifest declares name/short_name, a description, icons reused from existing `public/` assets (favicon-16/32, apple-touch-icon 180, logo 512), theme/background color `#070d1a`, `display: standalone`, and `start_url`/`scope` `/`. It is served by the Go `spaFallback` handler at `/manifest.webmanifest` — the same path the existing favicons and apple-touch-icon already use — so no server or CSP change was needed (`default-src 'self'` covers the same-origin manifest fetch).

What remains (follow-up, intentionally out of scope): a service worker / offline shell (the harder, riskier half of full PWA support) and, optionally, serving the manifest with an explicit `application/manifest+json` content-type (browsers accept the current JSON response for installability).

Verification: `cd client && npm run build` succeeds; the built `dist/index.html` contains `<link rel="manifest" href="/manifest.webmanifest">`; the manifest is well-formed JSON; and all four referenced icon files exist in `public/`.

Refs #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)