### PR TITLE
fix: reject weights and body-fat values that round to zero

### DIFF
--- a/internal/service/utils.go
+++ b/internal/service/utils.go
@@ -41,7 +41,17 @@ func ParseWeight(input string) ParseWeightResult {
 	if err != nil || val <= 0 || val > 1500 || math.IsInf(val, 0) || math.IsNaN(val) {
 		return ParseWeightResult{Ok: false}
 	}
-	return ParseWeightResult{Ok: true, Value: math.Round(val*100) / 100}
+	// Re-check the lower bound *after* rounding. A positive input below half
+	// the rounding granularity ("0.004") clears `val <= 0` and then rounds to
+	// exactly 0, which the weight_entries_positive CHECK rejects — a 500 from
+	// the database instead of a 400 here. Ok == true must imply Value > 0.
+	// The upper bound stays pre-rounding on purpose: "1500.004" is out of
+	// range as typed, and the parser is strict at both ends.
+	rounded := math.Round(val*100) / 100
+	if rounded <= 0 {
+		return ParseWeightResult{Ok: false}
+	}
+	return ParseWeightResult{Ok: true, Value: rounded}
 }
 
 // MaxBodyFatPct bounds an accepted body-fat reading. It is deliberately loose —
@@ -53,6 +63,10 @@ const MaxBodyFatPct = 75.0
 // ParseBodyFat parses a body-fat percentage, accepting the same comma-decimal
 // and stringified-number inputs as ParseWeight. Rounds to one decimal to match
 // the NUMERIC(4,1) column.
