### PR TITLE
fix: return problem+json when an /api/v1 handler panics

### DIFF
--- a/internal/handler/v1_recovery_test.go
+++ b/internal/handler/v1_recovery_test.go
@@ -1,0 +1,51 @@
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"schautrack/internal/apierr"
+)
+
+// TestV1RouterRecoversAsProblemJSON pins the mount, not just the middleware:
+// middleware.ProblemRecovery only protects v1 if MountAPIV1 actually installs
+// it. Drop the r.Use and a panic falls through to the globally-mounted
+// middleware.Recovery, which answers in the legacy {"ok": false} envelope and
+// breaks v1 invariant #3 (see #307).
+//
+// The probe route is registered on the router MountAPIV1 returns, so it rides
+// the real middleware chain. It is added after construction and never appears
+// in another test's instance, so TestV1RoutesMatchSpec is unaffected.
+func TestV1RouterRecoversAsProblemJSON(t *testing.T) {
+	prevWriter, prevFlags := log.Writer(), log.Flags()
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(prevWriter); log.SetFlags(prevFlags) })
+
+	router := (&V1Handler{}).MountAPIV1(nil)
+	router.Get("/panic-probe", func(http.ResponseWriter, *http.Request) {
+		panic("kaboom")
+	})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/panic-probe", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != apierr.ContentType {
+		t.Fatalf("Content-Type = %q, want %q — MountAPIV1 is not recovering panics as problem details",
+			ct, apierr.ContentType)
+	}
+
+	var p apierr.Problem
+	if err := json.Unmarshal(w.Body.Bytes(), &p); err != nil {
+		t.Fatalf("body is not JSON: %v (body: %q)", err, w.Body.String())
+	}
+	if p.Status != http.StatusInternalServerError || p.Title == "" || p.Detail == "" {
+		t.Errorf("problem = %+v, want a populated 500 problem", p)
+	}
+}

--- a/internal/handler/v1_router.go
+++ b/internal/handler/v1_router.go
@@ -49,6 +49,16 @@ type V1Handler struct {
 func (h *V1Handler) MountAPIV1(pool *pgxpool.Pool) chi.Router {
 	r := chi.NewRouter()
 
+	// Panics are an error path like any other, so they must answer in the v1
+	// error format too. The globally-mounted middleware.Recovery writes the
+	// legacy {"ok": false} envelope, which would break invariant #3 at exactly
+	// the moment a client most needs a machine-readable error. Recovering here
+	// — inside the mount, so this runs first and the global one never sees the
+	// panic — keeps the decision in the route table rather than in a path
+	// prefix check somewhere else. Same reasoning as the 404/405 overrides
+	// below.
+	r.Use(middleware.ProblemRecovery)
+
 	// The spec is public: a client must be able to fetch it before it has a
 	// token, and it contains no user data.
 	r.Get("/openapi.json", h.OpenAPI)

--- a/internal/middleware/recovery.go
+++ b/internal/middleware/recovery.go
@@ -5,22 +5,109 @@ import (
 	"log"
 	"net/http"
 	"runtime/debug"
+
+	"schautrack/internal/apierr"
 )
 
-// Recovery catches panics and returns a 500 JSON response.
+// Recovery catches panics and returns a 500 in the legacy
+// {"ok": false, "error": "..."} envelope.
+//
+// This is the error boundary of the SPA/session surface, and it is mounted
+// globally in cmd/server/main.go. The public API must NOT answer in this shape
+// — v1 errors are RFC 9457 problem details — so /api/v1 mounts ProblemRecovery
+// inside its own router instead. See handler.MountAPIV1.
 func Recovery(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer func() {
-			if rec := recover(); rec != nil {
-				log.Printf("panic: %v\n%s", rec, debug.Stack())
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusInternalServerError)
-				json.NewEncoder(w).Encode(map[string]any{
-					"ok":    false,
-					"error": "Internal server error",
-				})
-			}
-		}()
-		next.ServeHTTP(w, r)
+	return recoverWith(next, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "Internal server error",
+		})
 	})
