### PR TITLE
fix: self-host Noto Sans, remove Google Fonts third-party dependency

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,9 +8,6 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7,6 +7,7 @@
       "name": "schautrack-client",
       "dependencies": {
         "@ericblade/quagga2": "^1.12.1",
+        "@fontsource/noto-sans": "^5.2.10",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
@@ -120,6 +121,12 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/noto-sans": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans/-/noto-sans-5.2.10.tgz",
+      "integrity": "sha512-J58RVfS/C0Z2VBF+PoU260Tx8cdRGYuS+e3yQe4hYaIYDl0sEVn5CzlLo5zVRvQD0HaIUTV8AZMfqR7rtdEpqQ==",
+      "license": "OFL-1.1"
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@ericblade/quagga2": "^1.12.1",
+    "@fontsource/noto-sans": "^5.2.10",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -4,6 +4,12 @@ import { BrowserRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import App from './App';
+// Self-hosted Noto Sans (weights 400/500/600/700) — replaces the third-party
+// Google Fonts request for GDPR compliance and air-gapped/self-hosted support.
+import '@fontsource/noto-sans/400.css';
+import '@fontsource/noto-sans/500.css';
+import '@fontsource/noto-sans/600.css';
+import '@fontsource/noto-sans/700.css';
 import '@/styles/global.css';
 
 export const queryClient = new QueryClient({

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -7,8 +7,8 @@ func SecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; "+
-				"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "+
-				"font-src 'self' https://fonts.gstatic.com; "+
+				"style-src 'self' 'unsafe-inline'; "+
+				"font-src 'self'; "+
 				"img-src 'self' data: blob:; "+
 				"script-src 'self'")
 		w.Header().Set("Cross-Origin-Opener-Policy", "same-origin")


### PR DESCRIPTION
Self-hosts the Noto Sans font (weights 400/500/600/700) via `@fontsource/noto-sans` instead of loading it from fonts.googleapis.com / fonts.gstatic.com, then tightens the CSP to drop those third-party allowances. Removes a GDPR liability for German-imprint deployments (LG München ruling), fixes broken typography in air-gapped self-hosts, and eliminates a render-blocking third-party request.

Verification: `cd client && npm run build` succeeds and the built `dist/` no longer references `fonts.googleapis.com`/`fonts.gstatic.com` (fonts now emitted as same-origin `/assets/noto-sans-*.woff2`); `npm ci` reproduces cleanly from the lockfile; `go build ./...` and the middleware tests pass. The tightened `font-src 'self'` / `style-src 'self'` covers the now same-origin `@font-face` CSS and font files.

Refs #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