+//
+// Like ParseWeight it validates the rounded value against the lower bound, so
+// ok == true always implies pct > 0 — the contract the
+// weight_entries_body_fat_range CHECK depends on.
 func ParseBodyFat(input string) (float64, bool) {
 	input = strings.TrimSpace(input)
 	if input == "" || len(input) > 12 {
@@ -62,7 +76,11 @@ func ParseBodyFat(input string) (float64, bool) {
 	if err != nil || val <= 0 || val > MaxBodyFatPct || math.IsInf(val, 0) || math.IsNaN(val) {
 		return 0, false
 	}
-	return math.Round(val*10) / 10, true
+	rounded := math.Round(val*10) / 10
+	if rounded <= 0 {
+		return 0, false
+	}
+	return rounded, true
 }
 
 func SubtractDaysUTC(dateStr string, days int) string {

--- a/internal/service/utils_test.go
+++ b/internal/service/utils_test.go
@@ -36,6 +36,19 @@ func TestFormatTimeInTz(t *testing.T) {
 	}
 }
 
+// assertOkImpliesPositive pins the invariant both weight parsers share with the
+// database: an accepted value must be strictly positive. weight_entries_positive
+// is CHECK (weight > 0) and weight_entries_body_fat_range is
+// CHECK (body_fat IS NULL OR (body_fat > 0 AND body_fat <= 75)), so a parser that
+// reports success for a value of 0 turns a clean 400 into a 500 from the DB.
+func assertOkImpliesPositive(t *testing.T, parser, input string, ok bool, value float64) {
+	t.Helper()
+	if ok && !(value > 0) {
+		t.Errorf("%s(%q) reported ok with value %v — ok == true must imply value > 0 "+
+			"(the DB CHECK rejects anything <= 0)", parser, input, value)
+	}
+}
+
 func TestParseWeight(t *testing.T) {
 	tests := []struct {
 		input string
@@ -49,6 +62,15 @@ func TestParseWeight(t *testing.T) {
 		{"1501", false, 0},
 		{"", false, 0},
 		{"abc", false, 0},
+
+		// Rounding boundary. ParseWeight rounds to two decimals, so anything
+		// below 0.005 rounds to exactly 0 — which CHECK (weight > 0) rejects.
+		// These must be refused by the parser, not by the database.
+		{"0.001", false, 0},
+		{"0.004", false, 0},
+		{"0.0049", false, 0},
+		{"0.005", true, 0.01}, // first value that rounds up to 0.01
+		{"0.01", true, 0.01},
 	}
 	for _, tt := range tests {
 		got := ParseWeight(tt.input)
@@ -58,6 +80,7 @@ func TestParseWeight(t *testing.T) {
 		if got.Ok && got.Value != tt.value {
 			t.Errorf("ParseWeight(%q).Value = %v, want %v", tt.input, got.Value, tt.value)
 		}
+		assertOkImpliesPositive(t, "ParseWeight", tt.input, got.Ok, got.Value)
 	}
 }
 

--- a/internal/service/weight_test.go
+++ b/internal/service/weight_test.go
@@ -99,9 +99,11 @@ func TestParseBodyFat(t *testing.T) {
 		{"24.34", 24.3},
 		{"75", 75}, // exactly at MaxBodyFatPct
 		{"0.1", 0.1},
+		{"0.05", 0.1}, // first value that rounds up to 0.1
 	}
 	for _, tt := range valid {
 		got, ok := ParseBodyFat(tt.input)
+		assertOkImpliesPositive(t, "ParseBodyFat", tt.input, ok, got)
 		if !ok {
 			t.Errorf("ParseBodyFat(%q) = not ok, want %v", tt.input, tt.value)
 			continue
@@ -118,13 +120,28 @@ func TestParseBodyFat(t *testing.T) {
 		{"0", "zero"},
 		{"-5", "negative"},
 		{"75.1", "just above the 75% ceiling"},
+		// The ceiling is checked before rounding, so a value that would round
+		// back down to 75.0 is still out of range as typed. Pinned deliberately:
+		// the parser is strict at both ends rather than silently accepting an
+		// input the user can see is above the limit.
+		{"75.04", "above the ceiling even though it rounds to 75.0"},
 		{"100", "a percentage no body can reach"},
 		{"NaN", "NaN string"},
 		{"Inf", "infinity string"},
 		{"1234567890123", "longer than 12 chars"},
+		// Rounding boundary: ParseBodyFat rounds to one decimal, so anything
+		// below 0.05 rounds to exactly 0 — which
+		// CHECK (body_fat > 0 AND body_fat <= 75) rejects. The parser must
+		// refuse these itself so the failure is a 400, not a 500.
+		{"0.01", "rounds to 0"},
+		{"0.04", "rounds to 0"},
+		{"0.0499", "rounds to 0"},
+		{"1e-07", "rounds to 0"},
 	}
 	for _, tt := range invalid {
-		if got, ok := ParseBodyFat(tt.input); ok {
+		got, ok := ParseBodyFat(tt.input)
+		assertOkImpliesPositive(t, "ParseBodyFat", tt.input, ok, got)
+		if ok {
 			t.Errorf("ParseBodyFat(%q) [%s] = %v, want not ok", tt.input, tt.desc, got)
 		}
 	}


### PR DESCRIPTION
Closes #302

## Problem

`ParseWeight` and `ParseBodyFat` validated the *pre-rounding* value and returned the *post-rounding* one. A small positive input cleared the `val <= 0` guard and was then reported as valid with a `Value` of exactly `0`:

```
ParseWeight("0.004")   -> Ok=true  Value=0
ParseBodyFat("0.04")   -> ok=true  pct=0
```

The database rejects precisely that value:

- `weight_entries_positive CHECK (weight > 0)` — `internal/database/migrations.go:110`
- `weight_entries_body_fat_range CHECK (body_fat IS NULL OR (body_fat > 0 AND body_fat <= 75))` — `internal/database/migrations.go:854`

So the request failed as a **500 `"Failed to save weight"`** instead of a clean 400 — the exact failure mode the `MaxBodyFatPct` comment says the parser exists to prevent. The upper bound was guarded; the lower bound was not.

## Change

`internal/service/utils.go` — both parsers re-check the lower bound **after** rounding:

```go
rounded := math.Round(val*100) / 100
if rounded <= 0 {
    return ParseWeightResult{Ok: false}
}
```

The upper bounds are untouched and stay pre-rounding, so the parser is strict at both ends: `"1500.004"` and `"75.04"` remain rejected even though they round back into range. That is a deliberate decision (the issue asked for `75.04` to be decided and pinned) — a value the user can see is above the limit should not be silently accepted, and it keeps the Go bound a literal match for the DB `CHECK`.

## Tests

- `TestParseWeight` (`internal/service/utils_test.go`) — rounding boundary: `"0.001"`, `"0.004"`, `"0.0049"` rejected; `"0.005"` (first value that rounds up) and `"0.01"` accepted as `0.01`.
- `TestParseBodyFat` — note this already existed in `internal/service/weight_test.go`, contrary to the issue text, so it was extended in place rather than duplicated (a second `TestParseBodyFat` in the same package would not compile). Added the round-to-zero cases `"0.01"`, `"0.04"`, `"0.0499"`, `"1e-07"`, the accepted boundary `"0.05"` -> `0.1`, and `"75.04"` pinned as rejected. Comma decimals, whitespace, the 12-char cap, `0`, negatives, `75`, `75.1`, `Inf` and `NaN` were already covered there.
- `assertOkImpliesPositive` — the shared invariant helper, called from both tables: **`ok == true` implies `value > 0`**. This is the property that keeps the parsers' contract matching the DB constraints.

Verified the tests actually catch the bug — with the `utils.go` fix stashed:

```
--- FAIL: TestParseWeight (0.00s)
    utils_test.go:78: ParseWeight("0.001").Ok = true, want false
    utils_test.go:83: ParseWeight("0.001") reported ok with value 0 — ok == true must imply value > 0 (the DB CHECK rejects anything <= 0)
    utils_test.go:78: ParseWeight("0.004").Ok = true, want false
    utils_test.go:78: ParseWeight("0.0049").Ok = true, want false
--- FAIL: TestParseBodyFat (0.00s)
    weight_test.go:143: ParseBodyFat("0.01") reported ok with value 0 — ok == true must imply value > 0 (the DB CHECK rejects anything <= 0)
    weight_test.go:145: ParseBodyFat("0.04") [rounds to 0] = 0, want not ok
    weight_test.go:145: ParseBodyFat("0.0499") [rounds to 0] = 0, want not ok
    weight_test.go:145: ParseBodyFat("1e-07") [rounds to 0] = 0, want not ok
FAIL
```

## Verification

`go build ./...` -> `BUILD OK`, `go vet ./...` -> `VET OK`.

```
$ go test ./...
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	0.005s
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	0.003s
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	0.004s
ok  	schautrack/internal/handler	0.700s
ok  	schautrack/internal/middleware	0.068s
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	0.023s
ok  	schautrack/internal/release	0.005s
ok  	schautrack/internal/service	0.216s
ok  	schautrack/internal/session	0.004s
ok  	schautrack/internal/sse	0.018s
```

```
$ go test ./internal/service/ -run 'TestParse' -v
...
=== RUN   TestParseWeight
--- PASS: TestParseWeight (0.00s)
=== RUN   TestParseWeightValid
--- PASS: TestParseWeightValid (0.00s)
=== RUN   TestParseWeightInvalid
--- PASS: TestParseWeightInvalid (0.00s)
=== RUN   TestParseWeightCommaDecimal
--- PASS: TestParseWeightCommaDecimal (0.00s)
=== RUN   TestParseWeightRounding
--- PASS: TestParseWeightRounding (0.00s)
=== RUN   TestParseWeightTooLong
--- PASS: TestParseWeightTooLong (0.00s)
=== RUN   TestParseBodyFat
--- PASS: TestParseBodyFat (0.00s)
PASS
ok  	schautrack/internal/service	0.006s
```

E2E was not run (per instructions).

## Follow-on work

This PR is the canonical home for the fix. Two other issues build on it:

- **#315** (`go-fuzz-targets`) adds `FuzzParseWeight` / `FuzzParseBodyFat` asserting the same `Ok implies Value > 0` invariant — it will fail against `staging` until this lands.
- **#310** adds a Go-bound ↔ DB-`CHECK` drift test, which this makes true for the lower bound of both columns.

Also filed while here: #319 — `POST /entries` silently discards an invalid weight instead of returning 400, unlike `POST /weight` which correctly rejects it. Out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
