### PR TITLE
fix: bound validateTargetWeight so a huge target weight 400s instead of 500ing

### DIFF
--- a/internal/handler/plan.go
+++ b/internal/handler/plan.go
@@ -41,8 +41,17 @@ func validateActivityLevel(a *string) bool {
 	return a == nil || validActivityLevels[*a]
 }
 
+// validateTargetWeight bounds the goal's target weight. Unlike start_weight —
+// which is copied from the user's latest weight entry and so has already been
+// through service.ParseWeight — TargetWeight is decoded straight off the JSON
+// body as a float64, making this the only place the cap is applied. The upper
+// bound keeps the value within the target_weight NUMERIC(6,2) column (max
+// 9999.99) and matches ParseWeight's cap; without it a target weight >= 10000
+// passes validation and then 500s on INSERT with a numeric overflow instead of
+// a clean 400. NaN and ±Inf are rejected as a side effect: NaN fails every
+// comparison, and +Inf exceeds the cap.
 func validateTargetWeight(w float64) bool {
-	return w > 0
+	return w > 0 && w <= service.MaxWeight
 }
 
 func validatePaceMode(m string) bool {

--- a/internal/handler/plan_test.go
+++ b/internal/handler/plan_test.go
@@ -2,9 +2,11 @@ package handler
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 
 	"schautrack/internal/model"
+	"schautrack/internal/service"
 )
 
 func TestValidateHeightCm(t *testing.T) {
@@ -92,15 +94,70 @@ func TestValidateActivityLevel(t *testing.T) {
 	}
 }
 
+// targetWeightColumnMax is the largest value the weight_goals.target_weight
+// NUMERIC(6,2) column can hold (internal/database/migrations.go). Anything the
+// validator accepts must fit, or the INSERT overflows and the caller gets a 500
+// instead of a 400.
+const targetWeightColumnMax = 9999.99
+
+// fitsTargetWeightColumn reports whether w survives an INSERT into
+// NUMERIC(6,2). Postgres rounds to two decimals on store, so the check is
+// against the rounded value; NaN and ±Inf never fit.
+func fitsTargetWeightColumn(w float64) bool {
+	if math.IsNaN(w) || math.IsInf(w, 0) {
+		return false
+	}
+	return math.Abs(math.Round(w*100)/100) <= targetWeightColumnMax
+}
+
 func TestValidateTargetWeight(t *testing.T) {
-	if !validateTargetWeight(70) {
-		t.Error("70 should be valid")
+	tests := []struct {
+		name string
+		val  float64
+		want bool
+	}{
+		{"zero", 0, false},
+		{"negative", -5, false},
+		{"NaN", math.NaN(), false},
+		{"positive infinity", math.Inf(1), false},
+		{"negative infinity", math.Inf(-1), false},
+		{"tiny but positive", 0.001, true},
+		{"one", 1, true},
+		{"typical", 70, true},
+		{"ParseWeight cap", service.MaxWeight, true},
+		{"just over the ParseWeight cap", service.MaxWeight + 1, false},
+		{"column max", targetWeightColumnMax, false},
+		{"column max plus one", 10000, false},
+		{"absurdly large", 1e9, false},
 	}
-	if validateTargetWeight(0) {
-		t.Error("0 should be invalid")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validateTargetWeight(tt.val); got != tt.want {
+				t.Errorf("validateTargetWeight(%v) = %v, want %v", tt.val, got, tt.want)
+			}
+		})
 	}
-	if validateTargetWeight(-5) {
-		t.Error("-5 should be invalid")
+}
+
+// TestValidateTargetWeightFitsColumn pins the invariant validateRateKgPerWeek
+// already holds for its own column: every value the validator accepts must be
+// storable in target_weight NUMERIC(6,2). Without an upper bound in the
+// validator, {"target_weight": 100000} passed here and 500d on INSERT.
+func TestValidateTargetWeightFitsColumn(t *testing.T) {
+	candidates := []float64{
+		math.NaN(), math.Inf(1), math.Inf(-1),
+		-1e9, -1, 0,
+		0.001, 0.005, 1, 70, 999.994,
+		service.MaxWeight - 0.01, service.MaxWeight, service.MaxWeight + 0.01,
+		1501, 9999.99, 9999.995, 10000, 1e6, 1e9, math.MaxFloat64,
+	}
+	for f := 0.5; f < 1e12; f *= 3 {
+		candidates = append(candidates, f)
+	}
+	for _, w := range candidates {
+		if validateTargetWeight(w) && !fitsTargetWeightColumn(w) {
+			t.Errorf("validateTargetWeight(%v) accepted a value that does not fit NUMERIC(6,2)", w)
+		}
 	}
 }
 

--- a/internal/service/utils.go
+++ b/internal/service/utils.go
@@ -38,11 +38,18 @@ func ParseWeight(input string) ParseWeightResult {
 		return ParseWeightResult{Ok: false}
 	}
 	val, err := strconv.ParseFloat(normalized, 64)
