### PR TITLE
fix(auth): revalidate reset token before password change

### DIFF
--- a/internal/handler/auth_password.go
+++ b/internal/handler/auth_password.go
@@ -1,14 +1,43 @@
 package handler
 
 import (
+	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
+
 	"schautrack/internal/service"
 	"schautrack/internal/session"
 )
+
+var errResetTokenNoLongerValid = errors.New("password reset token is no longer valid")
+
+type resetTokenExecutor interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+}
+
+// consumePasswordResetToken revalidates and consumes the token at the moment
+// the password is changed. Code verification and password submission are two
+// separate requests, so the token may expire or be consumed by another reset
+// between them.
+func consumePasswordResetToken(ctx context.Context, tx resetTokenExecutor, tokenID, userID int) error {
+	tag, err := tx.Exec(ctx, `
+		UPDATE password_reset_tokens
+		SET used = TRUE
+		WHERE id = $1 AND user_id = $2 AND used = FALSE AND expires_at > NOW()`,
+		tokenID, userID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() != 1 {
+		return errResetTokenNoLongerValid
+	}
+	return nil
+}
 
 // ForgotPassword handles POST /api/auth/forgot-password
 func (h *AuthHandler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
@@ -154,8 +183,8 @@ func (h *AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update the password, consume the token, and invalidate EVERY existing
-	// session of the user atomically: an attacker holding a stolen session
+	// Revalidate and consume the token, update the password, and invalidate every
+	// existing session atomically: an attacker holding a stolen session
 	// cookie must not keep access after the victim resets their password.
 	// The caller's own (anonymous) session carries no userId and survives.
 	tx, err := h.Pool.Begin(r.Context())
@@ -164,11 +193,19 @@ func (h *AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer tx.Rollback(r.Context())
-	if _, err := tx.Exec(r.Context(), "UPDATE users SET password_hash = $1 WHERE id = $2", hash, userID); err != nil {
+	if err := consumePasswordResetToken(r.Context(), tx, tokenID, userID); err != nil {
+		if errors.Is(err, errResetTokenNoLongerValid) {
+			sess.Delete("resetEmail")
+			sess.Delete("resetCodeVerified")
+			sess.Delete("resetTokenId")
+			sess.Delete("resetUserId")
+			ErrorJSON(w, http.StatusBadRequest, "Reset code expired or already used. Please start again.")
+			return
+		}
 		ErrorJSON(w, http.StatusInternalServerError, "Could not reset password.")
 		return
 	}
-	if _, err := tx.Exec(r.Context(), "UPDATE password_reset_tokens SET used = TRUE WHERE id = $1", tokenID); err != nil {
+	if _, err := tx.Exec(r.Context(), "UPDATE users SET password_hash = $1 WHERE id = $2", hash, userID); err != nil {
 		ErrorJSON(w, http.StatusInternalServerError, "Could not reset password.")
 		return
 	}

--- a/internal/handler/auth_password_test.go
+++ b/internal/handler/auth_password_test.go
@@ -1,14 +1,64 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
+
 	"schautrack/internal/session"
 )
+
+type fakeResetTokenExecutor struct {
+	tag   pgconn.CommandTag
+	err   error
+	query string
+	args  []any
+}
+
+func (f *fakeResetTokenExecutor) Exec(_ context.Context, query string, args ...any) (pgconn.CommandTag, error) {
+	f.query = query
+	f.args = args
+	return f.tag, f.err
+}
+
+func TestConsumePasswordResetToken(t *testing.T) {
+	t.Run("consumes one current unused token", func(t *testing.T) {
+		fake := &fakeResetTokenExecutor{tag: pgconn.NewCommandTag("UPDATE 1")}
+		if err := consumePasswordResetToken(context.Background(), fake, 17, 42); err != nil {
+			t.Fatalf("consumePasswordResetToken: %v", err)
+		}
+		for _, guard := range []string{"user_id = $2", "used = FALSE", "expires_at > NOW()"} {
+			if !strings.Contains(fake.query, guard) {
+				t.Errorf("query missing guard %q: %s", guard, fake.query)
+			}
+		}
+		if len(fake.args) != 2 || fake.args[0] != 17 || fake.args[1] != 42 {
+			t.Errorf("args = %#v, want [17 42]", fake.args)
+		}
+	})
+
+	t.Run("rejects expired or already consumed token", func(t *testing.T) {
+		fake := &fakeResetTokenExecutor{tag: pgconn.NewCommandTag("UPDATE 0")}
+		err := consumePasswordResetToken(context.Background(), fake, 17, 42)
+		if !errors.Is(err, errResetTokenNoLongerValid) {
+			t.Fatalf("error = %v, want errResetTokenNoLongerValid", err)
+		}
+	})
+
+	t.Run("propagates database errors", func(t *testing.T) {
+		want := errors.New("database unavailable")
+		fake := &fakeResetTokenExecutor{err: want}
+		if err := consumePasswordResetToken(context.Background(), fake, 17, 42); !errors.Is(err, want) {
+			t.Fatalf("error = %v, want %v", err, want)
+		}
+	})
+}
 
 // newRequestWithSessionData builds a POST request whose context carries the
 // given session, and returns both the request and the session so the test can


### PR DESCRIPTION
## Summary

- revalidate the stored reset token when the password change is submitted
- atomically consume only a matching, unused, unexpired token for the same user
- clear stale reset state when another request consumed the token or it expired

## Why

Code verification and password submission are separate requests. Previously, the second request trusted session flags indefinitely and marked the token used without checking its current state, allowing an expired or concurrently consumed token to authorize a later password change.

## Tests

- go test ./...
- go vet ./...
- focused command-tag and query-guard regression tests