### PR TITLE
fix(links): refresh viewers when sharing permissions change

### DIFF
--- a/client/src/hooks/useSSE.ts
+++ b/client/src/hooks/useSSE.ts
@@ -54,6 +54,13 @@ export function useSSE() {
         queryClient.invalidateQueries({ queryKey: ['dashboard'] });
       });
 
+      source.addEventListener('link-shares-change', () => {
+        // A permission change can add/remove whole sections from a linked
+        // dashboard. Refresh both the viewer and any other open settings tab.
+        queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+        queryClient.invalidateQueries({ queryKey: ['settings'] });
+      });
+
       source.addEventListener('todo-change', () => {
         queryClient.invalidateQueries({ queryKey: ['dashboard'] });
         queryClient.invalidateQueries({ queryKey: ['todos'] });

--- a/e2e/linked-sse.spec.ts
+++ b/e2e/linked-sse.spec.ts
@@ -12,6 +12,8 @@ let userA: { email: string; password: string; id: string };
 let userB: { email: string; password: string; id: string };
 
 test.describe('Linked User SSE Propagation', () => {
+  test.describe.configure({ mode: 'serial' });
+
   test.beforeAll(() => {
     userA = createIsolatedUser('linked-sse-a');
     userB = createIsolatedUser('linked-sse-b');
@@ -90,6 +92,40 @@ test.describe('Linked User SSE Propagation', () => {
         await expect(pageA.getByRole('button', { name: entryName })).toBeVisible({ timeout: 5000 });
         test.skip(true, 'Share card dot not visible; cannot verify cross-user SSE in this configuration');
       }
+    } finally {
+      await ctxA.close();
+      await ctxB.close();
+    }
+  });
+
+  test('share permission changes propagate to the linked viewer without reload', async ({ browser }) => {
+    // User A is target_id, so target_shares controls what A shares with B.
+    // Start with nutrition as the only shared category: disabling it should
+    // remove A's entire share card from B's already-open dashboard.
+    psql(`UPDATE account_links
+      SET target_shares = '{"nutrition":true,"weight":false,"todos":false,"notes":false}'::jsonb
+      WHERE requester_id = ${userB.id} AND target_id = ${userA.id}`);
+
+    const { context: ctxA, page: pageA } = await loginUser(browser, userA.email, userA.password);
+    const { context: ctxB, page: pageB } = await loginUser(browser, userB.email, userB.password);
+
+    try {
+      await pageB.goto('/dashboard');
+      const userALabel = pageB
+        .locator('.text-sm.font-medium')
+        .filter({ hasText: new RegExp(userA.email.split('@')[0], 'i') })
+        .first();
+      await expect(userALabel).toBeVisible({ timeout: 20000 });
+
+      await pageA.goto('/settings');
+      const linkButton = pageA.getByRole('button', { name: userB.email });
+      await expect(linkButton).toBeVisible({ timeout: 10000 });
+      const linkRow = linkButton.locator('../..');
+      const nutrition = linkRow.locator('label', { hasText: 'Nutrition' });
+      await expect(nutrition.locator('input')).toBeChecked();
+      await nutrition.click();
+
+      await expect(userALabel).toHaveCount(0, { timeout: 15000 });
     } finally {
       await ctxA.close();
       await ctxB.close();

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -918,14 +918,16 @@ func (h *LinksHandler) SetShares(w http.ResponseWriter, r *http.Request) {
 	user := middleware.GetCurrentUser(r)
 
 	var saved []byte
+	var otherUserID int
 	err = h.Pool.QueryRow(r.Context(), `
 		UPDATE account_links
 		SET requester_shares = CASE WHEN requester_id = $3 THEN $1::jsonb ELSE requester_shares END,
 			target_shares    = CASE WHEN target_id    = $3 THEN $1::jsonb ELSE target_shares    END,
 			updated_at = NOW()
 		WHERE id = $2 AND status = 'accepted' AND ($3 = requester_id OR $3 = target_id)
-		RETURNING CASE WHEN requester_id = $3 THEN requester_shares ELSE target_shares END`,
-		sharesJSON, linkID, user.ID).Scan(&saved)
+		RETURNING CASE WHEN requester_id = $3 THEN requester_shares ELSE target_shares END,
+			CASE WHEN requester_id = $3 THEN target_id ELSE requester_id END`,
+		sharesJSON, linkID, user.ID).Scan(&saved, &otherUserID)
 	if err != nil {
 		ErrorJSON(w, http.StatusNotFound, "Link not found")
 		return
@@ -934,7 +936,10 @@ func (h *LinksHandler) SetShares(w http.ResponseWriter, r *http.Request) {
 	var savedMap map[string]bool
 	json.Unmarshal(saved, &savedMap)
 	savedMap = service.SanitizeShareMap(savedMap)
+	// Notify both sides: the caller may have another settings tab open, while
+	// the linked user must immediately gain/lose the affected dashboard data.
 	h.Broker.BroadcastLinkSharesChange(linkID, user.ID, savedMap)
+	h.Broker.BroadcastLinkSharesChange(linkID, otherUserID, savedMap)
 	JSON(w, http.StatusOK, map[string]any{"ok": true, "shares": savedMap})
 }
 


### PR DESCRIPTION
## Summary

- return the linked user ID while updating per-link share permissions
- publish the permission-change SSE event to both link participants
- handle link-shares-change in the client and refresh dashboard/settings data
- add a browser regression test for a linked viewer losing access without reloading

## Why

The server previously sent link-shares-change only to the user who changed the setting, and the client had no listener for it. A linked user could keep seeing stale sections until a manual reload.

## Tests

- go test ./...
- go vet ./...
- npm test
- npm run typecheck
- npm run build
- Playwright linked-sse.spec.ts: 3 passed against an isolated app/PostgreSQL stack