### PR TITLE
refactor: move Internationalization below Track Body Fat in Settings

### DIFF
--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -60,9 +60,6 @@ export default function Settings() {
           <MacroSettings user={data.user} onSave={refresh} />
         </div>
         <div className="break-inside-avoid">
-          <PreferencesSettings user={data.user} timezones={data.timezones} onSave={refresh} />
-        </div>
-        <div className="break-inside-avoid">
           <TodoSettings user={data.user} onSave={refresh} />
         </div>
         <div className="break-inside-avoid">
@@ -70,6 +67,9 @@ export default function Settings() {
         </div>
         <div className="break-inside-avoid">
           <BodyFatSettings user={data.user} onSave={refresh} />
+        </div>
+        <div className="break-inside-avoid">
+          <PreferencesSettings user={data.user} timezones={data.timezones} onSave={refresh} />
         </div>
         <div className="break-inside-avoid">
           <SavedFoodsSettings />


### PR DESCRIPTION
## What

The Internationalization card now sits directly below Track Body Fat.

New order:

`Nutrition Goals → Todos → Daily Notes → **Track Body Fat** → **Internationalization** → Saved foods → AI Settings → Account Links → Welcome tour`

One block moved in `Settings.tsx` — 3 lines out, 3 lines in. Note that "Internationalization" is the heading on the `PreferencesSettings` card, so language, weight unit and timezone all move together; they live in that one card.

## Verification

| Check | Result |
|---|---|
| Rendered DOM order in the running app | `Track Body Fat` → `Internationalization` |
| `tsc -b --force` | pass |
| `settings.spec.ts` + `settings-extra.spec.ts` | 12/12 pass |

Checked beforehand that nothing depends on card position: every settings spec locates cards by `data-testid`, and there are no order assertions in the e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAME8WUkrmnProFzSmZgj9