### PR TITLE
fix(todos): use a native time picker and unblock the Clear button

### DIFF
--- a/client/src/i18n/locales/de/dashboard.json
+++ b/client/src/i18n/locales/de/dashboard.json
@@ -282,6 +282,7 @@
     "missedDaysAgo_other": "{{count}}T",
     "streakDays_one": "{{count}}T",
     "streakDays_other": "{{count}}T",
+    "timeOfDayAriaLabel": "Uhrzeit",
     "toastCreateFailed": "Todo konnte nicht erstellt werden",
     "toastUpdateFailed": "Todo konnte nicht aktualisiert werden",
     "toastDeleteFailed": "Todo konnte nicht gelöscht werden",

--- a/client/src/i18n/locales/en/dashboard.json
+++ b/client/src/i18n/locales/en/dashboard.json
@@ -290,6 +290,7 @@
     "specificDaysOption": "Specific days",
     "streakDays_one": "{{count}}d",
     "streakDays_other": "{{count}}d",
+    "timeOfDayAriaLabel": "Time of day",
     "toastCreateFailed": "Failed to create todo",
     "toastDeleteFailed": "Failed to delete todo",
     "toastUpdateFailed": "Failed to update todo",

--- a/client/src/i18n/locales/es/dashboard.json
+++ b/client/src/i18n/locales/es/dashboard.json
@@ -282,6 +282,7 @@
     "missedDaysAgo_other": "{{count}}d",
     "streakDays_one": "{{count}}d",
     "streakDays_other": "{{count}}d",
+    "timeOfDayAriaLabel": "Hora del día",
     "toastCreateFailed": "Error al crear la tarea",
     "toastUpdateFailed": "Error al actualizar la tarea",
     "toastDeleteFailed": "Error al eliminar la tarea",

--- a/client/src/i18n/locales/fr/dashboard.json
+++ b/client/src/i18n/locales/fr/dashboard.json
@@ -282,6 +282,7 @@
     "missedDaysAgo_other": "{{count}} j",
     "streakDays_one": "{{count}} j",
     "streakDays_other": "{{count}} j",
+    "timeOfDayAriaLabel": "Heure de la journée",
     "toastCreateFailed": "Échec de la création de la tâche",
     "toastUpdateFailed": "Échec de la mise à jour de la tâche",
     "toastDeleteFailed": "Échec de la suppression de la tâche",

--- a/client/src/i18n/locales/it/dashboard.json
+++ b/client/src/i18n/locales/it/dashboard.json
@@ -282,6 +282,7 @@
     "missedDaysAgo_other": "{{count}}g",
     "streakDays_one": "{{count}}g",
     "streakDays_other": "{{count}}g",
+    "timeOfDayAriaLabel": "Ora del giorno",
     "toastCreateFailed": "Creazione dell'attività non riuscita",
     "toastUpdateFailed": "Aggiornamento dell'attività non riuscito",
     "toastDeleteFailed": "Eliminazione dell'attività non riuscita",

--- a/client/src/i18n/locales/nl/dashboard.json
+++ b/client/src/i18n/locales/nl/dashboard.json
@@ -282,6 +282,7 @@
     "missedDaysAgo_other": "{{count}}d",
     "streakDays_one": "{{count}}d",
     "streakDays_other": "{{count}}d",
+    "timeOfDayAriaLabel": "Tijdstip",
     "toastCreateFailed": "Aanmaken van taak mislukt",
     "toastUpdateFailed": "Bijwerken van taak mislukt",
     "toastDeleteFailed": "Verwijderen van taak mislukt",

--- a/client/src/i18n/locales/pl/dashboard.json
+++ b/client/src/i18n/locales/pl/dashboard.json
@@ -298,6 +298,7 @@
     "streakDays_few": "{{count}}d",
     "streakDays_many": "{{count}}d",
     "streakDays_other": "{{count}}d",