-	if err != nil || val <= 0 || val > 1500 || math.IsInf(val, 0) || math.IsNaN(val) {
+	if err != nil || val <= 0 || val > MaxWeight || math.IsInf(val, 0) || math.IsNaN(val) {
 		return ParseWeightResult{Ok: false}
 	}
 	return ParseWeightResult{Ok: true, Value: math.Round(val*100) / 100}
 }
+
+// MaxWeight bounds an accepted weight, in whichever display unit the user has
+// selected (kg or lb). It is deliberately loose — far above any plausible human
+// weight — while keeping every stored value well inside the NUMERIC(6,2) weight
+// columns (max 9999.99), so an out-of-range value fails as a 400 here rather
+// than a 500 from a numeric overflow on INSERT.
+const MaxWeight = 1500.0
 
 // MaxBodyFatPct bounds an accepted body-fat reading. It is deliberately loose —
 // the highest percentages ever recorded are around 70 — and matches the


### PR DESCRIPTION
Closes #305

## The defect

`validateTargetWeight` was just `w > 0`:

```go
func validateTargetWeight(w float64) bool {
	return w > 0
}
```

`weight_goals.target_weight` is `NUMERIC(6,2)` (`internal/database/migrations.go:812`), so it holds at most `9999.99`. Unlike `start_weight` — which is copied from the user's latest weight entry and has therefore already been through `service.ParseWeight` and its 1500 cap — `TargetWeight` is decoded straight off the `PUT /plan/goal` JSON body as a `float64` and never goes through `ParseWeight`. So `{"target_weight": 100000}` passed validation, overflowed the column on INSERT, and the caller got a **500 instead of a 400**.

This is the exact failure mode the validator immediately below it already documents — it was fixed in `validateRateKgPerWeek` and missed here.

## What changed

- **`internal/handler/plan.go`** — `validateTargetWeight` now returns `w > 0 && w <= service.MaxWeight`, with an explanatory comment mirroring `validateRateKgPerWeek`'s. `NaN` and `±Inf` fall out as rejected: `NaN` fails every comparison, `+Inf` exceeds the cap. That was already true for `NaN` by accident; it is now recorded as intended and covered by a test.
- **`internal/service/utils.go`** — extracted `ParseWeight`'s hardcoded `1500` into an exported `service.MaxWeight` constant, following the existing `service.MaxBodyFatPct` pattern, so the handler bound and the parser bound cannot drift apart.
- **`internal/handler/plan_test.go`** — replaced the three-assertion `TestValidateTargetWeight` with a table over `0`, negative, `NaN`, `+Inf`, `-Inf`, `0.001`, `1`, `70`, `1500` (the `ParseWeight` cap), `1501`, `9999.99` (the column max), `10000`, `1e9`. Added `TestValidateTargetWeightFitsColumn`, which pins the same invariant `validateRateKgPerWeek` holds: **anything the validator accepts must fit `NUMERIC(6,2)`** (checked against the two-decimal-rounded value, since Postgres rounds on store).

`PUT /plan/goal` is the only write path to `weight_goals.target_weight` — verified by grepping every `TargetWeight` / `weight_goals` reference outside tests.

## Verification

Both new tests fail against the unfixed validator (temporarily reverted `validateTargetWeight` to `return w > 0`):

```
    plan_test.go:159: validateTargetWeight(+Inf) accepted a value that does not fit NUMERIC(6,2)
    plan_test.go:159: validateTargetWeight(9999.995) accepted a value that does not fit NUMERIC(6,2)
    plan_test.go:159: validateTargetWeight(10000) accepted a value that does not fit NUMERIC(6,2)
    plan_test.go:159: validateTargetWeight(1e+06) accepted a value that does not fit NUMERIC(6,2)
    plan_test.go:159: validateTargetWeight(1e+09) accepted a value that does not fit NUMERIC(6,2)
    plan_test.go:159: validateTargetWeight(1.7976931348623157e+308) accepted a value that does not fit NUMERIC(6,2)
    ...
FAIL	schautrack/internal/handler	0.004s
```

`go build ./... && go vet ./...` — clean. `go test ./...`:

```
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	0.008s
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	0.004s
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	0.006s
ok  	schautrack/internal/handler	0.766s
ok  	schautrack/internal/middleware	0.068s
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	0.021s
ok  	schautrack/internal/release	0.004s
ok  	schautrack/internal/service	0.215s
ok  	schautrack/internal/session	0.004s
ok  	schautrack/internal/sse	0.014s
```

`go test ./internal/handler/ -run 'TestValidate' -v` — all 8 validator tests pass, including all 13 `TestValidateTargetWeight` subtests and `TestValidateTargetWeightFitsColumn`.

`gofmt -l` reports nothing for the three touched files.

## Coordination

This PR is the canonical home for the `validateTargetWeight` bound. #310 (branch `go-db-constraint-drift-test`) is building the general Go-bound ↔ DB-CHECK drift test and depends on this bound existing; the third bullet of #305 — pinning all validator/CHECK pairs in one place — is deliberately left to #310 and is **not** done here.

## Deliberately out of scope

`internal/handler/v1_weight.go:184` still hardcodes `1500` in a user-facing error string rather than deriving it from `service.MaxWeight`. Cosmetic drift risk only; left alone to keep this diff to #305. Filed as an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)