### PR TITLE
ci: run the Go test job against a real Postgres 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,32 @@ env:
 jobs:
   test:
     runs-on: ${{ github.ref == 'refs/heads/staging' && 'arc-runner' || 'ubuntu-latest' }}
+    # Without a database, every test guarded by `TEST_DATABASE_URL` skips — and
+    # `go test` reports a skip as a pass. That silently disabled the tests most
+    # worth running, above all
+    # TestRunAllMigrationsIdempotentBodyProfileAndWeightGoals: migrations re-run
+    # on every container start, so a non-idempotent migration's first symptom is
+    # a pod that will not start, in production, on a RollingUpdate with
+    # maxUnavailable: 0.
+    #
+    # The postgres major here must track the one the app actually runs against
+    # (compose.test.yml / the Helm chart's postgres) — testing migrations on a
+    # different major tests the wrong DDL semantics.
+    #
+    # TestIntegrationTestsRunInCI (internal/database/ci_guard_test.go) fails the
+    # build if this block is ever removed while CI keeps reporting green.
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -62,6 +88,8 @@ jobs:
 
       - name: Run Go tests
         run: go test ./...
+        env:
+          TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
 
       # Client type errors were previously caught only inside the Docker build
       # (client "build" is "tsc -b && vite build"), which runs after

--- a/internal/database/ci_guard_test.go
+++ b/internal/database/ci_guard_test.go
@@ -1,0 +1,29 @@
+package database
+
+import (
+	"os"
+	"testing"
+)
+
+// TestIntegrationTestsRunInCI is the tripwire for the `services: postgres`
+// block in the `test` job of .github/workflows/build.yml.
+//
+// Every DB-backed test in this repo is guarded by
+//
+//	if os.Getenv("TEST_DATABASE_URL") == "" { t.Skip(...) }
+//
+// and `go test` reports a skip as a pass. So if the Postgres service is ever
+// removed — or its credentials/port drift out of sync with the env var on the
+// "Run Go tests" step — CI stays green while quietly testing nothing. That
+// includes TestRunAllMigrationsIdempotentBodyProfileAndWeightGoals, the only
+// automated proof that migrations survive the re-run they get on every
+// container start.
+//
+// GitHub Actions always sets CI=true, so this fails there and nowhere else:
+// a plain local `go test ./...` (CI unset) is unaffected and the integration
+// tests keep skipping as before.
+func TestIntegrationTestsRunInCI(t *testing.T) {
+	if os.Getenv("CI") != "" && os.Getenv("TEST_DATABASE_URL") == "" {
+		t.Fatal("TEST_DATABASE_URL must be set in CI; integration tests are silently skipping")
+	}
+}


### PR DESCRIPTION
Closes #313

## What was broken

The `test` job had no database, so every test guarded by

```go
if os.Getenv("TEST_DATABASE_URL") == "" { t.Skip(...) }
```

skipped on every CI run — and `go test` reports a skip as a pass. Six integration tests across five files had **never once executed in CI**:

| Package | Test |
|---|---|
| `internal/database` | `TestRunAllMigrationsIdempotentBodyProfileAndWeightGoals` |
| `internal/database` | `TestAccountLinksShareColumns` |
| `internal/database` | `TestOnboardingBackfillRunsOnlyOnColumnCreation` |
| `internal/database` | `TestNewPoolPingsRealDatabase` |
| `internal/handler` | `TestOnboardingCompleteKeepsFirstTimestamp` |
| `internal/service` | `TestUpsertActiveGoalOneActiveInvariant` |

The first is the only automated proof that migrations survive the re-run they get on every container start. Without it, a non-idempotent migration's first symptom is a pod that will not start, in production, on a `RollingUpdate` with `maxUnavailable: 0`.

## What changed

Two things, diff confined to the existing `test` job plus one new test file:

1. **`.github/workflows/build.yml`** — a `postgres:18` service container with a `pg_isready` healthcheck on the `test` job, and `TEST_DATABASE_URL` on the "Run Go tests" step. No new job; no other job touched.
2. **`internal/database/ci_guard_test.go`** — `TestIntegrationTestsRunInCI`, which fails when `CI` is set but `TEST_DATABASE_URL` is not. Removing the service block a year from now goes red instead of silently reverting to a suite that tests nothing. GitHub Actions always sets `CI=true`, so a plain local `go test ./...` is unaffected and keeps skipping as before.