+}
+
+// ProblemRecovery is Recovery with an RFC 9457 rejection, for the public API
+// surface — the same split as NewRateLimiter/NewProblemRateLimiter.
+//
+// It is mounted inside handler.MountAPIV1 rather than switched on r.URL.Path
+// from the global Recovery, so the route table stays the one place that decides
+// which surface a request belongs to (v1 invariant #2). Because it sits inside
+// the v1 mount it recovers first, and the global Recovery above it never sees
+// the panic.
+func ProblemRecovery(next http.Handler) http.Handler {
+	return recoverWith(next, func(w http.ResponseWriter, r *http.Request) {
+		apierr.Write(w, r, apierr.Internal("The request could not be completed."))
+	})
+}
+
+// recoverWith is the shared body of Recovery and ProblemRecovery: catch the
+// panic, log it with its stack, and let write render the surface-appropriate
+// error document.
+func recoverWith(next http.Handler, write func(http.ResponseWriter, *http.Request)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rw := &recoveryWriter{ResponseWriter: w}
+		defer func() {
+			rec := recover()
+			if rec == nil {
+				return
+			}
+
+			if rw.committed {
+				// The handler already wrote a status and probably part of a
+				// body. Writing the error document now would append a second
+				// JSON value to a half-written response and provoke a
+				// "superfluous response.WriteHeader" warning, while the status
+				// line — already on the wire — would still claim success.
+				// Nothing can be salvaged: leave the response truncated so the
+				// framing, not a bogus body, tells the client it is incomplete.
+				log.Printf("panic after response was committed (%s %s), response left truncated: %v\n%s",
+					r.Method, r.URL.Path, rec, debug.Stack())
+				return
+			}
+
+			// The panic value and the stack go to the operator's log and stop
+			// there. Both routinely carry request data, and a stack frame hands
+			// out the server's package and file layout; the client gets the
+			// fixed, generic body write produces instead.
+			log.Printf("panic: %v\n%s", rec, debug.Stack())
+			write(rw, r)
+		}()
+		next.ServeHTTP(rw, r)
+	})
+}
+
+// recoveryWriter records whether the response has been committed, so a panic
+// raised after the handler started writing does not double-write.
+//
+// It mirrors accessLogWriter: deliberately transparent, forwarding Flush and
+// exposing Unwrap so SSE streams and http.NewResponseController (the SSE
+// handler clears its write deadline through it) keep working.
+type recoveryWriter struct {
+	http.ResponseWriter
+	committed bool
+}
+
+func (w *recoveryWriter) WriteHeader(code int) {
+	w.committed = true
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *recoveryWriter) Write(b []byte) (int, error) {
+	w.committed = true
+	return w.ResponseWriter.Write(b)
+}
+
+// Flush forwards to the underlying Flusher so SSE streams keep working. A flush
+// commits the response even if nothing was written explicitly.
+func (w *recoveryWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		w.committed = true
+		f.Flush()
+	}
+}
+
+// Unwrap lets http.NewResponseController reach the underlying writer.
+func (w *recoveryWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
 }

