### PR TITLE
fix: let a body-fat save leave the weight alone

### DIFF
--- a/client/src/api/weight.test.ts
+++ b/client/src/api/weight.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { upsertWeight } from './weight';
+
+/**
+ * These assert the wire shape of a weight save, because that shape is the whole
+ * fix: the server leaves alone whichever of the two columns the request omits,
+ * so a key that should not be there is a silent overwrite rather than an error.
+ */
+
+type Sent = { url: string; body: Record<string, unknown> };
+
+function stubFetch(): Sent[] {
+  const sent: Sent[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/csrf') {
+        return new Response(JSON.stringify({ token: 'test-csrf' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      sent.push({ url, body: JSON.parse(String(init?.body ?? '{}')) });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }),
+  );
+  return sent;
+}
+
+describe('upsertWeight', () => {
+  let sent: Sent[];
+  beforeEach(() => {
+    sent = stubFetch();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('omits weight when only a body fat is being saved', async () => {
+    await upsertWeight({ date: '2026-08-08', body_fat: 24.3 });
+    expect(sent).toHaveLength(1);
+    expect(sent[0].url).toBe('/weight/upsert');
+    // The regression: sending the dashboard's cached weight back here reverts
+    // a newer weight logged from another device.
+    expect(sent[0].body).not.toHaveProperty('weight');
+    expect(sent[0].body).toEqual({ date: '2026-08-08', body_fat: 24.3 });
+  });
+
+  it('sends an explicit null to clear a body fat, still without a weight', async () => {
+    await upsertWeight({ date: '2026-08-08', body_fat: null });
+    expect(sent[0].body).not.toHaveProperty('weight');
+    expect(sent[0].body).toEqual({ date: '2026-08-08', body_fat: null });
+  });
+
+  it('omits body_fat when only a weight is being saved', async () => {
+    // The mirror-image guarantee that already existed: a weight-only save must
+    // not wipe a reading taken from the same day's scale.
+    await upsertWeight({ date: '2026-08-08', weight: 82 });
+    expect(sent[0].body).not.toHaveProperty('body_fat');
+    expect(sent[0].body).toEqual({ date: '2026-08-08', weight: 82 });
+  });
+});

--- a/client/src/api/weight.ts
+++ b/client/src/api/weight.ts
@@ -10,11 +10,20 @@ export function getWeightDay(date: string, userId?: number) {
 }
 
 /**
- * `body_fat` is three-state on the server: omit the key to leave a stored
- * reading untouched, send null to clear it, send a number to set it. Callers
- * that only deal in weight must omit it rather than sending null.
+ * Both value fields are optional and omitting one leaves whatever is stored
+ * alone, so a save only ever writes what the user actually entered.
+ *
+ * - `body_fat` is three-state: omit the key to keep a stored reading, send null
+ *   to clear it, send a number to set it.
+ * - `weight` is two-state (the column is NOT NULL, so it cannot be cleared):
+ *   omit the key to keep the stored weight, send a number to replace it.
+ *   Callers that only deal in body fat MUST omit it — restating a cached weight
+ *   overwrites a newer one logged from another device. Omitting it on a date
+ *   with no entry yet is an error: there is no weight to attach the reading to.
+ *
+ * At least one of the two must be present.
  */
-export function upsertWeight(data: { date: string; weight: number; body_fat?: number | null }) {
+export function upsertWeight(data: { date: string; weight?: number; body_fat?: number | null }) {
   return api<{ ok: boolean }>('/weight/upsert', {
     method: 'POST',
     body: JSON.stringify(data),

--- a/client/src/i18n/locales/de/dashboard.json
+++ b/client/src/i18n/locales/de/dashboard.json
@@ -325,6 +325,7 @@
     "bodyFatNeedsWeight": "Körperfett %: trag zuerst oben ein Gewicht ein, dann wird es freigeschaltet.",
     "toastBodyFatTracked": "Körperfett getrackt",
     "toastBodyFatCleared": "Körperfett entfernt",
+    "toastBodyFatInvalid": "Körperfett muss zwischen 0 und {{max}} % liegen",
     "toastBodyFatSaveFailed": "Körperfett konnte nicht gespeichert werden",
     "bodyFatHint": "Das zweite Feld ist dein Körperfettanteil in %, falls deine Waage ihn misst.",
     "bodyFatPlaceholder": "% Fett"

--- a/client/src/i18n/locales/en/dashboard.json
+++ b/client/src/i18n/locales/en/dashboard.json
@@ -322,6 +322,7 @@
     "deleteEntryTitle": "Delete weight entry",
     "sectionTitle": "Weight",
     "toastBodyFatCleared": "Body fat removed",
+    "toastBodyFatInvalid": "Body fat must be between 0 and {{max}}%",
     "toastBodyFatSaveFailed": "Failed to save body fat",
     "toastBodyFatTracked": "Body fat tracked",
     "toastDeleteFailed": "Failed to delete weight",

--- a/client/src/i18n/locales/es/dashboard.json
+++ b/client/src/i18n/locales/es/dashboard.json
@@ -325,6 +325,7 @@
     "bodyFatNeedsWeight": "Grasa corporal %: registra primero un peso arriba y se desbloqueará.",
     "toastBodyFatTracked": "Grasa corporal registrada",
     "toastBodyFatCleared": "Grasa corporal eliminada",
+    "toastBodyFatInvalid": "La grasa corporal debe estar entre 0 y {{max}} %",
     "toastBodyFatSaveFailed": "Error al guardar la grasa corporal",
     "bodyFatHint": "La segunda casilla es tu % de grasa corporal, si tu báscula lo mide.",
     "bodyFatPlaceholder": "% grasa"

--- a/client/src/i18n/locales/fr/dashboard.json
+++ b/client/src/i18n/locales/fr/dashboard.json
@@ -325,6 +325,7 @@
     "bodyFatNeedsWeight": "Masse grasse % : enregistrez d’abord un poids ci-dessus pour la débloquer.",
     "toastBodyFatTracked": "Masse grasse suivie",
     "toastBodyFatCleared": "Masse grasse supprimée",
+    "toastBodyFatInvalid": "La masse grasse doit être comprise entre 0 et {{max}} %",
     "toastBodyFatSaveFailed": "Échec de l’enregistrement de la masse grasse",
     "bodyFatHint": "La seconde case est votre % de masse grasse, si votre balance le mesure.",
     "bodyFatPlaceholder": "% gras"

--- a/client/src/i18n/locales/it/dashboard.json
+++ b/client/src/i18n/locales/it/dashboard.json
@@ -325,6 +325,7 @@
     "bodyFatNeedsWeight": "Grasso corporeo %: registra prima un peso qui sopra e si sbloccherà.",
     "toastBodyFatTracked": "Grasso corporeo registrato",
     "toastBodyFatCleared": "Grasso corporeo rimosso",
+    "toastBodyFatInvalid": "Il grasso corporeo deve essere tra 0 e {{max}} %",
     "toastBodyFatSaveFailed": "Salvataggio del grasso corporeo non riuscito",
     "bodyFatHint": "Il secondo campo è la tua percentuale di grasso corporeo, se la bilancia la misura.",
     "bodyFatPlaceholder": "% grasso"

--- a/client/src/i18n/locales/nl/dashboard.json
+++ b/client/src/i18n/locales/nl/dashboard.json
@@ -325,6 +325,7 @@
     "bodyFatNeedsWeight": "Vetpercentage %: registreer eerst hierboven een gewicht, dan wordt het beschikbaar.",
     "toastBodyFatTracked": "Vetpercentage bijgehouden",
     "toastBodyFatCleared": "Vetpercentage verwijderd",
+    "toastBodyFatInvalid": "Vetpercentage moet tussen 0 en {{max}} % liggen",
     "toastBodyFatSaveFailed": "Opslaan van vetpercentage mislukt",
     "bodyFatHint": "Het tweede vak is je vetpercentage, als je weegschaal dat meet.",
     "bodyFatPlaceholder": "% vet"

--- a/client/src/i18n/locales/pl/dashboard.json
+++ b/client/src/i18n/locales/pl/dashboard.json
@@ -343,6 +343,7 @@
     "bodyFatNeedsWeight": "Tkanka tłuszczowa %: najpierw zapisz wagę powyżej, wtedy pole się odblokuje.",
     "toastBodyFatTracked": "Tkanka tłuszczowa zapisana",
     "toastBodyFatCleared": "Tkanka tłuszczowa usunięta",
+    "toastBodyFatInvalid": "Tkanka tłuszczowa musi wynosić od 0 do {{max}} %",
     "toastBodyFatSaveFailed": "Nie udało się zapisać tkanki tłuszczowej",
     "bodyFatHint": "Drugie pole to Twój procent tkanki tłuszczowej, jeśli waga go mierzy.",
     "bodyFatPlaceholder": "% tł."

--- a/client/src/i18n/locales/pt/dashboard.json
+++ b/client/src/i18n/locales/pt/dashboard.json
@@ -325,6 +325,7 @@
     "bodyFatNeedsWeight": "Gordura corporal %: registe primeiro um peso acima para desbloquear.",
     "toastBodyFatTracked": "Gordura corporal registada",
     "toastBodyFatCleared": "Gordura corporal removida",
+    "toastBodyFatInvalid": "A gordura corporal deve estar entre 0 e {{max}} %",
     "toastBodyFatSaveFailed": "Falha ao guardar gordura corporal",
     "bodyFatHint": "A segunda caixa é a sua % de gordura corporal, se a balança a medir.",
     "bodyFatPlaceholder": "% gordura"

--- a/client/src/lib/bodyFat.test.ts
+++ b/client/src/lib/bodyFat.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { MAX_BODY_FAT_PCT, parseBodyFatInput } from './bodyFat';
+
+describe('parseBodyFatInput', () => {
+  it('treats an empty field as "clear the reading"', () => {
+    // Matches the wire contract: null clears, a number sets. Emptying the
+    // input is the only way to remove a reading.
+    for (const raw of ['', '   ']) {
+      expect(parseBodyFatInput(raw)).toEqual({ ok: true, value: null });
+    }
+  });
+
+  it('accepts a percentage, including the European comma decimal', () => {
+    expect(parseBodyFatInput('24.3')).toEqual({ ok: true, value: 24.3 });
+    expect(parseBodyFatInput('24,3')).toEqual({ ok: true, value: 24.3 });
+    expect(parseBodyFatInput('  18 ')).toEqual({ ok: true, value: 18 });
+    expect(parseBodyFatInput('0.1')).toEqual({ ok: true, value: 0.1 });
+  });
+
+  it('accepts exactly the ceiling but nothing above it', () => {
+    // service.ParseBodyFat and the weight_entries_body_fat_range CHECK both
+    // use `0 < pct <= 75`; drifting from that would either reject values the
+    // server takes or let through ones it rejects.
+    expect(parseBodyFatInput(String(MAX_BODY_FAT_PCT))).toEqual({ ok: true, value: 75 });
+    expect(parseBodyFatInput('75.1')).toEqual({ ok: false });
+    expect(parseBodyFatInput('100')).toEqual({ ok: false });
+  });
+
+  it('rejects zero and negatives', () => {
+    for (const raw of ['0', '-5', '-0.1']) {
+      expect(parseBodyFatInput(raw)).toEqual({ ok: false });
+    }
+  });
+
+  it('rejects anything that is not a number', () => {
+    // Number() rather than parseFloat(): parseFloat('24abc') would silently
+    // save 24 for a value the user clearly mistyped.
+    for (const raw of ['abc', '24abc', 'NaN', 'Infinity', '12.34.56', '1234567890123']) {
+      expect(parseBodyFatInput(raw)).toEqual({ ok: false });
+    }
+  });
+});

--- a/client/src/lib/bodyFat.ts
+++ b/client/src/lib/bodyFat.ts
@@ -1,0 +1,32 @@
+/**
+ * Client-side parsing of the body-fat input, kept in lockstep with the server's
+ * `service.ParseBodyFat` and the `weight_entries_body_fat_range` CHECK.
+ *
+ * It exists so an out-of-range percentage fails where the user typed it instead
+ * of round-tripping to the server just to come back as a generic error toast.
+ */
+
+/** Mirror of `service.MaxBodyFatPct`. Deliberately loose — the highest values
+ *  ever recorded are around 70 — and the bound is inclusive on both sides:
+ *  0 < pct <= 75. */
+export const MAX_BODY_FAT_PCT = 75;
+
+/**
+ * The three outcomes of reading the field, matching the three states the
+ * `body_fat` key has on the wire: `null` clears the stored reading, a number
+ * sets it, and an unusable value is rejected without a request.
+ */
+export type BodyFatInput =
+  | { ok: true; value: number | null }
+  | { ok: false };
+
+export function parseBodyFatInput(raw: string): BodyFatInput {
+  const trimmed = raw.trim();
+  if (trimmed === '') return { ok: true, value: null };
+  // Same comma-decimal tolerance as the server, and the same length guard so a
+  // pasted essay never reaches parseFloat.
+  if (trimmed.length > 12) return { ok: false };
+  const num = Number(trimmed.replace(',', '.'));
+  if (!Number.isFinite(num) || num <= 0 || num > MAX_BODY_FAT_PCT) return { ok: false };
+  return { ok: true, value: num };
+}

--- a/client/src/pages/Dashboard/WeightRow.tsx
+++ b/client/src/pages/Dashboard/WeightRow.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import type { WeightEntry } from '@/types';
 import { upsertWeight, deleteWeight } from '@/api/weight';
+import { MAX_BODY_FAT_PCT, parseBodyFatInput } from '@/lib/bodyFat';
 import { useToastStore } from '@/stores/toastStore';
 import { SectionLabel } from '@/components/ui/SectionLabel';
 
@@ -48,17 +49,24 @@ export default function WeightRow({ weightEntry, lastWeightEntry, weightUnit, ca
   };
 
   const handleSaveBodyFat = async () => {
-    // The field is disabled until the date has a weight entry, so the weight
-    // sent here is the stored one — never the previous-day pre-fill.
+    // The field is disabled until the date has a weight entry, so there is
+    // always a stored weight for the server to keep.
     if (!weightEntry) return;
-    const raw = bodyFatRef.current?.value.trim() || '';
-    const num = raw === '' ? null : parseFloat(raw.replace(',', '.'));
-    if (num !== null && (!Number.isFinite(num) || num <= 0)) return;
+    const parsed = parseBodyFatInput(bodyFatRef.current?.value ?? '');
+    if (!parsed.ok) {
+      // Rejected here rather than round-tripping only to come back as a
+      // generic server error — the bound is the same on both sides.
+      addToast('error', t('weight.toastBodyFatInvalid', { max: MAX_BODY_FAT_PCT }));
+      return;
+    }
     setLoading(true);
     try {
-      await upsertWeight({ date: selectedDate, weight: Number(weightEntry.weight), body_fat: num });
+      // No weight key: this path only ever means "save the body fat", and the
+      // weight it would otherwise send is a cached value the user did not just
+      // measure — re-asserting it reverts a newer weight logged elsewhere.
+      await upsertWeight({ date: selectedDate, body_fat: parsed.value });
       queryClient.invalidateQueries({ queryKey: ['weight'] });
-      addToast('success', num === null ? t('weight.toastBodyFatCleared') : t('weight.toastBodyFatTracked'));
+      addToast('success', parsed.value === null ? t('weight.toastBodyFatCleared') : t('weight.toastBodyFatTracked'));
     } catch (err) {
       addToast('error', err instanceof Error ? err.message : t('weight.toastBodyFatSaveFailed'));
     }

--- a/docs/api-internal.md
+++ b/docs/api-internal.md
@@ -251,7 +251,7 @@ returns `401` when unauthenticated.
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | GET | `/weight/day` | Session, link-aware | Weight entry (weight + optional body fat) for a given day. |
-| POST | `/weight/upsert` | Session +CSRF | Create or update a weight entry for a date. |
+| POST | `/weight/upsert` | Session +CSRF | Create or update a weight entry for a date. `weight` and `body_fat` are independently optional; an omitted key leaves that column untouched. |
 | POST | `/weight/{id}/delete` | Session +CSRF | Delete a weight entry. |
 | POST | `/weight/toggle-body-fat` | Session +CSRF | Enable/disable the body-fat field for the current user. |
 
@@ -473,6 +473,30 @@ Request contains any subset of `name`, `amount`, and the macro `*_g` fields.
 ### `POST /entries/{id}/delete`
 
 No body. → `200 { "ok": true }` or `404` if not found.
+
+### `POST /weight/upsert`
+
+```json
+{ "date": "2026-07-12", "weight": "72.5", "body_fat": "24.3" }
+```
+
+Both value fields are optional and **an omitted key leaves the stored column
+alone**, so a save only ever writes what the caller actually measured. At least
+one of the two must be present.
+
+- `weight` — omit (or send `null` / `""`) to keep the stored weight, send a
+  number in `(0, 1500]` to replace it. It cannot be cleared; the column is
+  `NOT NULL`. A client saving only a body fat **must** omit it: restating a
+  cached weight overwrites a newer one logged from another device.
+- `body_fat` — a percentage in `(0, 75]`, three-state as described under
+  `POST /entries`.
+- `date` (alias `entry_date`) is `YYYY-MM-DD`; defaults to today in the user's
+  timezone.
+
+→ `200 { "ok": true, "entry": { "id", "entry_date", "weight", "body_fat", "created_at", "updated_at" } }`.
+`400 { "ok": false, "error": "Log a weight for that date first" }` when the
+request carries no `weight` and the date has no entry yet — there is nothing to
+attach a body-fat reading to. `400 "Nothing to save"` when both keys are absent.
 
 ---
 

--- a/internal/handler/weight.go
+++ b/internal/handler/weight.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -62,6 +63,30 @@ func parseBodyFatUpdate(body map[string]any) (service.BodyFatUpdate, bool) {
 		return service.BodyFatUpdate{}, false
 	}
 	return service.BodyFatUpdate{Set: true, Value: &pct}, true
+}
+
+// parseWeightUpdate is the weight counterpart of parseBodyFatUpdate: an absent,
+// null or empty weight leaves the stored one alone, a number replaces it. The
+// bool is false only when a value was supplied but is unusable.
+//
+// Making the key optional is what lets a body-fat-only save stop restating a
+// weight it never measured. The old contract forced the dashboard to send back
+// whatever weight its cache held, which silently reverted a newer one logged
+// from another device.
+func parseWeightUpdate(body map[string]any) (service.WeightUpdate, bool) {
+	raw, exists := body["weight"]
+	if !exists || raw == nil {
+		return service.KeepWeight, true
+	}
+	s := strings.TrimSpace(fmt.Sprintf("%v", raw))
+	if s == "" || s == "<nil>" {
+		return service.KeepWeight, true
+	}
+	wr := service.ParseWeight(s)
+	if !wr.Ok {
+		return service.WeightUpdate{}, false
+	}
+	return service.SetWeight(wr.Value), true
 }
 
 // WeightDay handles GET /weight/day
@@ -130,9 +155,8 @@ func (h *WeightHandler) WeightUpsert(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	weightStr := fmt.Sprintf("%v", body["weight"])
-	wr := service.ParseWeight(weightStr)
-	if !wr.Ok {
+	weightUpd, ok := parseWeightUpdate(body)
+	if !ok {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid weight")
 		return
 	}
@@ -143,8 +167,19 @@ func (h *WeightHandler) WeightUpsert(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entry, err := service.UpsertWeightEntry(r.Context(), h.Pool, user.ID, dateStr, wr.Value, bodyFat)
+	// Both omitted would be a write that changes nothing but updated_at, which
+	// is never what a caller meant — answer instead of quietly touching the row.
+	if !weightUpd.Set && !bodyFat.Set {
+		ErrorJSON(w, http.StatusBadRequest, "Nothing to save")
+		return
+	}
+
+	entry, err := service.UpsertWeightEntryPartial(r.Context(), h.Pool, user.ID, dateStr, weightUpd, bodyFat)
 	if err != nil {
+		if errors.Is(err, service.ErrNoWeightEntry) {
+			ErrorJSON(w, http.StatusBadRequest, "Log a weight for that date first")
+			return
+		}
 		ErrorJSON(w, http.StatusInternalServerError, "Could not save weight")
 		return
 	}

--- a/internal/handler/weight_test.go
+++ b/internal/handler/weight_test.go
@@ -80,3 +80,50 @@ func TestParseBodyFatUpdate(t *testing.T) {
 		}
 	})
 }
+
+func TestParseWeightUpdate(t *testing.T) {
+	t.Run("absent key preserves the stored weight", func(t *testing.T) {
+		// The case the endpoint was missing: a body-fat-only save. Before
+		// this, the dashboard had to restate its cached weight, which
+		// overwrote a newer one logged from another device.
+		got, ok := parseWeightUpdate(decodeBody(t, `{"body_fat":24.3}`))
+		if !ok {
+			t.Fatal("expected a body-fat-only body to be accepted")
+		}
+		if got.Set {
+			t.Errorf("Set = true for an absent weight key, want false (preserve)")
+		}
+	})
+
+	t.Run("null and empty string also preserve", func(t *testing.T) {
+		for _, raw := range []string{`{"weight":null,"body_fat":24.3}`, `{"weight":"","body_fat":24.3}`, `{"weight":"   ","body_fat":24.3}`} {
+			got, ok := parseWeightUpdate(decodeBody(t, raw))
+			if !ok || got.Set {
+				t.Errorf("%s: got {Set:%v ok:%v}, want a preserve", raw, got.Set, ok)
+			}
+		}
+	})
+
+	t.Run("a number sets the weight", func(t *testing.T) {
+		for _, raw := range []string{`{"weight":82}`, `{"weight":"82"}`, `{"weight":"82,0"}`} {
+			got, ok := parseWeightUpdate(decodeBody(t, raw))
+			if !ok {
+				t.Errorf("%s: expected acceptance", raw)
+				continue
+			}
+			if !got.Set || got.Value != 82 {
+				t.Errorf("%s: got {Set:%v Value:%v}, want {true 82}", raw, got.Set, got.Value)
+			}
+		}
+	})
+
+	t.Run("an unusable value is rejected rather than dropped", func(t *testing.T) {
+		// Rejected, not treated as "preserve": silently ignoring a weight the
+		// user did type would look like a successful save.
+		for _, raw := range []string{`{"weight":0}`, `{"weight":-5}`, `{"weight":1501}`, `{"weight":"abc"}`} {
+			if _, ok := parseWeightUpdate(decodeBody(t, raw)); ok {
+				t.Errorf("%s: expected rejection so the caller can answer 400", raw)
+			}
+		}
+	})
+}

--- a/internal/service/weight.go
+++ b/internal/service/weight.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -44,24 +45,82 @@ type BodyFatUpdate struct {
 // deal in weight.
 var KeepBodyFat = BodyFatUpdate{}
 
+// WeightUpdate is the counterpart of BodyFatUpdate for the weight column: it
+// lets a writer that has no weight of its own leave the stored one alone. A
+// body-fat-only save (the dashboard's body-fat input) otherwise has to restate
+// a weight it did not measure — in practice whatever its cache happens to
+// hold — and that unconditionally overwrites a newer reading logged from
+// another device.
+//
+// Only two states, not three: weight is NOT NULL, so there is no "clear it".
+//
+//	WeightUpdate{}   / KeepWeight   // leave the stored weight alone
+//	SetWeight(82.0)                 // write 82.0
+//
+// KeepWeight only makes sense for a date that already has a row — a body-fat
+// reading with no weight to hang it on is not an entry — so the write reports
+// ErrNoWeightEntry rather than inventing one.
+type WeightUpdate struct {
+	Set   bool
+	Value float64
+}
+
+// KeepWeight is the zero-value WeightUpdate, named for call sites that only
+// deal in body fat.
+var KeepWeight = WeightUpdate{}
+
+// SetWeight is the WeightUpdate that writes v.
+func SetWeight(v float64) WeightUpdate { return WeightUpdate{Set: true, Value: v} }
+
+// ErrNoWeightEntry is returned when a write that carries no weight of its own
+// (KeepWeight) targets a date that has no weight entry yet.
+var ErrNoWeightEntry = errors.New("no weight entry for that date")
+
+// UpsertWeightEntry writes weight unconditionally, preserving or changing the
+// body fat per bodyFat. It is the shape every caller that actually measured a
+// weight wants; callers that may not have one use UpsertWeightEntryPartial.
 func UpsertWeightEntry(ctx context.Context, q Querier, userID int, dateStr string, weight float64, bodyFat BodyFatUpdate) (*WeightResult, error) {
-	// The CASE resolves the three states inside the single statement rather
-	// than reading the row first, so two concurrent saves for the same day
-	// cannot interleave into a lost update.
-	row := q.QueryRow(ctx, `
-		INSERT INTO weight_entries (user_id, entry_date, weight, body_fat)
-		VALUES ($1, $2, $3, $4)
-		ON CONFLICT (user_id, entry_date)
-			DO UPDATE SET
-				weight = EXCLUDED.weight,
-				body_fat = CASE WHEN $5 THEN EXCLUDED.body_fat ELSE weight_entries.body_fat END,
-				updated_at = NOW()
-		RETURNING `+weightColumns,
-		userID, dateStr, weight, bodyFat.Value, bodyFat.Set)
+	return UpsertWeightEntryPartial(ctx, q, userID, dateStr, SetWeight(weight), bodyFat)
+}
+
+// UpsertWeightEntryPartial applies whichever of the two columns the caller
+// actually has a value for, leaving the other untouched.
+//
+// Both branches are a single statement so that two concurrent saves for the
+// same day cannot interleave into a lost update — that is the whole point of
+// resolving the states in SQL instead of reading the row first.
+func UpsertWeightEntryPartial(ctx context.Context, q Querier, userID int, dateStr string, weight WeightUpdate, bodyFat BodyFatUpdate) (*WeightResult, error) {
+	var row pgx.Row
+	if weight.Set {
+		row = q.QueryRow(ctx, `
+			INSERT INTO weight_entries (user_id, entry_date, weight, body_fat)
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (user_id, entry_date)
+				DO UPDATE SET
+					weight = EXCLUDED.weight,
+					body_fat = CASE WHEN $5 THEN EXCLUDED.body_fat ELSE weight_entries.body_fat END,
+					updated_at = NOW()
+			RETURNING `+weightColumns,
+			userID, dateStr, weight.Value, bodyFat.Value, bodyFat.Set)
+	} else {
+		// No weight means there is nothing to insert, so this is an UPDATE and
+		// a missing row is a real error instead of a silently created entry
+		// with a made-up weight.
+		row = q.QueryRow(ctx, `
+			UPDATE weight_entries
+				SET body_fat = CASE WHEN $3 THEN $4::numeric ELSE body_fat END,
+					updated_at = NOW()
+			WHERE user_id = $1 AND entry_date = $2
+			RETURNING `+weightColumns,
+			userID, dateStr, bodyFat.Set, bodyFat.Value)
+	}
 
 	var w WeightResult
 	err := row.Scan(&w.ID, &w.Date, &w.Weight, &w.BodyFat, &w.CreatedAt, &w.UpdatedAt)
 	if err != nil {
+		if !weight.Set && errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNoWeightEntry
+		}
 		return nil, err
 	}
 	return &w, nil

--- a/internal/service/weight_test.go
+++ b/internal/service/weight_test.go
@@ -1,7 +1,14 @@
 package service
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
 )
 
 func TestParseWeightValid(t *testing.T) {
@@ -127,5 +134,148 @@ func TestParseBodyFat(t *testing.T) {
 		if got, ok := ParseBodyFat(tt.input); ok {
 			t.Errorf("ParseBodyFat(%q) [%s] = %v, want not ok", tt.input, tt.desc, got)
 		}
+	}
+}
+
+// --- three-state weight write path -----------------------------------------
+
+// fakeRow satisfies pgx.Row. A nil err fills the six weightColumns
+// destinations with recognizable values so the happy path can Scan.
+type fakeRow struct {
+	err     error
+	bodyFat *float64
+}
+
+func (r fakeRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	if len(dest) != 6 {
+		return fmt.Errorf("scan into %d destinations, want the 6 of weightColumns", len(dest))
+	}
+	*dest[0].(*int) = 7
+	*dest[1].(*string) = "2026-08-08"
+	*dest[2].(*float64) = 82.0
+	*dest[3].(**float64) = r.bodyFat
+	*dest[4].(*time.Time) = time.Unix(0, 0).UTC()
+	*dest[5].(*time.Time) = time.Unix(0, 0).UTC()
+	return nil
+}
+
+// fakeQuerier records the single statement the upsert issues, which is what
+// these tests are really about: which columns the write touches.
+type fakeQuerier struct {
+	sql  string
+	args []any
+	row  pgx.Row
+}
+
+func (q *fakeQuerier) QueryRow(_ context.Context, sql string, args ...any) pgx.Row {
+	q.sql, q.args = sql, args
+	return q.row
+}
+
+func TestUpsertWeightEntryWritesWeight(t *testing.T) {
+	q := &fakeQuerier{row: fakeRow{}}
+	pct := 24.3
+	if _, err := UpsertWeightEntry(context.Background(), q, 3, "2026-08-08", 82.0, BodyFatUpdate{Set: true, Value: &pct}); err != nil {
+		t.Fatalf("UpsertWeightEntry: %v", err)
+	}
+	if !strings.Contains(q.sql, "INSERT INTO weight_entries") {
+		t.Errorf("a caller that measured a weight must insert-or-update; got:\n%s", q.sql)
+	}
+	if !strings.Contains(q.sql, "weight = EXCLUDED.weight") {
+		t.Errorf("weight must be written unconditionally on this path; got:\n%s", q.sql)
+	}
+	want := []any{3, "2026-08-08", 82.0, &pct, true}
+	if len(q.args) != len(want) {
+		t.Fatalf("args = %v, want %v", q.args, want)
+	}
+	for i := range want {
+		if fmt.Sprintf("%v", q.args[i]) != fmt.Sprintf("%v", want[i]) {
+			t.Errorf("arg %d = %v, want %v", i, q.args[i], want[i])
+		}
+	}
+}
+
+func TestUpsertWeightEntryPartialKeepWeightLeavesWeightAlone(t *testing.T) {
+	// The regression this whole three-state weight exists for: a body-fat-only
+	// save must not carry a weight, so it cannot revert one logged elsewhere.
+	pct := 24.3
+	q := &fakeQuerier{row: fakeRow{bodyFat: &pct}}
+	got, err := UpsertWeightEntryPartial(context.Background(), q, 3, "2026-08-08", KeepWeight, BodyFatUpdate{Set: true, Value: &pct})
+	if err != nil {
+		t.Fatalf("UpsertWeightEntryPartial: %v", err)
+	}
+	if got.BodyFat == nil || *got.BodyFat != pct {
+		t.Errorf("BodyFat = %v, want %v", got.BodyFat, pct)
+	}
+	if strings.Contains(q.sql, "INSERT") {
+		t.Errorf("with no weight there is nothing to insert; got:\n%s", q.sql)
+	}
+	if !strings.Contains(q.sql, "UPDATE weight_entries") {
+		t.Errorf("want an UPDATE; got:\n%s", q.sql)
+	}
+	if strings.Contains(q.sql, "SET weight") || strings.Contains(q.sql, "weight = ") {
+		t.Errorf("the weight column must not be assigned; got:\n%s", q.sql)
+	}
+	for _, arg := range q.args {
+		if w, ok := arg.(float64); ok {
+			t.Errorf("a weight (%v) reached the statement despite KeepWeight", w)
+		}
+	}
+	want := []any{3, "2026-08-08", true, &pct}
+	if len(q.args) != len(want) {
+		t.Fatalf("args = %v, want %v", q.args, want)
+	}
+	for i := range want {
+		if fmt.Sprintf("%v", q.args[i]) != fmt.Sprintf("%v", want[i]) {
+			t.Errorf("arg %d = %v, want %v", i, q.args[i], want[i])
+		}
+	}
+}
+
+func TestUpsertWeightEntryPartialKeepBothTouchesNeitherColumn(t *testing.T) {
+	q := &fakeQuerier{row: fakeRow{}}
+	if _, err := UpsertWeightEntryPartial(context.Background(), q, 3, "2026-08-08", KeepWeight, KeepBodyFat); err != nil {
+		t.Fatalf("UpsertWeightEntryPartial: %v", err)
+	}
+	// $3 false makes the CASE fall through to the stored value, so even this
+	// degenerate write cannot clear a reading.
+	if len(q.args) < 3 || q.args[2] != false {
+		t.Errorf("args = %v, want the body-fat Set flag to be false", q.args)
+	}
+}
+
+func TestUpsertWeightEntryPartialKeepWeightNeedsAnExistingEntry(t *testing.T) {
+	q := &fakeQuerier{row: fakeRow{err: pgx.ErrNoRows}}
+	_, err := UpsertWeightEntryPartial(context.Background(), q, 3, "2026-08-08", KeepWeight, BodyFatUpdate{Set: true})
+	if !errors.Is(err, ErrNoWeightEntry) {
+		// Inventing a weight would be worse than refusing: the caller has to
+		// be told there is nothing to attach the reading to.
+		t.Errorf("err = %v, want ErrNoWeightEntry", err)
+	}
+}
+
+func TestUpsertWeightEntryPartialSetWeightDoesNotMaskNoRows(t *testing.T) {
+	// INSERT ... RETURNING always yields a row, so ErrNoRows on that path is a
+	// real anomaly and must not be dressed up as "log a weight first".
+	q := &fakeQuerier{row: fakeRow{err: pgx.ErrNoRows}}
+	_, err := UpsertWeightEntryPartial(context.Background(), q, 3, "2026-08-08", SetWeight(82.0), KeepBodyFat)
+	if errors.Is(err, ErrNoWeightEntry) {
+		t.Errorf("err = %v, want the raw pgx.ErrNoRows", err)
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		t.Errorf("err = %v, want pgx.ErrNoRows", err)
+	}
+}
+
+func TestWeightUpdateStates(t *testing.T) {
+	if KeepWeight.Set {
+		t.Error("KeepWeight.Set = true, want false")
+	}
+	got := SetWeight(82.5)
+	if !got.Set || got.Value != 82.5 {
+		t.Errorf("SetWeight(82.5) = %+v, want {Set:true Value:82.5}", got)
 	}
 }


### PR DESCRIPTION
Closes #295

## The bug

There was no way to write a body-fat reading without also writing a weight, so `handleSaveBodyFat` sent back whatever weight its React cache held:

```ts
await upsertWeight({ date: selectedDate, weight: Number(weightEntry.weight), body_fat: num });
```

The server took it at face value — `ON CONFLICT ... DO UPDATE SET weight = EXCLUDED.weight` overwrites unconditionally. Phone logs 82.0, desktop tab still shows a cached 80.0, typing a body fat on the desktop writes `weight = 80.0` and the 82.0 is gone. Same-tab, blurring from the weight field into the body-fat field fires the save while the `invalidateQueries(['weight'])` refetch is still in flight and re-asserts the pre-edit weight.

`service.BodyFatUpdate` was built specifically so the reverse — a weight-only save — cannot clobber a body fat. Weight had no equivalent. This adds the mirror image.

## What changed

**`internal/service/weight.go`**
- `WeightUpdate` / `KeepWeight` / `SetWeight(v)`, the weight counterpart of `BodyFatUpdate`. Two states, not three: `weight` is `NOT NULL`, so there is no "clear it".
- `UpsertWeightEntryPartial(ctx, q, userID, date, WeightUpdate, BodyFatUpdate)` applies whichever column the caller actually has a value for. With `KeepWeight` there is nothing to insert, so it runs an `UPDATE` and a missing row returns the new `ErrNoWeightEntry` rather than inventing a weight. Both branches stay a single statement, so two concurrent saves for the same day still cannot interleave into a lost update.
- `UpsertWeightEntry` keeps its exact signature and wraps the new function, so no existing call site changes.

**`internal/handler/weight.go`**
- `parseWeightUpdate`, mirroring `parseBodyFatUpdate`: absent / `null` / `""` weight leaves the stored one alone, a number replaces it, an unusable value is a 400 rather than being silently dropped.
- `POST /weight/upsert` requires at least one of the two keys (`400 "Nothing to save"` otherwise) and maps `ErrNoWeightEntry` to `400 "Log a weight for that date first"`.

**Client**
- `handleSaveBodyFat` omits `weight` entirely, so a body-fat write touches only body fat.
- New `client/src/lib/bodyFat.ts` — `parseBodyFatInput` enforces the same `0 < pct <= 75` bound as `service.ParseBodyFat` and the `weight_entries_body_fat_range` CHECK. The old code rejected only `num <= 0`, so an out-of-range percentage round-tripped to the server just to come back as a generic toast. It now fails where the user typed it, with a new `weight.toastBodyFatInvalid` string translated into all 8 locales. Using `Number()` instead of `parseFloat()` also stops `24abc` from silently saving `24`.
- `upsertWeight`'s `weight` param is now optional, documented alongside the existing `body_fat` three-state contract.

**Docs** — `docs/api-internal.md` gains a `POST /weight/upsert` section spelling out that both value fields are independently optional.

### Backward compatibility

Additive on the wire: every existing client (SPA, schautrack-android) already sends a `weight`, and that path behaves exactly as before. Requests that previously 400'd (`"Invalid weight"` for an absent weight) now either succeed or return a more specific 400.

### Coordination with #296

No `/api/v1` handler is touched. `WeightUpdate` / `KeepWeight` / `UpsertWeightEntryPartial` are there for #296 to reuse when it adds body fat to `PUT /api/v1/weight/{date}`.

## Tests added

- `internal/service/weight_test.go` — a fake `Querier`/`pgx.Row` captures the statement the write issues. Asserts the body-fat-only path issues an `UPDATE` that never assigns `weight` and passes no weight argument at all (this is the regression guard), that `KeepWeight` on a date with no entry yields `ErrNoWeightEntry`, that `SetWeight` does *not* mask a `pgx.ErrNoRows` as that error, and that the weight-bearing path still writes `weight = EXCLUDED.weight`.
- `internal/handler/weight_test.go` — `TestParseWeightUpdate`, mirroring `TestParseBodyFatUpdate`.
- `client/src/api/weight.test.ts` — stubs `fetch` and asserts the serialized body: a body-fat save carries no `weight` key, a weight save carries no `body_fat` key.
- `client/src/lib/bodyFat.test.ts` — the bound, comma decimals, the inclusive 75 ceiling, and non-numeric rejection.

A component-level test of `WeightRow` was not added: the vitest project runs `environment: 'node'` with no jsdom and no `@testing-library/react`, and pulling those in would be a lockfile change well outside this fix. The validation and payload logic it would cover is tested directly instead.

## Verification

```
$ export GOFLAGS=-p=2 GOMAXPROCS=2
$ go build ./... && go vet ./... && go test ./...
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	0.021s
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	0.007s
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	0.008s
ok  	schautrack/internal/handler	1.936s
ok  	schautrack/internal/middleware	0.213s
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	0.065s
ok  	schautrack/internal/release	0.010s
ok  	schautrack/internal/service	0.247s
ok  	schautrack/internal/session	0.009s
ok  	schautrack/internal/sse	0.019s
```

```
$ cd client && npm ci && npm run typecheck && npm test && npm run i18n:drift && npm run i18n:check

> typecheck
> tsc -b --force
(clean)

> test
> vitest run
 RUN  v4.1.10
 Test Files  11 passed (11)
      Tests  129 passed (129)
   Duration  2.61s

> i18n:drift
> i18next-cli extract --ci
✔ Extraction complete!
✅ No files were updated.

> i18n:check
> node scripts/i18n-parity.mjs
✓ de: 818 keys (parity with en: 816)
✓ es: 818 keys (parity with en: 816)
✓ fr: 818 keys (parity with en: 816)
✓ it: 818 keys (parity with en: 816)
✓ nl: 818 keys (parity with en: 816)
✓ pl: 842 keys (parity with en: 816)
✓ pt: 818 keys (parity with en: 816)

i18n parity check passed.
```

`npm run test:e2e` was not run (excluded by the task's resource limits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)