The service image tracks the major the app actually runs (`postgres:18-alpine` in `compose.yml`, `compose.dev.yml`, `compose.test.yml` and `helm/schautrack/values.yaml`) — testing migrations on a different major would test the wrong DDL semantics. Renovate already blocks Postgres major bumps repo-wide, so this pin will not drift on its own. (If you'd rather it match the other files byte-for-byte, `postgres:18-alpine` is a smaller pull; #313 specified `postgres:18` and that is what was verified.)

## Verification — real output, not "should work"

**1. Local dev path (no `CI`, no database) — unchanged and green:**

```
$ go build ./... && go vet ./... && go test -count=1 ./...
ok  	schautrack/cmd/server	0.006s
ok  	schautrack/internal/clientip	0.002s
ok  	schautrack/internal/database	0.005s
ok  	schautrack/internal/handler	1.164s
ok  	schautrack/internal/middleware	0.068s
ok  	schautrack/internal/openapi	0.031s
ok  	schautrack/internal/release	0.014s
ok  	schautrack/internal/service	0.220s
ok  	schautrack/internal/session	0.005s
ok  	schautrack/internal/sse	0.018s
exit=0
```

**2. The guard actually trips (`CI=true`, `TEST_DATABASE_URL` unset):**

```
$ CI=true go test -count=1 -run TestIntegrationTestsRunInCI -v ./internal/database/
=== RUN   TestIntegrationTestsRunInCI
    ci_guard_test.go:27: TEST_DATABASE_URL must be set in CI; integration tests are silently skipping
--- FAIL: TestIntegrationTestsRunInCI (0.00s)
FAIL
FAIL	schautrack/internal/database	0.005s
```

**3. Full CI simulation against a real `postgres:18` container** (`PostgreSQL 18.4 (Debian 18.4-1.pgdg13+1)`):

```
$ CI=true TEST_DATABASE_URL='postgres://postgres:postgres@localhost:55313/postgres?sslmode=disable' go test -count=1 ./...
ok  	schautrack/cmd/server	0.011s
ok  	schautrack/internal/clientip	0.005s
ok  	schautrack/internal/database	0.518s
ok  	schautrack/internal/handler	1.302s
ok  	schautrack/internal/middleware	0.072s
ok  	schautrack/internal/openapi	0.037s
ok  	schautrack/internal/release	0.006s
ok  	schautrack/internal/service	0.415s
ok  	schautrack/internal/session	0.011s
ok  	schautrack/internal/sse	0.021s
```

**4. The six formerly-skipping tests, verbose, proving they now run and pass:**

```
=== RUN   TestIntegrationTestsRunInCI
--- PASS: TestIntegrationTestsRunInCI (0.00s)
=== RUN   TestRunAllMigrationsIdempotentBodyProfileAndWeightGoals
--- PASS: TestRunAllMigrationsIdempotentBodyProfileAndWeightGoals (0.21s)
=== RUN   TestAccountLinksShareColumns
--- PASS: TestAccountLinksShareColumns (0.14s)
=== RUN   TestOnboardingBackfillRunsOnlyOnColumnCreation
--- PASS: TestOnboardingBackfillRunsOnlyOnColumnCreation (0.16s)
=== RUN   TestNewPoolPingsRealDatabase
--- PASS: TestNewPoolPingsRealDatabase (0.02s)
PASS
ok  	schautrack/internal/database	0.534s
=== RUN   TestOnboardingCompleteKeepsFirstTimestamp
--- PASS: TestOnboardingCompleteKeepsFirstTimestamp (0.17s)
PASS
ok  	schautrack/internal/handler	0.204s
=== RUN   TestUpsertActiveGoalOneActiveInvariant
--- PASS: TestUpsertActiveGoalOneActiveInvariant (0.17s)
PASS
ok  	schautrack/internal/service	0.187s
```

**Zero new failures.** Nothing that was skipping now fails, so no follow-up issue was needed on that front.

**5. Cross-package contention.** `internal/database`, `internal/handler` and `internal/service` all migrate and write to the *same* database, and `go test` runs packages in parallel (`-p` defaults to `GOMAXPROCS`). Ran the suite 3× at `-p=4` with `-count=1`: green every time. The migration advisory lock (`TestMigrationLockKeyStable`) serialises concurrent `runAllMigrations`, and the fixtures use per-test unique emails, so this looks structurally safe rather than lucky — but it is worth remembering if a future DB test starts truncating shared tables.

**6. Workflow YAML parses and the change is scoped to `test`:**

```
$ yq '[.jobs | to_entries[] | select(.value.services != null) | .key]' .github/workflows/build.yml
[
  "test"
]
```

**7. This PR's own CI run — green, and the log proves the tests really executed** ([run 31244356783](https://github.com/schaurian/schautrack/actions/runs/31244356783), all jobs `success`):

```
Initialize containers  ##[group]Starting postgres service container
Initialize containers  ##[command]/usr/bin/docker pull postgres:18
Initialize containers  Status: Downloaded newer image for postgres:18
Initialize containers  ##[command]/usr/bin/docker create ... -p 5432:5432 --health-cmd pg_isready
                       --health-interval 10s --health-timeout 5s --health-retries 5
                       -e "POSTGRES_PASSWORD=postgres" ... postgres:18
Initialize containers  healthy
Initialize containers  postgres service is healthy.

Run Go tests  env:
Run Go tests    TEST_DATABASE_URL: ***localhost:5432/postgres?sslmode=disable
Run Go tests  ok  	schautrack/internal/database	0.492s
Run Go tests  ok  	schautrack/internal/handler	0.446s
Run Go tests  ok  	schautrack/internal/service	0.328s

Stop containers  LOG:  starting PostgreSQL 18.4 (Debian 18.4-1.pgdg13+1) on x86_64-pc-linux-gnu
```

Two things worth pointing at:

- `internal/database` took **0.492s** on this run. On `staging` today it takes **0.005s** — that gap *is* the six tests, running for the first time.
- The `test` job passing is itself proof that `TEST_DATABASE_URL` reached the step, because `TestIntegrationTestsRunInCI` would have failed the job otherwise. The guard is self-demonstrating on the very run that introduces it.

## The `arc-runner` question — service containers on the self-hosted runner

`runs-on` switches to the self-hosted `arc-runner` scale set on `staging`, and GitHub Actions `services:` needs a Docker-capable runner. **Answer: yes, it works — and here is the evidence rather than an assumption.**

- The ARC scale set backing the `arc-runner` label for this repo (`githubConfigUrl: https://github.com/schaurian/schautrack`, `runnerScaleSetName: "arc-runner"`) is configured with **`containerMode.type: "dind"`**, gha-runner-scale-set chart 0.14.2. In dind mode the runner container and the Docker daemon sidecar sit in the same pod and therefore share a network namespace, so a service container's published `5432:5432` is reachable from the job steps at `localhost:5432`. This is the standard supported ARC pattern (it is the *kubernetes* container mode, not dind, that constrains service containers and requires a job `container:`).
- Corroborating from this repo alone: `build-and-push` already runs `docker/setup-buildx-action` + `docker/build-push-action` on `arc-runner`, which only works with a working Docker daemon.
- Image pull: the `arc-runners` namespace is default-deny-egress except DNS and `0.0.0.0/0:443,80` (cluster-internal ranges excluded), so pulling `postgres:18` from Docker Hub is permitted. Runner→service traffic never leaves the pod netns, so no NetworkPolicy applies to it.

**Caveat, stated plainly and still open:** the ARC configuration lives in a separate cluster repo, and I could not run a `staging` job from here. This PR's green run was on **`ubuntu-latest`**, not the arc-runner — the `runs-on` expression keys off `github.ref`, which for a PR is `refs/pull/N/merge`, so it never matches `refs/heads/staging`. **The hosted-runner path is now proven; the arc-runner path is first exercised on the merge commit to `staging`.** The configuration is unambiguous and the mechanism is well-defined, so I expect it to work, but I am not claiming it verified. If it does fail there the symptom is loud, not subtle — an "failed to initialize containers" error at job start — and the revert is a two-line change.

One operational note for the cluster side: the runner pod requests 1536Mi / limits 2Gi on the runner container, while the dind sidecar has no requests. A `postgres:18` container adds roughly 130–200 MB of unaccounted node memory for the duration of the job. Modest, but non-zero on a memory-tight cluster.

## Relationship to the other CI issues

- #312 (`ci-e2e-job`) touches the same file but adds a **new `e2e` job**; this diff stays strictly inside the existing `test` job, so the two should merge cleanly.
- **#310 and #311 depend on this landing** — they add tests that need a live database (v1 endpoint tests, and the app-bound ↔ DB-CHECK behavioural drift test). Merge this first or those will skip exactly the way these six did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