--- a/internal/middleware/recovery_test.go
+++ b/internal/middleware/recovery_test.go
@@ -1,0 +1,281 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"schautrack/internal/apierr"
+)
+
+// captureLog redirects the standard logger (which Recovery uses) into a buffer
+// for the duration of a test, both to keep panic stacks out of the test output
+// and so a test can assert what was logged.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prevWriter, prevFlags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevWriter)
+		log.SetFlags(prevFlags)
+	})
+	return &buf
+}
+
+func panicking(v any) http.HandlerFunc {
+	return func(http.ResponseWriter, *http.Request) { panic(v) }
+}
+
+// v1Router mirrors the real composition in cmd/server/main.go and
+// handler.MountAPIV1: the legacy Recovery wraps everything, and the /api/v1
+// sub-router mounts ProblemRecovery of its own. Rebuilt here rather than
+// imported because internal/handler imports this package.
+func v1Router(next http.Handler) http.Handler {
+	v1 := chi.NewRouter()
+	v1.Use(ProblemRecovery)
+	v1.Handle("/entries", next)
+	v1.Handle("/weight/{date}", next)
+
+	r := chi.NewRouter()
+	r.Use(Recovery)
+	r.Mount("/api/v1", v1)
+	r.Handle("/settings", next)
+	r.Handle("/api/entries", next)
+	return r
+}
+
+// TestRecoveryReturnsLegacyShapeOnSPARoutes pins the SPA contract. The fix for
+// the v1 surface must not change what the session/SPA surface answers, because
+// the client parses {"ok": false, "error": ...} everywhere else.
+func TestRecoveryReturnsLegacyShapeOnSPARoutes(t *testing.T) {
+	captureLog(t)
+
+	h := v1Router(panicking("kaboom"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/entries", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body is not JSON: %v (body: %q)", err, w.Body.String())
+	}
+	if body["ok"] != false {
+		t.Errorf(`body["ok"] = %v, want false`, body["ok"])
+	}
+	if body["error"] != "Internal server error" {
+		t.Errorf(`body["error"] = %v, want "Internal server error"`, body["error"])
+	}
+}
+
+// TestRecoveryReturnsProblemJSONOnV1Routes is the regression test for #307: a
+// panic under /api/v1 used to fall through to the global Recovery and answer in
+// the legacy envelope, violating v1 invariant #3. Every v1 error — including
+// the ones no handler chose to return — must be an RFC 9457 problem.
+func TestRecoveryReturnsProblemJSONOnV1Routes(t *testing.T) {
+	captureLog(t)
+
+	h := v1Router(panicking("kaboom"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/entries", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != apierr.ContentType {
+		t.Fatalf("Content-Type = %q, want %q — a panic on a v1 route must not answer in the legacy shape",
+			ct, apierr.ContentType)
+	}
+
+	var p apierr.Problem
+	if err := json.Unmarshal(w.Body.Bytes(), &p); err != nil {
+		t.Fatalf("body is not JSON: %v (body: %q)", err, w.Body.String())
+	}
+	if p.Type != "https://schautrack.com/problems/internal-error" {
+		t.Errorf("type = %q, want the internal-error problem type", p.Type)
+	}
+	if p.Title == "" {
+		t.Error("title is empty")
+	}
+	if p.Status != http.StatusInternalServerError {
+		t.Errorf("status member = %d, want 500", p.Status)
+	}
+	if p.Detail == "" {
+		t.Error("detail is empty — a client has nothing to show the user")
+	}
+	if p.Instance != "/api/v1/entries" {
+		t.Errorf("instance = %q, want /api/v1/entries", p.Instance)
+	}
+
+	// The legacy members must be absent, not merely ignored: a client that
+	// sniffs for "ok" would otherwise still see the old shape.
+	var raw map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &raw)
+	if _, ok := raw["ok"]; ok {
+		t.Error(`problem body carries an "ok" member — the legacy envelope leaked through`)
+	}
+}
+
+// TestRecoveryDoesNotLeakPanicDetail checks that the panic value and the stack
+// reach the operator's log and nothing else. A stack frame in a response body
+// hands out the server's package and file layout, and a panic value routinely
+// carries request data.
+func TestRecoveryDoesNotLeakPanicDetail(t *testing.T) {
+	const secret = "panic-value-2f8c1a-user@example.com"
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"spa", "/settings"},
+		{"v1", "/api/v1/weight/2026-01-01"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logged := captureLog(t)
+
+			h := v1Router(panicking(secret))
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, tc.path, nil))
+
+			body := w.Body.String()
+			if strings.Contains(body, secret) {
+				t.Errorf("response body leaks the panic value: %q", body)
+			}
+			for _, frame := range []string{"goroutine ", "runtime/debug", "recovery.go:", "recovery_test.go:", ".go:"} {
+				if strings.Contains(body, frame) {
+					t.Errorf("response body leaks a stack frame (%q): %q", frame, body)
+				}
+			}
+
+			// The other half of the contract: it must actually be logged, or
+			// the panic becomes undebuggable.
+			if !strings.Contains(logged.String(), secret) {
+				t.Error("panic value was not logged")
+			}
+			if !strings.Contains(logged.String(), "goroutine ") {
+				t.Errorf("stack was not logged: %q", logged.String())
+			}
+		})
+	}
+}
+
+// TestRecoveryAfterPartialWrite covers a panic raised after the handler has
+// already committed a status and part of a body. Recovery used to call WriteHeader
+// unconditionally, which logged a "superfluous response.WriteHeader" warning
+// and appended a second JSON document to the half-written response — so the
+// client got a 200 status line and a body that was two concatenated values.
+// Nothing is recoverable at that point: the correct behaviour is to log and
+// leave the response truncated.
+func TestRecoveryAfterPartialWrite(t *testing.T) {
+	partial := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "partial")
+		panic("kaboom")
+	})
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"spa", "/settings"},
+		{"v1", "/api/v1/entries"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logged := captureLog(t)
+
+			w := httptest.NewRecorder()
+			v1Router(partial).ServeHTTP(w, httptest.NewRequest(http.MethodGet, tc.path, nil))
+
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want the 200 the handler already committed", w.Code)
+			}
+			if got := w.Body.String(); got != "partial" {
+				t.Errorf("body = %q, want %q — an error document was appended to a committed response", got, "partial")
+			}
+			if ct := w.Header().Get("Content-Type"); ct != "text/plain" {
+				t.Errorf("Content-Type = %q, want text/plain — the committed header was overwritten", ct)
+			}
+			if !strings.Contains(logged.String(), "kaboom") {
+				t.Errorf("panic after commit was not logged: %q", logged.String())
+			}
+		})
+	}
+
+	// The recorder cannot see a "superfluous response.WriteHeader" warning —
+	// only a real net/http server emits that — so check it end to end too.
+	t.Run("no superfluous WriteHeader on a real server", func(t *testing.T) {
+		captureLog(t)
+
+		var serverLog bytes.Buffer
+		srv := httptest.NewUnstartedServer(v1Router(partial))
+		srv.Config.ErrorLog = log.New(&serverLog, "", 0)
+		srv.Start()
+
+		resp, err := srv.Client().Get(srv.URL + "/api/v1/entries")
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		srv.Close() // waits for the handler goroutine, so serverLog is settled
+
+		if string(body) != "partial" {
+			t.Errorf("body = %q, want %q", body, "partial")
+		}
+		if strings.Contains(serverLog.String(), "superfluous") {
+			t.Errorf("server logged a superfluous WriteHeader: %q", serverLog.String())
+		}
+	})
+}
+
+// TestRecoveryWriterIsTransparent guards the wrapper Recovery installs to spot
+// a committed response. SSE streams flush through it and the SSE handler
+// clears its write deadline with http.NewResponseController, which needs
+// Unwrap; an opaque wrapper would break long-lived streams.
+func TestRecoveryWriterIsTransparent(t *testing.T) {
+	var inner http.ResponseWriter
+	var flushed bool
+
+	rec := httptest.NewRecorder()
+	h := Recovery(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		inner = w
+		if _, ok := w.(http.Flusher); !ok {
+			t.Error("wrapper does not implement Flusher — SSE streams would stall")
+		}
+		if u, ok := w.(interface{ Unwrap() http.ResponseWriter }); !ok {
+			t.Error("wrapper does not expose Unwrap — http.NewResponseController would break")
+		} else if u.Unwrap() != rec {
+			t.Error("Unwrap does not return the wrapped writer")
+		}
+		if err := http.NewResponseController(w).Flush(); err != nil {
+			t.Errorf("ResponseController.Flush: %v", err)
+		}
+		flushed = true
+	}))
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/events", nil))
+
+	if !flushed {
+		t.Fatal("handler did not run")
+	}
+	if inner == rec {
+		t.Error("Recovery did not wrap the ResponseWriter, so it cannot detect a committed response")
+	}
+	if !rec.Flushed {
+		t.Error("Flush did not reach the underlying writer")
+	}
+}