+    "timeOfDayAriaLabel": "Pora dnia",
     "toastCreateFailed": "Nie udało się utworzyć zadania",
     "toastUpdateFailed": "Nie udało się zaktualizować zadania",
     "toastDeleteFailed": "Nie udało się usunąć zadania",

--- a/client/src/i18n/locales/pt/dashboard.json
+++ b/client/src/i18n/locales/pt/dashboard.json
@@ -282,6 +282,7 @@
     "missedDaysAgo_other": "{{count}}d",
     "streakDays_one": "{{count}}d",
     "streakDays_other": "{{count}}d",
+    "timeOfDayAriaLabel": "Hora do dia",
     "toastCreateFailed": "Falha ao criar tarefa",
     "toastUpdateFailed": "Falha ao atualizar tarefa",
     "toastDeleteFailed": "Falha ao eliminar tarefa",

--- a/client/src/pages/Dashboard/TodoList.tsx
+++ b/client/src/pages/Dashboard/TodoList.tsx
@@ -17,45 +17,24 @@ function getDayLabels(t: TFunction): string[] {
   return DAY_KEYS.map((k) => t(`dashboard:todos.days.${k}`));
 }
 
-function formatTimeDigits(digits: string): string {
-  if (digits.length <= 2) return digits;
-  return digits.slice(0, 2) + ':' + digits.slice(2, 4);
-}
-
-function toTimeValue(digits: string): string {
-  if (!digits) return '';
-  const h = digits.slice(0, 2).padEnd(2, '0');
-  const m = digits.length >= 3 ? digits.slice(2, 4).padEnd(2, '0') : '00';
-  return `${h}:${m}`;
-}
-
+// A native time input: it renders the platform's time picker, emits the same
+// `HH:MM` (24h) / '' the API already expects, and needs no manual digit
+// formatting. The picker's own clock affordance replaces the icon this used to
+// overlay — that icon was absolutely positioned against the wrapper (which also
+// holds the Clear button), so it rendered on top of Clear instead of inside the
+// field.
 function TimeInput({ value, onChange, onClear }: { value: string; onChange: (v: string) => void; onClear: () => void }) {
   const { t } = useTranslation('dashboard');
-  // value is HH:MM or '', digits is raw digits only
-  const digits = value.replace(':', '');
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const raw = e.target.value.replace(/\D/g, '').slice(0, 4);
-    onChange(raw ? formatTimeDigits(raw) : '');
-  };
-
-  const handleBlur = () => {
-    if (digits) onChange(toTimeValue(digits));
-  };
 
   return (
-    <span className="relative flex items-center gap-2">
+    <span className="flex items-center gap-2">
       <input
-        type="text"
-        inputMode="numeric"
+        type="time"
         value={value}
-        onChange={handleChange}
-        onBlur={handleBlur}
-        placeholder="HH:MM"
-        maxLength={5}
-        className="w-24 rounded-md border border-input bg-muted/50 px-2.5 py-2 text-sm text-foreground outline-none transition-colors focus:border-ring focus:ring-1 focus:ring-ring pr-7"
+        onChange={(e) => onChange(e.target.value)}
+        aria-label={t('todos.timeOfDayAriaLabel')}
+        className="rounded-md border border-input bg-muted/50 px-2.5 py-2 text-sm text-foreground outline-none transition-colors focus:border-ring focus:ring-1 focus:ring-ring"
       />
-      <span className="absolute right-2 text-[10px] text-muted-foreground/60 pointer-events-none">🕑</span>
       {value && (
         <Button type="button" size="sm" variant="ghost" onClick={onClear}>{t('todos.clearButton')}</Button>
       )}

--- a/e2e/todos.spec.ts
+++ b/e2e/todos.spec.ts
@@ -292,10 +292,10 @@ test.describe.serial('Todos', () => {
     await expect(nameInput).toBeVisible({ timeout: 5000 });
     await nameInput.fill('Timed Todo');
 
-    // Enter a time using the HH:MM input
-    const timeInput = page.locator('input[placeholder="HH:MM"]');
-    await timeInput.fill('0800');
-    await timeInput.blur(); // triggers formatting
+    // Pick a time using the native time picker
+    const timeInput = page.getByLabel('Time of day');
+    await expect(timeInput).toHaveAttribute('type', 'time');
+    await timeInput.fill('08:00');
 
     await page.getByRole('button', { name: 'Add', exact: true }).click();
 
@@ -314,6 +314,89 @@ test.describe.serial('Todos', () => {
     await page.getByRole('button', { name: 'Edit' }).first().click();
     const timedRow = page.locator('li').filter({ hasText: 'Timed Todo' });
     await timedRow.getByRole('button', { name: 'Remove' }).click();
+    await page.getByRole('button', { name: 'Done' }).last().click();
+
+    await ctx.close();
+  });
+
+  test('Clear button empties the time picker and persists the cleared time', async ({ browser }) => {
+    const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+    const page = await ctx.newPage();
+    await loginAndGo(page);
+
+    // Create a todo that has a time of day
+    const addTodoBtn = page.getByText('Add a todo');
+    if (await addTodoBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await addTodoBtn.click();
+    } else {
+      await page.getByRole('button', { name: 'Edit' }).first().click();
+      await page.getByRole('button', { name: 'Add todo' }).click();
+    }
+    const nameInput = page.locator('input[placeholder="Todo name"]');
+    await expect(nameInput).toBeVisible({ timeout: 5000 });
+    await nameInput.fill('Clearable Todo');
+    await page.getByLabel('Time of day').fill('09:30');
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
+
+    // Reopen it for editing — the saved time should be loaded into the picker
+    const managerRow = page.locator('li').filter({ hasText: 'Clearable Todo' });
+    await expect(managerRow).toBeVisible({ timeout: 5000 });
+    await managerRow.getByRole('button', { name: 'Edit' }).click();
+    const timeInput = page.getByLabel('Time of day');
+    await expect(timeInput).toHaveValue('09:30');
+
+    // The Clear button must not be covered by anything. The icon this field
+    // used to render was absolutely positioned against the wrapper that also
+    // holds this button, so it landed on top of the label ("Clea🕑") and made
+    // the button look broken. Assert no unrelated element overlaps its box.
+    const clearBtn = page.getByRole('button', { name: 'Clear' });
+    await expect(clearBtn).toBeVisible();
+    const clearBox = (await clearBtn.boundingBox())!;
+    const timeBox = (await timeInput.boundingBox())!;
+    expect(timeBox.x + timeBox.width).toBeLessThanOrEqual(clearBox.x);
+
+    const overlapping = await clearBtn.evaluate((btn) => {
+      const target = btn.getBoundingClientRect();
+      return [...document.body.querySelectorAll('*')]
+        .filter((el) => el !== btn && !el.contains(btn) && !btn.contains(el))
+        .filter((el) => {
+          const r = el.getBoundingClientRect();
+          return (
+            r.width > 0 &&
+            r.height > 0 &&
+            r.left < target.right &&
+            r.right > target.left &&
+            r.top < target.bottom &&
+            r.bottom > target.top
+          );
+        })
+        .map((el) => `${el.tagName.toLowerCase()}:${(el.textContent ?? '').trim().slice(0, 12)}`);
+    });
+    expect(overlapping).toEqual([]);
+
+    // Clearing empties the picker and hides the button
+    await clearBtn.click();
+    await expect(timeInput).toHaveValue('');
+    await expect(clearBtn).toBeHidden();
+
+    // Saving persists the cleared time (the dashboard has another Save button,
+    // so scope to the row holding the open todo editor)
+    const editRow = page.locator('li').filter({ has: page.getByLabel('Time of day') });
+    await editRow.getByRole('button', { name: 'Save' }).click();
+    await page.getByRole('button', { name: 'Done' }).last().click();
+
+    const listRow = page.locator('li').filter({ hasText: 'Clearable Todo' });
+    await expect(listRow).toBeVisible({ timeout: 5000 });
+    await expect(listRow.getByText(/09:30/)).toBeHidden();
+    expect(
+      psql(`SELECT COALESCE(time_of_day::text, 'NULL') FROM todos WHERE user_id = :id AND name = 'Clearable Todo'`, {
+        id: user.id,
+      })
+    ).toBe('NULL');
+
+    // Clean up
+    await page.getByRole('button', { name: 'Edit' }).first().click();
+    await page.locator('li').filter({ hasText: 'Clearable Todo' }).getByRole('button', { name: 'Remove' }).click();
     await page.getByRole('button', { name: 'Done' }).last().click();
 
     await ctx.close();


### PR DESCRIPTION
## What

The todo **time-of-day** field is now a native `<input type="time">` instead of a hand-rolled text input, and the **Clear** button is no longer covered by the clock icon.

> Note on scope: todos have no per-todo *date* — their schedule is `daily` or specific weekdays. The only temporal input on a todo (and the one the Clear button belongs to) is time-of-day, so that is the field this changes. Say the word if you meant something else.

## The Clear bug — validated

It reproduces, and it is a real defect. The 🕑 glyph was positioned `absolute right-2`, but its containing block was the wrapper holding **both** the input and the Clear button. So it anchored to the wrapper's right edge and landed on top of the button rather than inside the field — whose reserved `pr-7` padding sat empty.

Measured on the old build:

| | |
|---|---|
| input | x 346 → 442 |
| glyph | x 485 → 497 |
| Clear button | x 450 → 505 |
| | `clock-overlaps-clear: true`, `clock-inside-input: false` |

The click itself worked (the glyph is `pointer-events-none`) — the button just *looked* broken, rendering as `Clea🕑`:

**Before:** `[ 08:00 ]  Clea🕑`  &nbsp;&nbsp;→&nbsp;&nbsp; **After:** `[ 08:00 AM 🕐 ]  Clear`

## Why a native input

- Renders the platform time picker instead of asking for typed digits; on mobile it opens the OS time wheel.
- Emits the same `HH:MM` (24h) / `''` the API already expects, so no conversion — and ~25 lines of digit formatting plus the blur-reformat handler are deleted.
- Its own clock affordance replaces the overlaid glyph, removing the overlap outright.
- `global.css` already styles `input[type="date"]` / `input[type="time"]` for the dark theme, so no CSS was needed, and it matches the native date pickers the entry form and timeline already use.

Native time inputs take no placeholder, so the field gains an aria-label (`todos.timeOfDayAriaLabel`), added across all eight locales.

## Tests

- The existing time-of-day spec now drives the picker.
- New spec covers Clear end to end: empties the picker, hides the button, persists as `NULL` in the DB, and asserts no element overlaps the button's box (guards against reintroducing an overlay).
- **Both fail against the previous component and pass against this one** — verified by reverting the component, rebuilding the container, and re-running.

## Verification

| Check | Result |
|---|---|
| `go test ./...` | pass |
| `tsc -b --force` | pass |
| client unit tests | 102 pass |
| i18n parity + drift (8 locales) | pass |
| todos e2e | 8/8 pass |
| full e2e suite | 233 pass, 2 flaky (passed on retry) |
| mobile 375px | field + Clear end at 224px, no horizontal overflow |

One pre-existing failure is unrelated to this change: `mobile-shell.spec.ts:150 "a new quick food is created with its values in one step"`. I confirmed it fails identically on the unmodified base branch (stashed the change, rebuilt, re-ran).

## Known follow-up (not addressed)

The picker displays locale-aware time (`08:00 AM`) while the todo list row still prints the raw 24h `08:00`. Stored data is unchanged; only the picker's rendering is locale-aware. Worth aligning separately if it bothers you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAME8WUkrmnProFzSmZgj9