### PR TITLE
fix(e2e): raise the public API's rate limits in the test harness

### DIFF
--- a/compose.test.yml
+++ b/compose.test.yml
@@ -15,6 +15,13 @@ services:
       - SESSION_SECRET=e2e-test-session-secret-not-for-production
       - RATE_LIMIT_AUTH=1000
       - RATE_LIMIT_STRICT=1000
+      # The public API's limiters, raised for the same reason as the two above:
+      # every Playwright worker shares one IP, so the production per-IP ceiling
+      # (120/min) is reachable by the suite itself. Leaving it at the default
+      # made api-tokens.spec.ts fail with 429s that had nothing to do with what
+      # it was testing — a flake that looks exactly like a real regression.
+      - RATE_LIMIT_API=100000
+      - RATE_LIMIT_API_TOKEN=100000
       # Keep the shared-IP captcha counter from gating unrelated sessions —
       # all suite traffic is one IP and some specs fail logins on purpose.
       # The per-session captcha counter (captcha.spec) is unaffected.


### PR DESCRIPTION
Found while validating the merged API work, not from a failing build.

`compose.test.yml` already raises `RATE_LIMIT_AUTH` and `RATE_LIMIT_STRICT` so the suite can't throttle itself. When I added the `/api/v1` limiters I never gave them the same treatment, so they run at **production defaults** (120/min per IP, 60/min per token) while every Playwright worker shares one address.

`e2e/api-tokens.spec.ts` then fails with `429`s that have nothing to do with what it asserts. Running my validation suites back to back turned 44 passing assertions into 25 failures — every one a rate limit. A 429 mid-suite reads exactly like a real regression, which is the worst kind of flake: it costs someone an afternoon before they realise the product is fine.

**Verified:** with the fix, both shell suites plus `api-tokens.spec.ts` run back-to-back clean (44/44 and 6/6). Without it, the same sequence fails.

Limiter behaviour itself stays covered by the middleware unit tests — `TestRateLimitSetsRetryAfter`, `TestTokenRateLimiterBucketsByToken`, `TestTokenRateLimiterFallsBackToIP`, `TestRetryAfterSecondsNeverZero` — which are deterministic and need no shared address. Testing a rate limiter in the same environment you've raised the limits for isn't possible anyway; the unit tests are the right home for it.

**Not merged directly to `staging`** — the shared checkout currently holds 4 unpushed commits from another session (`desktop-add-fab`, a screenshot refresh). Merging locally and pushing would have carried their work along with mine, which isn't my call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)