### PR TITLE
fix(validation): reject impossible calendar dates

### DIFF
--- a/internal/handler/date_validation_handlers_test.go
+++ b/internal/handler/date_validation_handlers_test.go
@@ -1,0 +1,58 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func assertImpossibleDateRejected(t *testing.T, call func(http.ResponseWriter, *http.Request), path string) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, path+"?date=2026-02-31", nil)
+
+	// These handlers all validate before touching the current user or database;
+	// their zero-value dependencies make the test panic if that ordering regresses.
+	call(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["error"] != "Invalid date" {
+		t.Errorf("error = %q, want %q", body["error"], "Invalid date")
+	}
+}
+
+func TestDateReadHandlersRejectImpossibleCalendarDates(t *testing.T) {
+	t.Run("day entries", func(t *testing.T) {
+		assertImpossibleDateRejected(t, (&EntriesHandler{}).DayEntries, "/entries/day")
+	})
+	t.Run("weight", func(t *testing.T) {
+		assertImpossibleDateRejected(t, (&WeightHandler{}).WeightDay, "/weight/day")
+	})
+	t.Run("todos", func(t *testing.T) {
+		assertImpossibleDateRejected(t, (&TodosHandler{}).DayTodos, "/api/todos/day")
+	})
+	t.Run("notes", func(t *testing.T) {
+		assertImpossibleDateRejected(t, (&NotesHandler{}).Get, "/api/notes/day")
+	})
+}
+
+func TestValidateTargetDateRejectsImpossibleCalendarDate(t *testing.T) {
+	date := "2099-02-31"
+	if validateTargetDate("date", &date, "2026-01-01") {
+		t.Fatal("validateTargetDate accepted an impossible calendar date")
+	}
+}
+
+func TestSanitizeDateRangeFallsBackFromImpossibleCalendarDates(t *testing.T) {
+	start, end := sanitizeDateRange("2026-02-31", "2026-04-31", 14, "UTC")
+	if !isValidDate(start) || !isValidDate(end) {
+		t.Fatalf("sanitizeDateRange returned invalid range %q..%q", start, end)
+	}
+}

--- a/internal/handler/entries.go
+++ b/internal/handler/entries.go
@@ -388,7 +388,7 @@ func (h *EntriesHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 // DayEntries handles GET /entries/day
 func (h *EntriesHandler) DayEntries(w http.ResponseWriter, r *http.Request) {
 	dateStr := strings.TrimSpace(r.URL.Query().Get("date"))
-	if !dateRe.MatchString(dateStr) {
+	if !isValidDate(dateStr) {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid date")
 		return
 	}

--- a/internal/handler/entries_helpers.go
+++ b/internal/handler/entries_helpers.go
@@ -44,7 +44,7 @@ func getUserTimezone(r *http.Request, user interface{ GetTimezone() string }) st
 func sanitizeDateRange(startStr, endStr string, fallbackDays int, userTz string) (string, string) {
 	todayStr := service.FormatDateInTz(time.Now(), userTz)
 	endDate := todayStr
-	if endStr != "" && dateRe.MatchString(strings.TrimSpace(endStr)) {
+	if endStr != "" && isValidDate(strings.TrimSpace(endStr)) {
 		e := strings.TrimSpace(endStr)
 		if e <= todayStr {
 			endDate = e
@@ -53,7 +53,7 @@ func sanitizeDateRange(startStr, endStr string, fallbackDays int, userTz string)
 
 	fallbackStart := service.SubtractDaysUTC(endDate, fallbackDays-1)
 	startDate := fallbackStart
-	if startStr != "" && dateRe.MatchString(strings.TrimSpace(startStr)) {
+	if startStr != "" && isValidDate(strings.TrimSpace(startStr)) {
 		startDate = strings.TrimSpace(startStr)
 	}
 	if startDate > endDate {

--- a/internal/handler/notes.go
+++ b/internal/handler/notes.go
@@ -33,7 +33,7 @@ func (h *NotesHandler) ToggleEnabled(w http.ResponseWriter, r *http.Request) {
 // Get handles GET /api/notes/day?date=...&user=...
 func (h *NotesHandler) Get(w http.ResponseWriter, r *http.Request) {
 	dateStr := strings.TrimSpace(r.URL.Query().Get("date"))
-	if !dateRe.MatchString(dateStr) {
+	if !isValidDate(dateStr) {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid date")
 		return
 	}

--- a/internal/handler/plan.go
+++ b/internal/handler/plan.go
@@ -70,7 +70,7 @@ func validateTargetDate(paceMode string, dateStr *string, todayStr string) bool 
 	if paceMode != "date" {
 		return true
 	}
-	if dateStr == nil || !dateRe.MatchString(*dateStr) {
+	if dateStr == nil || !isValidDate(*dateStr) {
 		return false
 	}
 	return *dateStr > todayStr

--- a/internal/handler/todos.go
+++ b/internal/handler/todos.go
@@ -221,7 +221,7 @@ func (h *TodosHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 func (h *TodosHandler) DayTodos(w http.ResponseWriter, r *http.Request) {
 	dateStr := strings.TrimSpace(r.URL.Query().Get("date"))
-	if !dateRe.MatchString(dateStr) {
+	if !isValidDate(dateStr) {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid date")
 		return
 	}

--- a/internal/handler/weight.go
+++ b/internal/handler/weight.go
@@ -23,7 +23,7 @@ type WeightHandler struct {
 // WeightDay handles GET /weight/day
 func (h *WeightHandler) WeightDay(w http.ResponseWriter, r *http.Request) {
 	dateStr := strings.TrimSpace(r.URL.Query().Get("date"))
-	if !dateRe.MatchString(dateStr) {
+	if !isValidDate(dateStr) {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid date")
 		return
 	}
@@ -80,7 +80,7 @@ func (h *WeightHandler) WeightUpsert(w http.ResponseWriter, r *http.Request) {
 	if dateStr == "" || dateStr == "<nil>" {
 		dateStr = service.FormatDateInTz(time.Now(), userTz)
 	}
-	if !dateRe.MatchString(dateStr) {
+	if !isValidDate(dateStr) {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid date")
 		return
 	}
@@ -125,4 +125,3 @@ func (h *WeightHandler) WeightDelete(w http.ResponseWriter, r *http.Request) {
 	}
 	OkJSON(w)
 }
-


### PR DESCRIPTION
## Summary

- use full calendar validation for entry, weight, todo, and note day endpoints
- validate weight writes and planner target dates the same way
- ignore impossible custom range dates instead of forwarding them to PostgreSQL
- add regression coverage for 2026-02-31 and invalid range fallbacks

## Why

The affected paths checked only the YYYY-MM-DD shape. Values such as 2026-02-31 passed that regex and then caused database errors or inconsistent fallback behavior.

## Tests

- go test ./...
- go vet ./...
- handler regressions verify validation happens before user/database access