### PR TITLE
fix(build): support Vite native config loading

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, 'src'),
+      '@': path.resolve(import.meta.dirname, 'src'),
     },
   },
   server: {


### PR DESCRIPTION
## Summary

- resolve the client source alias from import.meta.dirname instead of the CommonJS-style __dirname compatibility shim
- keep the existing alias behavior while making the ESM config compatible with Vite native config loading

## Why

Vite 8 warns that __dirname is unsupported by its native config loader, which is planned to become the default. The project runs on Node 24, where import.meta.dirname is available directly.

## Tests

- npm test
- npm run typecheck
- npm run build
- confirmed the Vite native-config compatibility warning is gone