### PR TITLE
fix(plan): make the weight-trend chart readable

### DIFF
--- a/client/src/lib/chartScale.test.ts
+++ b/client/src/lib/chartScale.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import { niceStep, niceTicks, clampBand } from './chartScale';
+
+/** Every step must be a 1/2/5 x 10^n value. */
+function isRoundStep(step: number): boolean {
+  const magnitude = 10 ** Math.floor(Math.log10(step));
+  const mantissa = Number((step / magnitude).toFixed(6));
+  return mantissa === 1 || mantissa === 2 || mantissa === 5;
+}
+
+describe('niceTicks', () => {
+  it('produces round ticks for the domain that motivated this helper', () => {
+    // Actual weights 105-130 plus a 79.8 target, padded. The old evenTicks()
+    // split the raw range into thirds and labelled the axis 54.7 / 79.8 /
+    // 104.9 / 130.
+    expect(niceTicks(75.8, 134, 6)).toEqual([80, 90, 100, 110, 120, 130]);
+  });
+
+  it('keeps every tick inside the domain', () => {
+    for (const [lo, hi] of [
+      [75.8, 134],
+      [54.7, 130],
+      [0, 1],
+      [-20, 5],
+      [1000, 9000],
+      [0.3, 0.9],
+      [99.4, 100.6],
+    ] as const) {
+      for (const t of niceTicks(lo, hi, 6)) {
+        expect(t).toBeGreaterThanOrEqual(lo);
+        expect(t).toBeLessThanOrEqual(hi);
+      }
+    }
+  });
+
+  it('only emits steps from the 1/2/5 x 10^n family', () => {
+    for (const [lo, hi] of [
+      [0, 1],
+      [0, 7],
+      [12, 13],
+      [54.7, 130],
+      [75.8, 134],
+      [0.3, 0.9],
+      [1000, 9000],
+    ] as const) {
+      const ticks = niceTicks(lo, hi, 6);
+      expect(ticks.length).toBeGreaterThan(1);
+      const step = Number((ticks[1] - ticks[0]).toFixed(6));
+      expect(isRoundStep(step), `step ${step} for [${lo}, ${hi}]`).toBe(true);
+    }
+  });
+
+  it('lands near the requested tick count', () => {
+    for (const [lo, hi] of [
+      [75.8, 134],
+      [54.7, 130],
+      [0, 1],
+      [1000, 9000],
+    ] as const) {
+      const n = niceTicks(lo, hi, 6).length;
+      expect(n, `count for [${lo}, ${hi}]`).toBeGreaterThanOrEqual(4);
+      expect(n, `count for [${lo}, ${hi}]`).toBeLessThanOrEqual(9);
+    }
+  });
+
+  it('spaces ticks evenly', () => {
+    const ticks = niceTicks(75.8, 134, 6);
+    const gaps = ticks.slice(1).map((t, i) => Number((t - ticks[i]).toFixed(6)));
+    expect(new Set(gaps).size).toBe(1);
+  });
+
+  it('is free of binary-float drift', () => {
+    for (const ticks of [niceTicks(0, 1, 6), niceTicks(0.3, 0.9, 6)]) {
+      for (const t of ticks) expect(Number(t.toFixed(6))).toBe(t);
+    }
+  });
+
+  it('handles a flat domain without emitting a zero-width axis', () => {
+    expect(niceTicks(80, 80, 6)).toEqual([80]);
+  });
+
+  it('accepts a reversed domain', () => {
+    expect(niceTicks(134, 75.8, 6)).toEqual(niceTicks(75.8, 134, 6));
+  });
+
+  it('returns nothing for non-finite input rather than NaN ticks', () => {
+    expect(niceTicks(NaN, 10, 6)).toEqual([]);
+    expect(niceTicks(0, Infinity, 6)).toEqual([]);
+  });
+});
+
+describe('niceStep', () => {
+  it('picks the nearest round step, not always the larger one', () => {
+    // span 58.2 over 5 slots = 11.64 -> nearest round step is 10, not 20.
+    expect(niceStep(75.8, 134, 6)).toBe(10);
+  });
+
+  it('always returns a positive finite step', () => {
+    for (const [lo, hi] of [
+      [0, 0],
+      [5, 5],
+      [0, 1e-9],
+      [-100, 100],
+    ] as const) {
+      const s = niceStep(lo, hi, 6);
+      expect(Number.isFinite(s)).toBe(true);
+      expect(s).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('clampBand', () => {
+  // Screen space: y grows downward, so plot top (10) < plot bottom (200).
+  const TOP = 10;
+  const BOTTOM = 200;
+
+  it('leaves a band fully inside the plot unchanged', () => {
+    expect(clampBand(50, 120, TOP, BOTTOM)).toEqual({ top: 50, bottom: 120 });
+  });
+
+  it('trims a band that overruns the bottom edge', () => {
+    expect(clampBand(150, 400, TOP, BOTTOM)).toEqual({ top: 150, bottom: BOTTOM });
+  });
+
+  it('trims a band that overruns the top edge', () => {
+    expect(clampBand(-90, 60, TOP, BOTTOM)).toEqual({ top: TOP, bottom: 60 });
+  });
+
+  it('drops a band that falls entirely below the plot', () => {
+    // The real case: healthy range 54.7-73.9 against an 80-130 axis.
+    expect(clampBand(320, 480, TOP, BOTTOM)).toBeNull();
+  });
+
+  it('drops a band that falls entirely above the plot', () => {
+    expect(clampBand(-200, -40, TOP, BOTTOM)).toBeNull();
+  });
+
+  it('drops a degenerate band grazing an edge', () => {
+    expect(clampBand(BOTTOM, 400, TOP, BOTTOM)).toBeNull();
+    expect(clampBand(-50, TOP, TOP, BOTTOM)).toBeNull();
+  });
+
+  it('accepts inverted top/bottom', () => {
+    expect(clampBand(120, 50, TOP, BOTTOM)).toEqual({ top: 50, bottom: 120 });
+  });
+
+  it('returns null for non-finite input', () => {
+    expect(clampBand(NaN, 50, TOP, BOTTOM)).toBeNull();
+  });
+});

--- a/client/src/lib/chartScale.ts
+++ b/client/src/lib/chartScale.ts
@@ -1,0 +1,98 @@
+/**
+ * Axis scaling helpers for the plan chart.
+ *
+ * Splitting a domain into N equal parts is mathematically correct but
+ * unreadable: a 54.7-130 range divided in three labels the axis 54.7 / 79.8 /
+ * 104.9 / 130. Readers anchor on round numbers, so ticks are snapped to a
+ * 1 / 2 / 5 x 10^n increment and only those landing inside the domain are kept.
+ */
+
+/**
+ * Trims binary-float drift (0.1 * 3 = 0.30000000000000004) without discarding
+ * real precision. Uses significant digits rather than decimal places: rounding
+ * to 6 decimals would collapse a legitimately tiny step to 0, and a zero step
+ * makes the tick loop divide by zero.
+ */
+const clean = (n: number) => (Number.isFinite(n) ? Number(n.toPrecision(12)) : n);
+
+// Geometric-mean thresholds pick the *nearest* allowed step rather than always
+// rounding up, which would systematically emit fewer ticks than requested.
+// Same heuristic d3-array uses for tickIncrement.
+const E10 = Math.sqrt(50); // 7.07
+const E5 = Math.sqrt(10); // 3.16
+const E2 = Math.sqrt(2); // 1.41
+
+/**
+ * Chooses a round step covering [min, max] in roughly `targetCount` intervals.
+ * Always returns a positive, finite number.
+ */
+export function niceStep(min: number, max: number, targetCount = 6): number {
+  const span = Math.abs(max - min);
+  if (!Number.isFinite(span) || span === 0) return 1;
+
+  const raw = span / Math.max(targetCount - 1, 1);
+  const magnitude = 10 ** Math.floor(Math.log10(raw));
+  const normalized = raw / magnitude;
+
+  const factor = normalized >= E10 ? 10 : normalized >= E5 ? 5 : normalized >= E2 ? 2 : 1;
+  return clean(factor * magnitude);
+}
+
+/**
+ * Round-numbered ticks lying inside [min, max].
+ *
+ * Ticks are placed *within* the domain rather than the domain being widened to
+ * meet them: widening trades away vertical resolution, which is the whole
+ * problem this chart had. Callers pad their domain a little so the extreme data
+ * points do not sit flush against the frame.
+ */
+export function niceTicks(min: number, max: number, targetCount = 6): number[] {
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return [];
+
+  const lo = Math.min(min, max);
+  const hi = Math.max(min, max);
+  if (lo === hi) return [clean(lo)];
+
+  const step = niceStep(lo, hi, targetCount);
+  if (!Number.isFinite(step) || step <= 0) return [];
+
+  const first = Math.ceil(lo / step) * step;
+
+  // Derive the count and multiply, rather than accumulating by +=, so the last
+  // tick is exact. The epsilon keeps a tick that lands exactly on `hi`.
+  const count = Math.floor((hi - first) / step + 1e-9);
+  if (!Number.isFinite(count) || count < 0) return [];
+
+  return Array.from({ length: count + 1 }, (_, i) => clean(first + i * step));
+}
+
+/**
+ * Clamps a band (e.g. the healthy-weight range) to the plotted area.
+ *
+ * The band is context, not data: it must never widen the domain, or a healthy
+ * range sitting 50kg below anything the user has logged would squash the actual
+ * trend into a corner. Returns null when the band falls entirely outside the
+ * plot, which callers use to drop it from the legend too.
+ *
+ * All values are screen-space y coordinates, where y grows downward.
+ */
+export function clampBand(
+  top: number,
+  bottom: number,
+  plotTop: number,
+  plotBottom: number,
+): { top: number; bottom: number } | null {
+  if (![top, bottom, plotTop, plotBottom].every(Number.isFinite)) return null;
+
+  const hi = Math.min(top, bottom);
+  const lo = Math.max(top, bottom);
+
+  // Fully above or fully below the plot — nothing to draw.
+  if (lo <= plotTop || hi >= plotBottom) return null;
+
+  const clampedTop = Math.max(hi, plotTop);
+  const clampedBottom = Math.min(lo, plotBottom);
+  if (clampedBottom - clampedTop <= 0) return null;
+
+  return { top: clampedTop, bottom: clampedBottom };
+}

--- a/client/src/pages/Plan/PlanChart.tsx
+++ b/client/src/pages/Plan/PlanChart.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { SeriesPoint, CurvePoint, HealthyRange } from '@/types';
 import { cn } from '@/lib/utils';
 import { formatDate } from '@/lib/format';
+import { niceTicks, clampBand } from '@/lib/chartScale';
 
 export interface PlanChartProps {
   series: SeriesPoint[];
@@ -45,11 +46,8 @@ function smoothPath(points: { x: number; y: number }[]): string {
   return d;
 }
 
-function evenTicks(min: number, max: number, count: number): number[] {
-  if (!Number.isFinite(min) || !Number.isFinite(max) || min === max) return [min];
-  const step = (max - min) / (count - 1);
-  return Array.from({ length: count }, (_, i) => min + step * i);
-}
+/** Y-axis ticks aimed for; the round-step snap lands within one or two of it. */
+const Y_TICK_TARGET = 6;
 
 const fmtTickDate = (ts: number) => formatDate(ts, undefined, { month: 'short', day: 'numeric' });
 const fmtWeight = (w: number) => (Number.isInteger(w) ? String(w) : w.toFixed(1));
@@ -124,9 +122,16 @@ export default function PlanChart({
     const plan = isSpark ? [] : planCurve.map((p) => ({ t: today + p.week * 7 * DAY_MS, w: p.weight }));
 
     const tValues = [...actual.map((p) => p.t), ...plan.map((p) => p.t)];
+
+    // The vertical domain covers what the user did (actual), what they intend
+    // (plan) and where they are headed (target) — but deliberately NOT the
+    // healthy range. That range is derived from height alone, so for a heavier
+    // user it can sit tens of kg below anything ever logged; letting it stretch
+    // the axis squeezed the real trend into a sliver at the top of the frame
+    // and made the chart unreadable. It is drawn clipped to the domain instead
+    // (see bandY below), so it still shows when it is actually in view.
     const wValues = [...actual.map((p) => p.w), ...plan.map((p) => p.w)];
     if (targetWeight != null) wValues.push(targetWeight);
-    if (!isSpark && healthyRange) wValues.push(healthyRange.minKg, healthyRange.maxKg);
 
     const tMin = Math.min(...tValues);
     const tMax = Math.max(...tValues);
@@ -136,7 +141,7 @@ export default function PlanChart({
       wMin -= 1;
       wMax += 1;
     }
-    const pad = (wMax - wMin) * (isSpark ? 0.15 : 0.1);
+    const pad = (wMax - wMin) * (isSpark ? 0.15 : 0.08);
     const wMinPadded = wMin - pad;
     const wMaxPadded = wMax + pad;
 
@@ -158,9 +163,15 @@ export default function PlanChart({
       actualPts: actual.map((p) => ({ x: x(p.t), y: y(p.w) })),
       planPts: plan.map((p) => ({ x: x(p.t), y: y(p.w) })),
       targetY: targetWeight != null ? y(targetWeight) : null,
-      bandY: !isSpark && healthyRange ? { top: y(healthyRange.maxKg), bottom: y(healthyRange.minKg) } : null,
+      bandY:
+        !isSpark && healthyRange
+          ? clampBand(y(healthyRange.maxKg), y(healthyRange.minKg), margin.top, margin.top + plotH)
+          : null,
+      // Where logged history ends and projection begins. Without it the two
+      // series just change colour somewhere in the middle of the frame.
+      todayX: !isSpark && plan.length > 0 && today >= tMin && today <= tMax ? x(today) : null,
       xAxisTicks: isSpark ? [] : [tMin, (tMin + tMax) / 2, tMax].map((t) => ({ t, x: x(t) })),
-      yAxisTicks: isSpark ? [] : evenTicks(wMin, wMax, 4).map((w) => ({ w, y: y(w) })),
+      yAxisTicks: isSpark ? [] : niceTicks(wMinPadded, wMaxPadded, Y_TICK_TARGET).map((w) => ({ w, y: y(w) })),
     };
   }, [series, planCurve, targetWeight, healthyRange, isSpark, size]);
 
@@ -194,7 +205,7 @@ export default function PlanChart({
     );
   }
 
-  const { margin, plotW, plotH, actualPts, planPts, targetY, bandY, xAxisTicks, yAxisTicks } = layout;
+  const { margin, plotW, plotH, actualPts, planPts, targetY, bandY, todayX, xAxisTicks, yAxisTicks } = layout;
   const actualPath = smoothPath(actualPts);
   const planPath = smoothPath(planPts);
 
@@ -224,6 +235,19 @@ export default function PlanChart({
         yAxisTicks.map(({ w, y: ty }) => (
           <line key={`grid-${w}`} x1={margin.left} x2={margin.left + plotW} y1={ty} y2={ty} className="stroke-border" strokeWidth={1} />
         ))}
+
+      {/* Today divider — separates logged history from projection */}
+      {todayX != null && (
+        <line
+          x1={todayX}
+          x2={todayX}
+          y1={margin.top}
+          y2={margin.top + plotH}
+          className="stroke-border"
+          strokeWidth={1}
+          strokeDasharray="2 3"
+        />
+      )}
 
       {/* Target-weight reference line — neutral, dashed; not a data series */}
       {targetY != null && (
@@ -308,7 +332,10 @@ export default function PlanChart({
           {targetWeight != null && (
             <LegendItem swatch={<span className="inline-block h-0 w-3 border-t-2 border-dashed border-muted-foreground/70" />} label={t('plan.chart.legendTarget')} />
           )}
-          {healthyRange && <LegendItem swatch={<span className="inline-block h-2.5 w-3 rounded-sm bg-success/20" />} label={t('plan.chart.legendHealthyRange')} />}
+          {/* Keyed off bandY, not healthyRange: the band is clipped to the
+              domain, so when it falls entirely off-chart there is nothing for
+              this swatch to point at. */}
+          {bandY && <LegendItem swatch={<span className="inline-block h-2.5 w-3 rounded-sm bg-success/20" />} label={t('plan.chart.legendHealthyRange')} />}
         </div>
       </div>
       <div ref={wrapRef} className="p-4">{svg}</div>


### PR DESCRIPTION
## The problem

The Weight Trend chart is illegible for anyone well above their healthy weight range:

- Y-axis labelled **`130 / 104.9 / 79.8 / 54.7`**
- The entire logged trend squeezed into the **top ~25%** of the frame
- Roughly half the canvas given to an empty green band

Both causes are in `PlanChart`'s layout pass.

**1. The healthy range was stretching the y-domain.** `healthyRange.minKg/maxKg` was pushed into the domain alongside real data. That range is derived from height alone (BMI 18.5–25), so at 130 kg it sits around 55–74 kg — tens of kg below anything ever logged. The axis stretched to 54.7–130 to accommodate a decorative band, and the actual data lost ~75% of its vertical resolution.

**2. `evenTicks()` split the raw domain into equal parts.** On a 54.7–130 domain that is `(130 − 54.7) / 3 = 25.1`, giving 54.7 / 79.8 / 104.9 / 130. Arithmetically correct, unusable as an axis — readers anchor on round numbers.

## The fix

- **Domain = actual + plan + target.** The healthy range no longer stretches it; it's drawn *clipped* to the domain, so it still appears when genuinely in view. Its legend entry is keyed off the clipped band, so the swatch never points at something invisible.
- **New `lib/chartScale.ts`** with `niceTicks()`, snapping to `1/2/5 × 10ⁿ` steps placed inside a lightly padded domain. Uses d3's nearest-step heuristic rather than always rounding the step up, which would systematically emit fewer ticks than asked for.
- **A dashed "today" divider**, so logged history and projection are distinguishable rather than just changing colour mid-frame.

Full-variant padding drops `0.1 → 0.08`. The spark variant is untouched.

## Result

Same data, before → after:

| | Before | After |
| --- | --- | --- |
| Y-axis | `130 / 104.9 / 79.8 / 54.7` | `80 / 90 / 100 / 110 / 120 / 130` |
| Trend uses | ~25% of plot height | ~86% |
| History vs projection | colour change only | explicit today divider |

## Tradeoff worth flagging

When the healthy range falls entirely outside the domain it is no longer drawn, and its legend entry disappears with it. That is deliberate — it is context, not data, and it was costing three quarters of the chart's resolution. If you'd rather always see it, the alternative is a small out-of-range marker pinned to the bottom axis; say the word and I'll add it.

## Validation

- **Rendered the real component** with data mirroring the report (weights 105→130, target 79.8, healthy range 54.7–73.9, 57-week plan curve) and inspected the output — not just asserted on numbers.
- **A second fixture** (weights 78→75, healthy range overlapping) confirms the band and its legend entry still draw when the range is in view.
- **19 unit tests** for `niceTicks` / `niceStep` / `clampBand`, covering round-step families, domain containment, reversed and flat domains, and non-finite input. One caught a real bug during development: the drift-trimming helper used `toFixed(6)`, which rounds a legitimately tiny step to `0` and would divide by zero — now precision-based.
- `tsc -b --force` clean, `vitest run` 121/121, `go test ./...` 9 packages, production build succeeds.

## Not addressed

The projection still dominates the x-axis — logged history occupies a small left fraction when the plan runs 12+ months. The today divider makes the split legible, but capping the visible plan horizon would be a separate change with its own product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)