### PR TITLE
fix: stop expired API tokens from locking users out of minting new ones

### DIFF
--- a/client/src/api/apiTokens.ts
+++ b/client/src/api/apiTokens.ts
@@ -9,6 +9,13 @@ export interface ApiToken {
   expires_at: string | null;
   last_used_at: string | null;
   created_at: string;
+  /**
+   * Whether the token has lapsed, decided by the SERVER's clock — the same one
+   * the mint limit is enforced against. Optional only because a freshly loaded
+   * bundle can briefly talk to a pod that predates the field; see
+   * `isTokenExpired` in `@/lib/apiTokenLimits` for the fallback.
+   */
+  expired?: boolean;
 }
 
 export interface ScopeInfo {

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -197,6 +197,8 @@
     "createFailed": "Token konnte nicht erstellt werden",
     "dismiss": "Fertig",
     "empty": "Keine API-Tokens. Erstelle eines, um Schautrack aus Skripten oder anderen Apps zu nutzen.",
+    "expiredBadge": "Abgelaufen",
+    "expiredOn": "am {{date}} abgelaufen",
     "expires": "läuft am {{date}} ab",
     "expiry30": "Läuft in 30 Tagen ab",
     "expiry365": "Läuft in 1 Jahr ab",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -114,6 +114,8 @@
     "createFailed": "Failed to create the token",
     "dismiss": "Done",
     "empty": "No API tokens. Create one to use Schautrack from scripts or other apps.",
+    "expiredBadge": "Expired",
+    "expiredOn": "expired {{date}}",
     "expires": "expires {{date}}",
     "expiry30": "Expires in 30 days",
     "expiry365": "Expires in 1 year",

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -197,6 +197,8 @@
     "createFailed": "No se pudo crear el token",
     "dismiss": "Listo",
     "empty": "No hay tokens de API. Crea uno para usar Schautrack desde scripts u otras aplicaciones.",
+    "expiredBadge": "Caducado",
+    "expiredOn": "caducó el {{date}}",
     "expires": "caduca el {{date}}",
     "expiry30": "Caduca en 30 días",
     "expiry365": "Caduca en 1 año",

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -197,6 +197,8 @@
     "createFailed": "Échec de la création du jeton",
     "dismiss": "Terminé",
     "empty": "Aucun jeton d'API. Créez-en un pour utiliser Schautrack depuis des scripts ou d'autres applications.",
+    "expiredBadge": "Expiré",
+    "expiredOn": "expiré le {{date}}",
     "expires": "expire le {{date}}",
     "expiry30": "Expire dans 30 jours",
     "expiry365": "Expire dans 1 an",

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -197,6 +197,8 @@
     "createFailed": "Impossibile creare il token",
     "dismiss": "Fatto",
     "empty": "Nessun token API. Creane uno per usare Schautrack da script o altre app.",
+    "expiredBadge": "Scaduto",
+    "expiredOn": "scaduto il {{date}}",
     "expires": "scade il {{date}}",
     "expiry30": "Scade tra 30 giorni",
     "expiry365": "Scade tra 1 anno",

--- a/client/src/i18n/locales/nl/settings.json
+++ b/client/src/i18n/locales/nl/settings.json
@@ -197,6 +197,8 @@
     "createFailed": "Token aanmaken mislukt",
     "dismiss": "Klaar",
     "empty": "Geen API-tokens. Maak er een om Schautrack vanuit scripts of andere apps te gebruiken.",
+    "expiredBadge": "Verlopen",
+    "expiredOn": "verlopen op {{date}}",
     "expires": "verloopt op {{date}}",
     "expiry30": "Verloopt over 30 dagen",
     "expiry365": "Verloopt over 1 jaar",

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -201,6 +201,8 @@
     "createFailed": "Nie udało się utworzyć tokena",
     "dismiss": "Gotowe",
     "empty": "Brak tokenów API. Utwórz token, aby korzystać ze Schautrack ze skryptów lub innych aplikacji.",
+    "expiredBadge": "Wygasł",
+    "expiredOn": "wygasł {{date}}",
     "expires": "wygasa {{date}}",
     "expiry30": "Wygasa za 30 dni",
     "expiry365": "Wygasa za 1 rok",

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -197,6 +197,8 @@
     "createFailed": "Não foi possível criar o token",
     "dismiss": "Concluído",
     "empty": "Sem tokens de API. Crie um para usar o Schautrack a partir de scripts ou outras aplicações.",
+    "expiredBadge": "Expirado",
+    "expiredOn": "expirou a {{date}}",
     "expires": "expira a {{date}}",
     "expiry30": "Expira em 30 dias",
     "expiry365": "Expira em 1 ano",

--- a/client/src/lib/apiTokenLimits.test.ts
+++ b/client/src/lib/apiTokenLimits.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { isTokenExpired, activeTokenCount, isAtTokenLimit } from './apiTokenLimits';
+
+const NOW = new Date('2026-06-15T12:00:00Z');
+const PAST = '2026-01-01T00:00:00Z';
+const FUTURE = '2027-01-01T00:00:00Z';
+
+/** A token as the list endpoint returns it. */
+const token = (expired?: boolean, expires_at: string | null = null) => ({ expired, expires_at });
+
+describe('isTokenExpired', () => {
+  // The server's clock is the one the limit is enforced against, so its answer
+  // wins even when the browser would read the date the other way.
+  it("trusts the server's flag over the browser's clock", () => {
+    expect(isTokenExpired(token(true, FUTURE), NOW)).toBe(true);
+    expect(isTokenExpired(token(false, PAST), NOW)).toBe(false);
+  });
+
+  it('falls back to expires_at when the server did not send the flag', () => {
+    expect(isTokenExpired(token(undefined, PAST), NOW)).toBe(true);
+    expect(isTokenExpired(token(undefined, FUTURE), NOW)).toBe(false);
+  });
+
+  it('treats a token with no expiry as live', () => {
+    expect(isTokenExpired(token(undefined, null), NOW)).toBe(false);
+    expect(isTokenExpired(token(false, null), NOW)).toBe(false);
+  });
+
+  it('expires exactly at the boundary, matching the server', () => {
+    expect(isTokenExpired(token(undefined, NOW.toISOString()), NOW)).toBe(true);
+  });
+});
+
+describe('activeTokenCount', () => {
+  it('counts only the tokens that are not expired', () => {
+    const tokens = [token(false), token(true), token(false), token(true)];
+    expect(activeTokenCount(tokens, NOW)).toBe(2);
+  });
+
+  it('is 0 for an empty list', () => expect(activeTokenCount([], NOW)).toBe(0));
+});
+
+describe('isAtTokenLimit', () => {
+  const many = (n: number, expired: boolean) => Array.from({ length: n }, () => token(expired));
+
+  it('is at the limit when every token is live', () => {
+    expect(isAtTokenLimit(many(20, false), 20, NOW)).toBe(true);
+  });
+
+  // The regression: 20 tokens of which 8 have lapsed leaves 12 live, so the
+  // server would mint eight more. Gating on tokens.length hid the button.
+  it('is NOT at the limit when expired tokens make up the difference', () => {
+    const tokens = [...many(12, false), ...many(8, true)];
+    expect(tokens.length).toBe(20);
+    expect(isAtTokenLimit(tokens, 20, NOW)).toBe(false);
+  });
+
+  it('is at the limit once the live subset reaches max, however many are dead', () => {
+    const tokens = [...many(20, false), ...many(5, true)];
+    expect(isAtTokenLimit(tokens, 20, NOW)).toBe(true);
+  });
+
+  it('is not at the limit below max, and never for an empty list', () => {
+    expect(isAtTokenLimit(many(19, false), 20, NOW)).toBe(false);
+    expect(isAtTokenLimit([], 20, NOW)).toBe(false);
+  });
+
+  it('derives the same answer from expires_at when the flag is absent', () => {
+    const tokens = [
+      ...Array.from({ length: 12 }, () => token(undefined, FUTURE)),
+      ...Array.from({ length: 8 }, () => token(undefined, PAST)),
+    ];
+    expect(isAtTokenLimit(tokens, 20, NOW)).toBe(false);
+  });
+});

--- a/client/src/lib/apiTokenLimits.ts
+++ b/client/src/lib/apiTokenLimits.ts
@@ -1,0 +1,44 @@
+import type { ApiToken } from '@/api/apiTokens';
+
+/**
+ * Which API tokens are dead, and which ones count against the per-user limit.
+ *
+ * This lives apart from the settings card because the rule has to match the
+ * server's exactly: `CreateAPIToken` caps *active* tokens (unrevoked and
+ * unexpired), while the list endpoint deliberately returns expired ones too so
+ * the user can see and clear them. Gating the "New token" button on the raw
+ * list length told a user with 20 tokens — 8 of them lapsed — that they were at
+ * the limit, and hid the button entirely, while the server would have minted
+ * eight more (issue #299).
+ */
+
+/** The fields the expiry rule reads. */
+type TokenExpiry = Pick<ApiToken, 'expires_at' | 'expired'>;
+
+/**
+ * Whether a token has lapsed.
+ *
+ * Prefers the server's `expired` flag: the limit is enforced against the
+ * server's clock, so anything the UI decides from a browser clock could
+ * disagree with it — which is the class of bug this module exists to prevent.
+ * The `expires_at` comparison is only a fallback for a response that predates
+ * the flag (possible mid-rollout, when a new bundle can hit an old pod).
+ */
+export function isTokenExpired(token: TokenExpiry, now: Date = new Date()): boolean {
+  if (typeof token.expired === 'boolean') return token.expired;
+  if (!token.expires_at) return false;
+  return new Date(token.expires_at).getTime() <= now.getTime();
+}
+
+/** How many of these tokens count against the limit. */
+export function activeTokenCount(tokens: TokenExpiry[], now?: Date): number {
+  return tokens.reduce((n, token) => (isTokenExpired(token, now) ? n : n + 1), 0);
+}
+
+/**
+ * Whether the user may still mint a token. Counts the active subset only, so it
+ * agrees with the server's cap.
+ */
+export function isAtTokenLimit(tokens: TokenExpiry[], max: number, now?: Date): boolean {
+  return activeTokenCount(tokens, now) >= max;
+}

--- a/client/src/pages/Settings/ApiTokenSettings.tsx
+++ b/client/src/pages/Settings/ApiTokenSettings.tsx
@@ -8,6 +8,7 @@ import {
   type ScopeInfo,
 } from '@/api/apiTokens';
 import { Button } from '@/components/ui/Button';
+import { isAtTokenLimit, isTokenExpired } from '@/lib/apiTokenLimits';
 import { useToastStore } from '@/stores/toastStore';
 
 /**
@@ -110,7 +111,10 @@ export default function ApiTokenSettings() {
 
   if (!loaded) return null;
 
-  const atLimit = tokens.length >= max;
+  // Only live tokens count, exactly as the server's cap does. Gating on
+  // tokens.length instead hid the "New token" button from anyone whose expired
+  // tokens padded the list to `max`, for tokens the server would have minted.
+  const atLimit = isAtTokenLimit(tokens, max);
   const fmtDate = (iso: string) => new Date(iso).toLocaleDateString();
 
   return (
@@ -166,30 +170,54 @@ export default function ApiTokenSettings() {
 
         {tokens.length > 0 && (
           <div className="flex flex-col divide-y divide-divider">
-            {tokens.map((tok) => (
-              <div key={tok.id} className="flex flex-wrap items-center gap-x-2 gap-y-1 py-2.5">
-                <div className="flex-1 min-w-0">
-                  <div className="truncate text-sm text-foreground">{tok.name}</div>
-                  <div className="text-xs text-muted-foreground">
-                    <code>{tok.prefix}…</code>
-                    {' · '}
-                    {tok.scopes.join(', ')}
+            {tokens.map((tok) => {
+              // An expired token authenticates nothing, so it has to read as
+              // dead: greyed name, an "expired" badge, and the date in the
+              // destructive colour rather than the same neutral grey a live
+              // token's expiry uses.
+              const expired = isTokenExpired(tok);
+              return (
+                <div key={tok.id} className="flex flex-wrap items-center gap-x-2 gap-y-1 py-2.5">
+                  <div className="flex-1 min-w-0">
+                    <div
+                      className={`truncate text-sm ${expired ? 'text-muted-foreground' : 'text-foreground'}`}
+                    >
+                      {tok.name}
+                      {expired && (
+                        <span className="ml-2 rounded border border-destructive/40 px-1.5 py-0.5 align-middle text-[10px] font-medium uppercase tracking-wide text-destructive">
+                          {t('apiTokens.expiredBadge')}
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      <code>{tok.prefix}…</code>
+                      {' · '}
+                      {tok.scopes.join(', ')}
+                    </div>
                   </div>
+                  <span className="text-xs text-muted-foreground whitespace-nowrap ml-auto">
+                    {tok.last_used_at
+                      ? t('apiTokens.usedOn', { date: fmtDate(tok.last_used_at) })
+                      : t('apiTokens.neverUsed')}
+                    {tok.expires_at && ' · '}
+                    {tok.expires_at &&
+                      (expired ? (
+                        <span className="text-destructive">
+                          {t('apiTokens.expiredOn', { date: fmtDate(tok.expires_at) })}
+                        </span>
+                      ) : (
+                        t('apiTokens.expires', { date: fmtDate(tok.expires_at) })
+                      ))}
+                  </span>
+                  <button
+                    className="text-xs text-destructive hover:text-destructive/80 cursor-pointer bg-transparent border-0 p-1 transition-colors"
+                    onClick={() => handleRevoke(tok)}
+                  >
+                    {t('apiTokens.revoke')}
+                  </button>
                 </div>
-                <span className="text-xs text-muted-foreground whitespace-nowrap ml-auto">
-                  {tok.last_used_at
-                    ? t('apiTokens.usedOn', { date: fmtDate(tok.last_used_at) })
-                    : t('apiTokens.neverUsed')}
-                  {tok.expires_at && ` · ${t('apiTokens.expires', { date: fmtDate(tok.expires_at) })}`}
-                </span>
-                <button
-                  className="text-xs text-destructive hover:text-destructive/80 cursor-pointer bg-transparent border-0 p-1 transition-colors"
-                  onClick={() => handleRevoke(tok)}
-                >
-                  {t('apiTokens.revoke')}
-                </button>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
 

--- a/internal/handler/api_tokens.go
+++ b/internal/handler/api_tokens.go
@@ -34,6 +34,12 @@ type apiTokenView struct {
 	ExpiresAt  *time.Time `json:"expires_at"`
 	LastUsedAt *time.Time `json:"last_used_at"`
 	CreatedAt  time.Time  `json:"created_at"`
+
+	// Expired is computed here rather than left to the client to derive from
+	// ExpiresAt. The browser clock is not the clock the limit is enforced
+	// against, and the UI both marks dead rows and gates its "New token"
+	// button on this — so it has to be the server's answer (issue #299).
+	Expired bool `json:"expired"`
 }
 
 // List handles GET /api/tokens.
@@ -46,11 +52,15 @@ func (h *APITokensHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// One clock reading for the whole list, so two rows expiring in the same
+	// instant cannot be classified differently.
+	now := time.Now()
 	views := make([]apiTokenView, 0, len(tokens))
 	for _, t := range tokens {
 		views = append(views, apiTokenView{
 			ID: t.ID, Name: t.Name, Prefix: t.Prefix, Scopes: t.Scopes,
 			ExpiresAt: t.ExpiresAt, LastUsedAt: t.LastUsedAt, CreatedAt: t.CreatedAt,
+			Expired: !t.Active(now),
 		})
 	}
 

--- a/internal/service/apitoken.go
+++ b/internal/service/apitoken.go
@@ -211,6 +211,34 @@ func LooksLikeAPIToken(s string) bool {
 // tokens.
 var ErrTokenLimit = fmt.Errorf("token limit reached (maximum %d)", MaxTokensPerUser)
 
+// activeTokenCountSQL is the single definition of "counts against
+// MaxTokensPerUser": unrevoked and unexpired, judged by the database clock.
+//
+// It is shared rather than copied because the copies drifted once already.
+// ListAPITokens keeps expired tokens, this count ignores them, and the token UI
+// gated its "New token" button on the raw list length — so a user holding 20
+// tokens of which 8 had lapsed was told they were at the limit while the server
+// would happily have minted eight more, with no way out of the UI except
+// revoking dead tokens one at a time (issue #299). Anything answering "is this
+// user at the limit?" must go through here.
+const activeTokenCountSQL = `
+	SELECT COUNT(*)::int FROM api_tokens
+	WHERE user_id = $1 AND revoked_at IS NULL
+	  AND (expires_at IS NULL OR expires_at > NOW())`
+
+// CountActiveAPITokens returns how many of a user's tokens count against
+// MaxTokensPerUser.
+//
+// It takes a Querier so the mint path can run it inside its transaction while
+// callers outside one pass the pool.
+func CountActiveAPITokens(ctx context.Context, db Querier, userID int) (int, error) {
+	var n int
+	if err := db.QueryRow(ctx, activeTokenCountSQL, userID).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
 // CreateAPIToken mints a token for a user and returns it along with the raw
 // secret. The raw secret is the only copy — it is never recoverable again.
 func CreateAPIToken(ctx context.Context, pool *pgxpool.Pool, userID int, name string, scopes []string, expiresAt *time.Time) (*model.APIToken, string, error) {
@@ -239,11 +267,8 @@ func CreateAPIToken(ctx context.Context, pool *pgxpool.Pool, userID int, name st
 	}
 	defer tx.Rollback(ctx)
 
-	var active int
-	if err := tx.QueryRow(ctx,
-		`SELECT COUNT(*)::int FROM api_tokens
-		 WHERE user_id = $1 AND revoked_at IS NULL
-		   AND (expires_at IS NULL OR expires_at > NOW())`, userID).Scan(&active); err != nil {
+	active, err := CountActiveAPITokens(ctx, tx, userID)
+	if err != nil {
 		return nil, "", err
 	}
 	if active >= MaxTokensPerUser {
@@ -274,6 +299,18 @@ func CreateAPIToken(ctx context.Context, pool *pgxpool.Pool, userID int, name st
 // ListAPITokens returns a user's tokens, newest first. Revoked tokens are
 // excluded: they are dead weight in a management UI, and the row is retained
 // only so the digest stays burned.
+//
+// Expired tokens ARE returned, deliberately. A token that quietly lapsed is the
+// likeliest explanation for "my script started getting 401s", so dropping it
+// from the list would delete the only place the user could discover that, and
+// leave them no way to tidy the row away either.
+//
+// The consequence: len(the returned slice) is NOT the number of tokens that
+// count against MaxTokensPerUser. Callers deciding whether a user may mint
+// another must use CountActiveAPITokens or filter on model.APIToken.Active —
+// counting the raw list is exactly the bug in issue #299. The handler stamps
+// each row with an Expired flag so the UI can gate on the active subset (and
+// grey the dead ones out) without trusting the browser clock.
 func ListAPITokens(ctx context.Context, pool *pgxpool.Pool, userID int) ([]model.APIToken, error) {
 	rows, err := pool.Query(ctx, `
 		SELECT id, name, prefix, scopes, expires_at, last_used_at, created_at, revoked_at

--- a/internal/service/apitoken_test.go
+++ b/internal/service/apitoken_test.go
@@ -1,9 +1,17 @@
 package service
 
 import (
+	"context"
 	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
 	"strings"
 	"testing"
+	"time"
+
+	"schautrack/internal/database"
+	"schautrack/internal/model"
 )
 
 func TestGenerateAPITokenShape(t *testing.T) {
@@ -172,6 +180,158 @@ func TestScopeSatisfies(t *testing.T) {
 			}
 		})
 	}
+}
+
+// activeInList counts the tokens a caller reading ListAPITokens would consider
+// live — the same subset the token UI renders as usable. It exists so the test
+// below can compare the list's answer against the cap's answer.
+func activeInList(tokens []model.APIToken, now time.Time) int {
+	n := 0
+	for _, t := range tokens {
+		if t.Active(now) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestListAndCapAgreeOnWhatCountsAgainstTheLimit is the regression test for
+// issue #299: ListAPITokens kept expired tokens while the mint cap ignored
+// them, and the UI — which gates its "New token" button on the list — locked
+// users out of tokens the server would have granted.
+//
+// The two must stay reconcilable: whatever ListAPITokens returns, the number of
+// entries satisfying model.APIToken.Active has to equal CountActiveAPITokens,
+// which is the number CreateAPIToken enforces against. This test drives a user
+// through the states where they diverged.
+//
+// Skipped unless TEST_DATABASE_URL is set, so it does not gate CI (which has no
+// database). Run locally with, e.g.:
+//
+//	TEST_DATABASE_URL='postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable' go test ./internal/service/ -run TestListAndCapAgreeOnWhatCountsAgainstTheLimit -v
+func TestListAndCapAgreeOnWhatCountsAgainstTheLimit(t *testing.T) {
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	pool, err := database.NewPool(ctx, url)
+	if err != nil {
+		t.Fatalf("NewPool failed: %v", err)
+	}
+	defer pool.Close()
+
+	if err := database.InitSchemaWithRetry(ctx, pool, 3); err != nil {
+		t.Fatalf("schema init failed: %v", err)
+	}
+
+	email := fmt.Sprintf("apitoken-limit-test-%d@example.com", time.Now().UnixNano())
+	var userID int
+	if err := pool.QueryRow(ctx,
+		"INSERT INTO users (email, password_hash) VALUES ($1, 'x') RETURNING id", email,
+	).Scan(&userID); err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+	defer pool.Exec(context.Background(), "DELETE FROM users WHERE id = $1", userID)
+
+	// assertAgreement is the invariant, checked after every state change: the
+	// list and the cap must describe the same set of live tokens.
+	assertAgreement := func(t *testing.T, wantListed, wantActive int) {
+		t.Helper()
+		tokens, err := ListAPITokens(ctx, pool, userID)
+		if err != nil {
+			t.Fatalf("ListAPITokens failed: %v", err)
+		}
+		if len(tokens) != wantListed {
+			t.Errorf("ListAPITokens returned %d tokens, want %d", len(tokens), wantListed)
+		}
+		counted, err := CountActiveAPITokens(ctx, pool, userID)
+		if err != nil {
+			t.Fatalf("CountActiveAPITokens failed: %v", err)
+		}
+		if listActive := activeInList(tokens, time.Now()); listActive != counted {
+			t.Errorf("the list says %d active tokens, the cap counts %d — they must agree",
+				listActive, counted)
+		}
+		if counted != wantActive {
+			t.Errorf("CountActiveAPITokens = %d, want %d", counted, wantActive)
+		}
+	}
+
+	mint := func(t *testing.T, name string) *model.APIToken {
+		t.Helper()
+		expiry := time.Now().Add(24 * time.Hour)
+		tok, raw, err := CreateAPIToken(ctx, pool, userID, name, []string{ScopeEntriesRead}, &expiry)
+		if err != nil {
+			t.Fatalf("CreateAPIToken(%q) failed: %v", name, err)
+		}
+		if !strings.HasPrefix(raw, TokenPrefix) {
+			t.Fatalf("CreateAPIToken(%q) returned a malformed secret", name)
+		}
+		return tok
+	}
+
+	// Fill the account to exactly the cap.
+	for i := range MaxTokensPerUser {
+		mint(t, fmt.Sprintf("token-%02d", i))
+	}
+	assertAgreement(t, MaxTokensPerUser, MaxTokensPerUser)
+
+	// At the cap, minting must be refused — this is the state the UI's "at the
+	// limit" message is supposed to describe.
+	expiry := time.Now().Add(24 * time.Hour)
+	if _, _, err := CreateAPIToken(ctx, pool, userID, "one too many",
+		[]string{ScopeEntriesRead}, &expiry); !errors.Is(err, ErrTokenLimit) {
+		t.Fatalf("CreateAPIToken at the cap returned %v, want ErrTokenLimit", err)
+	}
+
+	// Now let 8 of them lapse. The list must still show all 20 (the user has to
+	// be able to see and clear the dead ones) while only 12 count.
+	const expiredCount = 8
+	if _, err := pool.Exec(ctx, `
+		UPDATE api_tokens SET expires_at = NOW() - INTERVAL '1 day'
+		WHERE id IN (SELECT id FROM api_tokens WHERE user_id = $1 ORDER BY id LIMIT $2)`,
+		userID, expiredCount); err != nil {
+		t.Fatalf("failed to expire tokens: %v", err)
+	}
+	assertAgreement(t, MaxTokensPerUser, MaxTokensPerUser-expiredCount)
+
+	// The payoff: with expired tokens on the account the server grants another
+	// one. Before the fix the UI refused to even render the button here.
+	fresh := mint(t, "after the lapse")
+	assertAgreement(t, MaxTokensPerUser+1, MaxTokensPerUser-expiredCount+1)
+
+	// Revocation removes a token from the list and the count together — the
+	// one case where the two have always agreed, asserted so it stays that way.
+	ok, err := RevokeAPIToken(ctx, pool, userID, fresh.ID)
+	if err != nil || !ok {
+		t.Fatalf("RevokeAPIToken(%d) = %v, %v; want true, nil", fresh.ID, ok, err)
+	}
+	assertAgreement(t, MaxTokensPerUser, MaxTokensPerUser-expiredCount)
+
+	// An expired token can still be revoked, which is how a user clears the
+	// dead weight the list now shows them.
+	tokens, err := ListAPITokens(ctx, pool, userID)
+	if err != nil {
+		t.Fatalf("ListAPITokens failed: %v", err)
+	}
+	var expiredID int
+	for _, tok := range tokens {
+		if !tok.Active(time.Now()) {
+			expiredID = tok.ID
+			break
+		}
+	}
+	if expiredID == 0 {
+		t.Fatal("expected at least one expired token in the list")
+	}
+	if ok, err := RevokeAPIToken(ctx, pool, userID, expiredID); err != nil || !ok {
+		t.Fatalf("RevokeAPIToken(expired %d) = %v, %v; want true, nil", expiredID, ok, err)
+	}
+	assertAgreement(t, MaxTokensPerUser-1, MaxTokensPerUser-expiredCount)
 }
 
 // TestEveryScopeHasADescription guards the token UI and the generated docs:


### PR DESCRIPTION
Closes #299

## The bug

`ListAPITokens` keeps expired tokens; `CreateAPIToken`'s cap counts only unrevoked **and unexpired** ones. `ApiTokenSettings.tsx` gated on the raw list length (`tokens.length >= max`), so a user holding 20 tokens of which 8 had lapsed was told "you are at the limit of 20" and the **New token button was not rendered at all** — while the server would have minted eight more. The only escape was revoking dead tokens one at a time, and nothing marked which ones were dead. Reachable on the default path: the expiry dropdown defaults to 90 days.

## The fix

One definition, applied in both places: **a token counts against `MaxTokensPerUser` iff it is unrevoked and unexpired.**

- **`internal/service/apitoken.go`** — the cap's SQL becomes the shared `activeTokenCountSQL` behind a new `CountActiveAPITokens(ctx, Querier, userID)`, which `CreateAPIToken` calls inside its existing transaction (no behaviour change there, just one source of truth). `ListAPITokens`' docstring now states that expired tokens are kept **deliberately** — a lapsed token is the likeliest answer to "why did my script start getting 401s", so dropping it from the list would remove the only place a user could discover that, and leave them no way to tidy the row away — and that `len(list)` is consequently *not* the number that counts against the cap.
- **`internal/handler/api_tokens.go`** — each row carries a server-computed `expired` flag (`!t.Active(now)`, one clock reading for the whole list). The limit is enforced against the server's clock, so the UI must not be deriving expiry from the browser's.
- **`client/src/lib/apiTokenLimits.ts`** (new) — `isTokenExpired` / `activeTokenCount` / `isAtTokenLimit`. Prefers the server's flag, falling back to comparing `expires_at` only for a response that predates the field (possible mid-rollout, when a new bundle can hit an old pod).
- **`ApiTokenSettings.tsx`** — `atLimit` is computed from the active subset, and an expired row now reads as dead: greyed name, an "Expired" badge, and its date rendered as `expired <date>` in the destructive colour instead of the same neutral grey a live token's `expires <date>` uses. Matches the existing precedent for expired invites in `Admin.tsx`.
- **i18n** — two new keys (`apiTokens.expiredBadge`, `apiTokens.expiredOn`) extracted into `en` and hand-translated into all seven other locales.

## Tests

- **Go (`TestListAndCapAgreeOnWhatCountsAgainstTheLimit`)** — `TEST_DATABASE_URL`-gated, following the repo's existing skip pattern. Drives a user through 20 live → mint refused with `ErrTokenLimit` → 8 lapsed → mint succeeds again → revoke → revoke an expired one, asserting after every step that the entries in `ListAPITokens` satisfying `model.APIToken.Active` equal `CountActiveAPITokens`. Confirmed it pins the definition: making `ListAPITokens` filter expired tokens fails it (`ListAPITokens returned 12 tokens, want 20`).
- **vitest (`client/src/lib/apiTokenLimits.test.ts`)** — 11 cases over the gating, including the exact regression (12 live + 8 expired, max 20 → not at limit). Confirmed it catches the old behaviour: reverting `isAtTokenLimit` to `tokens.length >= max` fails 2 of them.

## Verification

```
$ export GOFLAGS=-p=2 GOMAXPROCS=2
$ go build ./... && go vet ./... && go test ./...
ok  	schautrack/cmd/server	0.015s
ok  	schautrack/internal/clientip	0.007s
ok  	schautrack/internal/database	0.025s
ok  	schautrack/internal/handler	1.449s
ok  	schautrack/internal/middleware	(cached)
ok  	schautrack/internal/openapi	(cached)
ok  	schautrack/internal/release	(cached)
ok  	schautrack/internal/service	0.241s
ok  	schautrack/internal/session	(cached)
ok  	schautrack/internal/sse	(cached)
```

Against a real Postgres 18 (`docker run ... postgres:18`):

```
$ TEST_DATABASE_URL='postgres://postgres:postgres@localhost:55299/postgres?sslmode=disable' \
    go test ./internal/service/... -run TestListAndCapAgreeOnWhatCountsAgainstTheLimit -v
=== RUN   TestListAndCapAgreeOnWhatCountsAgainstTheLimit
2026/08/08 08:38:46 Schema initialization successful
--- PASS: TestListAndCapAgreeOnWhatCountsAgainstTheLimit (0.42s)
PASS
ok  	schautrack/internal/service	0.425s

$ TEST_DATABASE_URL=... go test ./internal/service/... ./internal/handler/... ./internal/database/...
ok  	schautrack/internal/service	0.475s
ok  	schautrack/internal/handler	1.204s
ok  	schautrack/internal/database	0.525s
```

Client:

```
$ cd client && npm ci && npm run typecheck && npm test && npm run i18n:drift && npm run i18n:check
> tsc -b --force
(no output, exit 0)

 RUN  v4.1.10
 Test Files  10 passed (10)
      Tests  132 passed (132)

> i18next-cli extract --ci
✔ Extraction complete!
✅ No files were updated.

> node scripts/i18n-parity.mjs
✓ de: 819 keys (parity with en: 817)
✓ es: 819 keys (parity with en: 817)
✓ fr: 819 keys (parity with en: 817)
✓ it: 819 keys (parity with en: 817)
✓ nl: 819 keys (parity with en: 817)
✓ pl: 843 keys (parity with en: 817)
✓ pt: 819 keys (parity with en: 817)
i18n parity check passed.
```

`npm run test:e2e` was not run (excluded by the task's resource limits); `e2e/api-tokens.spec.ts` touches none of the changed strings or test ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)