### PR DESCRIPTION
Closes #307

## The defect

`middleware.Recovery` is mounted globally at `cmd/server/main.go:137`, above the `/api/v1` mount at `:370`, and writes the legacy SPA envelope. A panic on a v1 route therefore answered:

```
status=500 content-type="application/json" body={"error":"Internal server error","ok":false}
```

That breaks v1 invariant #3 (errors are RFC 9457 problem details) at exactly the moment a client most needs a machine-readable error — and the OpenAPI document tells it to expect `application/problem+json` for a 500. `internal/middleware` had no test file for `recovery.go` at all, so nothing caught it.

## What changed

**1. Split the middleware, mount the v1 variant in the route table.**

`Recovery` keeps the legacy envelope for the SPA/session surface. The new `middleware.ProblemRecovery` writes `apierr.Internal(...)`. Both share one `recoverWith` body — the same split the rate limiter already has (`NewRateLimiter` / `NewProblemRateLimiter`).

The issue offered two shapes; I took the second (mount a v1-specific recovery inside `MountAPIV1`) rather than branching on `r.URL.Path` inside the global `Recovery`, because:

- **Invariant #2.** A path-prefix check puts a second, hidden copy of "what counts as /api/v1" in a file that is not the route table. Change the mount point and the string check silently stops matching. `r.Use` inside `MountAPIV1` cannot drift from the routes it protects.
- **There is already a precedent in that exact function.** The `NotFound`/`MethodNotAllowed` overrides a few lines below exist for the identical reason: every response from this router, including the ones no handler chose, is problem+json.
- Sitting inside the mount, `ProblemRecovery` recovers first, so the global `Recovery` above it never sees a v1 panic — no ordering subtlety, no double handling.

Known limitation, deliberately not addressed: `apiV1IPLimiter.Middleware` is applied with `r.With(...)` *outside* the mount in `main.go`, so a panic originating in the IP rate limiter itself would still hit the global `Recovery`. That code is pure in-memory bookkeeping with no realistic panic path, and moving the limiter inside the mount would put a `cfg`-dependent middleware into the DB-free, spec-checked route table.

**2. Stop double-writing after a partial response.**

`Recovery` called `WriteHeader` unconditionally. A panic raised *after* the handler had already committed a status and some bytes produced:

```
body = "partial{\"error\":\"Internal server error\",\"ok\":false}\n"
server log: http: superfluous response.WriteHeader call from ...
```

— two concatenated JSON documents behind a status line that still claims 200, and an overwritten `Content-Type`. Nothing is salvageable once the status line is on the wire, so the intended behaviour is: log it and leave the response truncated, letting the framing rather than a bogus body tell the client it is incomplete.

Detecting that needs to know whether the response is committed, so `recoverWith` installs a small `recoveryWriter`. It mirrors the existing `accessLogWriter`: deliberately transparent, forwards `Flush`, and exposes `Unwrap` so SSE streams and `http.NewResponseController` (the SSE handler clears its write deadline through it) keep working. `TestRecoveryWriterIsTransparent` pins that.

**3. Tests.** `internal/middleware/recovery_test.go` (new):

- `TestRecoveryReturnsLegacyShapeOnSPARoutes` — the SPA contract is unchanged.
- `TestRecoveryReturnsProblemJSONOnV1Routes` — `application/problem+json`, `type`/`title`/`status`/`detail`/`instance` populated, and no `ok` member leaking through.
- `TestRecoveryDoesNotLeakPanicDetail` — SPA and v1: the body contains neither the panic value nor any stack frame, and the log contains both.
- `TestRecoveryAfterPartialWrite` — SPA and v1 via a recorder, plus an end-to-end subtest against a real `httptest` server asserting no `superfluous response.WriteHeader` in the server error log.
- `TestRecoveryWriterIsTransparent` — `Flusher` + `Unwrap`.

Plus `internal/handler/v1_recovery_test.go`, which pins the *mount*: `ProblemRecovery` only protects v1 if `MountAPIV1` installs it, and a middleware-package test cannot import `internal/handler` (cycle). It registers a panicking probe route on the router `MountAPIV1` returns, so it rides the real chain. `TestV1RoutesMatchSpec` is unaffected — it builds its own instance.

No route was added, so `api/openapi.json` and `docs/api-v1.md` are unchanged (`go test ./...` confirms, via the staleness check).

## Verification

Red check first — with `r.Use(middleware.ProblemRecovery)` and the `rw.committed` guard removed, the new tests fail on exactly the reported defect:

```
--- FAIL: TestRecoveryReturnsProblemJSONOnV1Routes (0.00s)
    recovery_test.go:99: Content-Type = "application/json", want "application/problem+json" — a panic on a v1 route must not answer in the legacy shape
--- FAIL: TestRecoveryAfterPartialWrite (0.00s)
    --- FAIL: TestRecoveryAfterPartialWrite/spa (0.00s)
        recovery_test.go:207: body = "partial{\"error\":\"Internal server error\",\"ok\":false}\n", want "partial" — an error document was appended to a committed response
        recovery_test.go:210: Content-Type = "application/json", want text/plain — the committed header was overwritten
    --- FAIL: TestRecoveryAfterPartialWrite/v1 (0.00s)
        recovery_test.go:207: body = "partial{\"error\":\"Internal server error\",\"ok\":false}\n", want "partial" — an error document was appended to a committed response
        recovery_test.go:210: Content-Type = "application/json", want text/plain — the committed header was overwritten
    --- FAIL: TestRecoveryAfterPartialWrite/no_superfluous_WriteHeader_on_a_real_server (0.00s)
        recovery_test.go:237: body = "partial{\"error\":\"Internal server error\",\"ok\":false}\n", want "partial"
        recovery_test.go:240: server logged a superfluous WriteHeader: "http: superfluous response.WriteHeader call from schautrack/internal/middleware.(*recoveryWriter).WriteHeader (recovery.go:93)\n"
FAIL	schautrack/internal/middleware	0.007s
--- FAIL: TestV1RouterRecoversAsProblemJSON (0.00s)
panic: kaboom [recovered, repanicked]
FAIL	schautrack/internal/handler	0.012s
```

Green, with the fix in place — `go build ./... && go vet ./... && go test ./...`:

```
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	(cached)
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	(cached)
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	(cached)
ok  	schautrack/internal/handler	1.291s
ok  	schautrack/internal/middleware	0.079s
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	(cached)
ok  	schautrack/internal/release	(cached)
ok  	schautrack/internal/service	(cached)
ok  	schautrack/internal/session	(cached)
ok  	schautrack/internal/sse	(cached)
```

`go test ./internal/middleware/ -run TestRecovery -v`:

```
=== RUN   TestRecoveryReturnsLegacyShapeOnSPARoutes
--- PASS: TestRecoveryReturnsLegacyShapeOnSPARoutes (0.00s)
=== RUN   TestRecoveryReturnsProblemJSONOnV1Routes
--- PASS: TestRecoveryReturnsProblemJSONOnV1Routes (0.00s)
=== RUN   TestRecoveryDoesNotLeakPanicDetail
=== RUN   TestRecoveryDoesNotLeakPanicDetail/spa
=== RUN   TestRecoveryDoesNotLeakPanicDetail/v1
--- PASS: TestRecoveryDoesNotLeakPanicDetail (0.00s)
    --- PASS: TestRecoveryDoesNotLeakPanicDetail/spa (0.00s)
    --- PASS: TestRecoveryDoesNotLeakPanicDetail/v1 (0.00s)
=== RUN   TestRecoveryAfterPartialWrite
=== RUN   TestRecoveryAfterPartialWrite/spa
=== RUN   TestRecoveryAfterPartialWrite/v1
=== RUN   TestRecoveryAfterPartialWrite/no_superfluous_WriteHeader_on_a_real_server
--- PASS: TestRecoveryAfterPartialWrite (0.00s)
    --- PASS: TestRecoveryAfterPartialWrite/spa (0.00s)
    --- PASS: TestRecoveryAfterPartialWrite/v1 (0.00s)
    --- PASS: TestRecoveryAfterPartialWrite/no_superfluous_WriteHeader_on_a_real_server (0.00s)
=== RUN   TestRecoveryWriterIsTransparent
--- PASS: TestRecoveryWriterIsTransparent (0.00s)
PASS
ok  	schautrack/internal/middleware	0.010s
```

`go test ./internal/handler/ -run TestV1Router -v`:

```
=== RUN   TestV1RouterRecoversAsProblemJSON
--- PASS: TestV1RouterRecoversAsProblemJSON (0.00s)
PASS
ok  	schautrack/internal/handler	0.036s
```

`go test -race ./internal/middleware/ -run TestRecovery` → `ok schautrack/internal/middleware 1.038s`. `gofmt -l` clean on all four touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)