### PR TITLE
fix: return every saved food from GET /api/v1/saved-foods

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1542,22 +1542,9 @@
       "get": {
         "operationId": "listSavedFoods",
         "summary": "List saved foods",
-        "description": "Most-used first, then most-recently-used.",
+        "description": "Most-used first, then most-recently-used, then newest first. Not paginated: an account holds at most 200 saved foods, so this always returns the complete set.",
         "tags": [
           "Saved foods"
-        ],
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Maximum results to return. Values above 200 are clamped to 200.",
-            "schema": {
-              "type": "integer",
-              "default": 50,
-              "minimum": 1,
-              "maximum": 200
-            }
-          }
         ],
         "responses": {
           "200": {
@@ -1566,16 +1553,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SavedFoodList"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "The request is malformed — unparseable JSON, an unknown field, or a bad query parameter.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
@@ -4106,11 +4083,11 @@
       },
       "SavedFoodList": {
         "type": "object",
-        "description": "Saved foods, most-used first.",
+        "description": "Saved foods, most-used first. Never partial.",
         "properties": {
           "data": {
             "type": "array",
-            "description": "The foods.",
+            "description": "Every saved food on the account.",
             "items": {
               "$ref": "#/components/schemas/SavedFood"
             }

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -612,16 +612,11 @@ GET /api/v1/saved-foods
 
 **Scope:** `foods:read`
 
-Most-used first, then most-recently-used.
-
-| Parameter | In | Required | Description |
-| --- | --- | --- | --- |
-| `limit` | query |  | Maximum results to return. Values above 200 are clamped to 200. |
+Most-used first, then most-recently-used, then newest first. Not paginated: an account holds at most 200 saved foods, so this always returns the complete set.
 
 | Status | Response |
 | --- | --- |
 | `200` | [`SavedFoodList`](#savedfoodlist) — The saved foods. |
-| `400` | [`Problem`](#problem) — The request is malformed — unparseable JSON, an unknown field, or a bad query parameter. |
 | `401` | [`Problem`](#problem) — No token, or the token is unknown, revoked, or expired. |
 | `403` | [`Problem`](#problem) — The token is valid but lacks the scope this endpoint requires. The `required_scope` field names it. |
 | `429` | [`Problem`](#problem) — Too many requests. The `Retry-After` header gives the number of seconds until the window reopens. |
@@ -1079,11 +1074,11 @@ A new saved food.
 
 ### SavedFoodList
 
-Saved foods, most-used first.
+Saved foods, most-used first. Never partial.
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `data` | array of [`SavedFood`](#savedfood) | yes | The foods. |
+| `data` | array of [`SavedFood`](#savedfood) | yes | Every saved food on the account. |
 
 ### SavedFoodPatch
 

--- a/internal/handler/saved_foods.go
+++ b/internal/handler/saved_foods.go
@@ -52,7 +52,8 @@ func toSavedFoodView(id int, name string, emoji *string, amount, protein, carbs,
 }
 
 // List handles GET /api/saved-foods. Returns the caller's own foods only,
-// ranked by use_count then last_used_at.
+// ranked by use_count then last_used_at. The ordering is savedFoodRank,
+// shared with ListSavedFoodsV1 so the app and the API cannot disagree.
 func (h *SavedFoodsHandler) List(w http.ResponseWriter, r *http.Request) {
 	user := middleware.GetCurrentUser(r)
 
@@ -61,7 +62,7 @@ func (h *SavedFoodsHandler) List(w http.ResponseWriter, r *http.Request) {
 		       use_count, last_used_at
 		FROM saved_foods
 		WHERE user_id = $1
-		ORDER BY use_count DESC, last_used_at DESC NULLS LAST, id DESC`,
+		ORDER BY `+savedFoodRank,
 		user.ID)
 	if err != nil {
 		slog.Error("saved_foods list", "error", err)

--- a/internal/handler/v1_foods.go
+++ b/internal/handler/v1_foods.go
@@ -30,6 +30,17 @@ type v1SavedFood struct {
 const savedFoodSelect = `id, name, emoji, amount, protein_g, carbs_g, fat_g, fiber_g, sugar_g,
 	use_count, last_used_at, created_at, updated_at`
 
+// savedFoodRank is the ranking shared by both saved-food list endpoints:
+// SavedFoodsHandler.List (the app) and ListSavedFoodsV1 (the API).
+//
+// It is one constant because the two must not drift. They previously
+// disagreed on the final tiebreaker — the app used `id DESC`, v1 used `id`
+// ascending — so two foods with the same use_count and last_used_at (both
+// never used, which is every food right after you create a few) came back in
+// opposite orders from the API and the app, despite v1 documenting itself as
+// "ranked the way the app ranks them".
+const savedFoodRank = `use_count DESC, last_used_at DESC NULLS LAST, id DESC`
+
 func scanSavedFood(row pgx.Row) (*v1SavedFood, error) {
 	var f v1SavedFood
 	if err := row.Scan(&f.ID, &f.Name, &f.Emoji, &f.Calories,
@@ -41,17 +52,32 @@ func scanSavedFood(row pgx.Row) (*v1SavedFood, error) {
 }
 
 // ListSavedFoodsV1 handles GET /api/v1/saved-foods, ranked the way the app
-// ranks them: most-used first, then most-recently-used.
+// ranks them: most-used first, then most-recently-used, then newest first.
+//
+// Deliberately unpaginated — it returns the account's complete set, always.
+// Saved foods are hard-bounded: every insert path refuses at MaxSavedFoods
+// (200), and 200 is also the largest page queryLimit would ever hand out, so a
+// "page" could never have held a row the whole set does not. All the old
+// `LIMIT $2` achieved was dropping everything past the 50-row default while
+// v1List's has_more and next_cursor — both omitempty — stayed absent, leaving
+// a caller with 60 foods no way to tell their 50-item response was partial.
+// A syncing client reasonably concluded the missing 10 had been deleted.
+//
+// Reporting has_more instead would need a cursor to be actionable, and the
+// (date, id) cursor here cannot encode a (use_count, last_used_at, id)
+// position — machinery a 200-row ceiling does not justify. The other bounded
+// collections, /todos and /links, already return everything with no
+// pagination fields; this one now matches them, and matches the SavedFoodList
+// schema, which never declared has_more or next_cursor in the first place.
+//
+// `limit` is consequently no longer read. Ignoring it can only ever return
+// more than a caller asked for, never fewer rows than exist — the safe
+// direction. It is dropped from this operation in the OpenAPI document.
 func (h *V1Handler) ListSavedFoodsV1(w http.ResponseWriter, r *http.Request) {
-	limit, prob := queryLimit(r)
-	if prob != nil {
-		apierr.Write(w, r, prob)
-		return
-	}
 	rows, err := h.Pool.Query(r.Context(),
 		"SELECT "+savedFoodSelect+` FROM saved_foods WHERE user_id = $1
-		 ORDER BY use_count DESC, last_used_at DESC NULLS LAST, id LIMIT $2`,
-		v1User(r).ID, limit)
+		 ORDER BY `+savedFoodRank,
+		v1User(r).ID)
 	if err != nil {
 		apierr.Write(w, r, dbFail("list saved foods", err))
 		return

--- a/internal/handler/v1_foods_list_test.go
+++ b/internal/handler/v1_foods_list_test.go
@@ -1,0 +1,231 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"schautrack/internal/database"
+	"schautrack/internal/middleware"
+	"schautrack/internal/model"
+)
+
+// savedFoodsTestPool opens the integration pool and applies migrations, or
+// skips. Matches internal/database's convention: no TEST_DATABASE_URL, no run.
+func savedFoodsTestPool(t *testing.T) (context.Context, *pgxpool.Pool) {
+	t.Helper()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	t.Cleanup(cancel)
+
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	if err := database.InitSchemaWithRetry(ctx, pool, 1); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+	return ctx, pool
+}
+
+// seedSavedFoodsUser creates a throwaway account and returns its id. The
+// account (and its foods, via ON DELETE CASCADE) is removed afterwards.
+func seedSavedFoodsUser(t *testing.T, ctx context.Context, pool *pgxpool.Pool, email string) int {
+	t.Helper()
+	cleanup := func() { pool.Exec(ctx, `DELETE FROM users WHERE email = $1`, email) }
+	cleanup()
+	t.Cleanup(cleanup)
+
+	var id int
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email, password_hash, email_verified)
+		 VALUES ($1, 'x', true) RETURNING id`, email).Scan(&id); err != nil {
+		t.Fatalf("seeding the user failed: %v", err)
+	}
+	return id
+}
+
+// listSavedFoodsV1 calls the handler as the given user and returns the decoded
+// envelope plus the raw body, so a test can assert on absent JSON keys.
+func listSavedFoodsV1(t *testing.T, ctx context.Context, pool *pgxpool.Pool, userID int, query string) (v1List[v1SavedFood], map[string]json.RawMessage) {
+	t.Helper()
+	h := &V1Handler{Pool: pool}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/saved-foods"+query, nil)
+	req = req.WithContext(middleware.WithTestUser(ctx, &model.User{ID: userID}))
+	rec := httptest.NewRecorder()
+	h.ListSavedFoodsV1(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/saved-foods%s: status = %d, want 200 (body %s)", query, rec.Code, rec.Body.String())
+	}
+	var page v1List[v1SavedFood]
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decoding the list failed: %v (body %s)", err, rec.Body.String())
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decoding the raw envelope failed: %v", err)
+	}
+	return page, raw
+}
+
+// TestListSavedFoodsV1ReturnsEveryFood is the regression test for #298.
+//
+// The endpoint used to apply `LIMIT $2` with a 50-row default while
+// has_more/next_cursor stayed omitempty-absent, so an account with more than
+// 50 saved foods received a silently truncated list that was indistinguishable
+// from a complete one. A syncing client read the shortfall as deletions.
+//
+// 60 foods is deliberately just over the old 50-row default and well under the
+// 200-food account cap: the whole set must come back, and the response must
+// still carry no pagination fields, because there is nothing left to paginate.
+func TestListSavedFoodsV1ReturnsEveryFood(t *testing.T) {
+	ctx, pool := savedFoodsTestPool(t)
+	userID := seedSavedFoodsUser(t, ctx, pool, "v1-saved-foods-page@handler.test")
+
+	const want = 60 // > defaultPageSize (50), < MaxSavedFoods (200)
+	for i := range want {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO saved_foods (user_id, name, amount) VALUES ($1, $2, $3)`,
+			userID, fmt.Sprintf("food-%03d", i), 100+i); err != nil {
+			t.Fatalf("seeding food %d failed: %v", i, err)
+		}
+	}
+
+	page, raw := listSavedFoodsV1(t, ctx, pool, userID, "")
+	if got := len(page.Data); got != want {
+		t.Errorf("returned %d of %d saved foods; a partial list is indistinguishable from a complete one", got, want)
+	}
+	if _, ok := raw["has_more"]; ok {
+		t.Errorf("response carries has_more = %s; an unpaginated complete list must not claim pagination", raw["has_more"])
+	}
+	if _, ok := raw["next_cursor"]; ok {
+		t.Errorf("response carries next_cursor = %s; there is no next page to point at", raw["next_cursor"])
+	}
+
+	// `limit` must no longer be able to drop rows. Ignoring it can only ever
+	// return more than asked for; it can never lose data.
+	page, _ = listSavedFoodsV1(t, ctx, pool, userID, "?limit=10")
+	if got := len(page.Data); got != want {
+		t.Errorf("?limit=10 returned %d of %d saved foods; limit must not silently truncate", got, want)
+	}
+
+	// A limit that no longer parses must not start failing the request either,
+	// now that the parameter is not read at all.
+	page, _ = listSavedFoodsV1(t, ctx, pool, userID, "?limit=not-a-number")
+	if got := len(page.Data); got != want {
+		t.Errorf("?limit=not-a-number returned %d of %d saved foods", got, want)
+	}
+}
+
+// TestListSavedFoodsV1TieBreakMatchesLegacy pins the two saved-food list
+// endpoints to one order.
+//
+// v1 ended its ORDER BY with `id` ascending while the app's /api/saved-foods
+// used `id DESC`, so foods tied on use_count and last_used_at — every food
+// that has never been tracked, i.e. all of them right after you create a
+// few — came back reversed between the two surfaces, contradicting v1's
+// "ranked the way the app ranks them".
+func TestListSavedFoodsV1TieBreakMatchesLegacy(t *testing.T) {
+	ctx, pool := savedFoodsTestPool(t)
+	userID := seedSavedFoodsUser(t, ctx, pool, "v1-saved-foods-order@handler.test")
+
+	// A mix: several never-used foods (the tie that used to reverse), plus
+	// rows that exercise the use_count and last_used_at keys ahead of it, and
+	// a same-use_count pair split by last_used_at.
+	now := time.Now().UTC()
+	seed := []struct {
+		name     string
+		useCount int
+		lastUsed *time.Time
+	}{
+		{"never-used-a", 0, nil},
+		{"never-used-b", 0, nil},
+		{"never-used-c", 0, nil},
+		{"used-once", 1, ptrTime(now.Add(-72 * time.Hour))},
+		{"used-twice-older", 2, ptrTime(now.Add(-48 * time.Hour))},
+		{"used-twice-newer", 2, ptrTime(now.Add(-1 * time.Hour))},
+		{"used-most", 9, ptrTime(now.Add(-240 * time.Hour))},
+	}
+	for _, s := range seed {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO saved_foods (user_id, name, use_count, last_used_at) VALUES ($1, $2, $3, $4)`,
+			userID, s.name, s.useCount, s.lastUsed); err != nil {
+			t.Fatalf("seeding %q failed: %v", s.name, err)
+		}
+	}
+
+	page, _ := listSavedFoodsV1(t, ctx, pool, userID, "")
+	v1IDs := make([]int, 0, len(page.Data))
+	v1Names := make([]string, 0, len(page.Data))
+	for _, f := range page.Data {
+		v1IDs = append(v1IDs, f.ID)
+		v1Names = append(v1Names, f.Name)
+	}
+
+	legacy := &SavedFoodsHandler{Pool: pool}
+	req := httptest.NewRequest(http.MethodGet, "/api/saved-foods", nil)
+	req = req.WithContext(middleware.WithTestUser(ctx, &model.User{ID: userID}))
+	rec := httptest.NewRecorder()
+	legacy.List(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/saved-foods: status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	var legacyBody struct {
+		SavedFoods []struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		} `json:"savedFoods"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &legacyBody); err != nil {
+		t.Fatalf("decoding the legacy list failed: %v", err)
+	}
+	legacyIDs := make([]int, 0, len(legacyBody.SavedFoods))
+	legacyNames := make([]string, 0, len(legacyBody.SavedFoods))
+	for _, f := range legacyBody.SavedFoods {
+		legacyIDs = append(legacyIDs, f.ID)
+		legacyNames = append(legacyNames, f.Name)
+	}
+
+	if len(v1IDs) != len(seed) || len(legacyIDs) != len(seed) {
+		t.Fatalf("row counts differ: v1 %d, legacy %d, seeded %d", len(v1IDs), len(legacyIDs), len(seed))
+	}
+	for i := range v1IDs {
+		if v1IDs[i] != legacyIDs[i] {
+			t.Fatalf("ordering diverges at position %d:\n  v1     = %v\n  legacy = %v",
+				i, v1Names, legacyNames)
+		}
+	}
+
+	// Pin the ranking itself, so "they agree" cannot be satisfied by both
+	// endpoints regressing together.
+	wantOrder := []string{
+		"used-most",        // highest use_count
+		"used-twice-newer", // use_count 2, more recent
+		"used-twice-older", // use_count 2, older
+		"used-once",        // use_count 1
+		"never-used-c",     // untouched, newest id first
+		"never-used-b",     //
+		"never-used-a",     //
+	}
+	for i, want := range wantOrder {
+		if v1Names[i] != want {
+			t.Fatalf("rank at position %d = %q, want %q (full order %v)", i, v1Names[i], want, v1Names)
+		}
+	}
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }

--- a/internal/openapi/spec.go
+++ b/internal/openapi/spec.go
@@ -377,8 +377,8 @@ func schemas() map[string]*Schema {
 				"emoji":    nullStr("`null` clears the emoji."),
 				"calories": withRange(nullInt("Energy per unit."), -9999, 9999),
 			}, macroInputProps())),
-		"SavedFoodList": object("Saved foods, most-used first.", map[string]*Schema{
-			"data": array(ref("SavedFood"), "The foods."),
+		"SavedFoodList": object("Saved foods, most-used first. Never partial.", map[string]*Schema{
+			"data": array(ref("SavedFood"), "Every saved food on the account."),
 		}, "data"),
 		"TrackInput": object("How to log this food.", map[string]*Schema{
 			"date":     dateStr("Defaults to today in the account's time zone."),
@@ -789,13 +789,15 @@ func paths() map[string]*PathItem {
 		"/saved-foods": {
 			Get: &Operation{
 				OperationID: "listSavedFoods", Summary: "List saved foods",
-				Description: "Most-used first, then most-recently-used.",
-				Tags:        []string{"Saved foods"}, Scope: service.ScopeFoodsRead,
-				Security:   []SecurityRequirement{{"bearerAuth": {service.ScopeFoodsRead}}},
-				Parameters: []Parameter{limitParam},
+				Description: "Most-used first, then most-recently-used, then newest first. " +
+					"Not paginated: an account holds at most 200 saved foods, so this always " +
+					"returns the complete set.",
+				Tags: []string{"Saved foods"}, Scope: service.ScopeFoodsRead,
+				Security: []SecurityRequirement{{"bearerAuth": {service.ScopeFoodsRead}}},
+				// No 400: the operation takes no input to reject, matching the
+				// other parameterless collections (listTodos, listLinks).
 				Responses: merge(map[string]*Response{
 					"200": ok200("The saved foods.", ref("SavedFoodList")),
-					"400": respRef("BadRequest"),
 				}, errs(nil)),
 			},
 			Post: &Operation{


### PR DESCRIPTION
Closes #298

## The bug

`ListSavedFoodsV1` applied `LIMIT $2` (default 50) but never set `has_more` or `next_cursor` — both are `omitempty` on `v1List`. `MaxSavedFoods` is 200, so an account with 60 saved foods got:

```json
{"data": [ ...50 items... ]}
```

byte-for-byte indistinguishable from a complete response. A syncing client reads the shortfall as 10 deletions.

## Which fix, and why

**Dropped the `LIMIT` entirely** rather than fetching `limit+1` and reporting `has_more`.

- Saved foods are **hard-bounded**. All three `INSERT INTO saved_foods` sites (`v1_foods.go:157`, `saved_foods.go:196`, `saved_foods.go:541`) refuse at `MaxSavedFoods` = 200.
- 200 is also `maxPageSize` — the largest page `queryLimit` would ever hand out. A page could therefore never have held a row the whole set does not. The pagination was pure ceremony that only ever lost rows.
- **`has_more` would not have been actionable.** The `cursor` type is `(Date string, ID int)`; it cannot encode a `(use_count, last_used_at, id)` position. Setting `has_more: true` with no `next_cursor` signals truncation while offering no remedy, and contradicts the spec's documented loop ("pass `next_cursor` back as `cursor`; stop when `has_more` is false"). Inventing a second cursor encoding for a 200-row ceiling is machinery the problem does not justify.
- It matches the other bounded collections: `/todos` and `/links` already return everything with no pagination fields.
- The `SavedFoodList` schema **never declared** `has_more` or `next_cursor`. This makes the code match the contract instead of loosening the contract.

`limit` is consequently no longer read, so it can no longer drop rows. Ignoring it can only ever return *more* than a caller asked for, never fewer rows than exist — the safe direction. It is removed from the operation in the OpenAPI document, along with the `400` that existed solely to reject a malformed `limit` (`listTodos` and `listLinks`, the other parameterless collections, declare no `400` either).

Behaviour change to note for reviewers: `?limit=10` now returns the full set instead of 10, and `?limit=abc` returns `200` instead of `400`. Nothing in the repo passes `limit` to this endpoint — the SPA uses the legacy `/api/saved-foods`.

## Ordering discrepancy

v1 ended its `ORDER BY` with `id` **ascending** while legacy `internal/handler/saved_foods.go` used `id DESC`. Foods tied on `use_count` and `last_used_at` — every never-tracked food, i.e. all of them right after you create a few — came back reversed between the API and the app, contradicting the "ranked the way the app ranks them" comment.

Both endpoints now share a single `savedFoodRank` constant, so they cannot drift again. v1 moved to the app's `id DESC`, since the app's order is the one users already see.

## `/api/v1/todos`

Left alone, as the issue suggests. It has no `LIMIT` and `service.MaxTodos` is 20, so it always returns everything.

## Tests

New `internal/handler/v1_foods_list_test.go`, integration tests gated on `TEST_DATABASE_URL` (the repo's existing skip pattern, per `onboarding_test.go`):

- `TestListSavedFoodsV1ReturnsEveryFood` — seeds 60 foods (over the old 50-row default, under the 200 cap), asserts all 60 return and that `has_more`/`next_cursor` are absent from the raw JSON, then re-checks with `?limit=10` and `?limit=not-a-number`.
- `TestListSavedFoodsV1TieBreakMatchesLegacy` — calls both `ListSavedFoodsV1` and `SavedFoodsHandler.List` over the same seed and asserts identical id order, plus pins the ranking itself so "they agree" cannot be satisfied by both regressing together.

**Both tests were confirmed to fail against the unfixed code**, reproducing the reported symptoms exactly:

```
--- FAIL: TestListSavedFoodsV1ReturnsEveryFood (0.22s)
    v1_foods_list_test.go:110: returned 50 of 60 saved foods; a partial list is indistinguishable from a complete one
    v1_foods_list_test.go:123: ?limit=10 returned 10 of 60 saved foods; limit must not silently truncate
    v1_foods_list_test.go:128: GET /api/v1/saved-foods?limit=not-a-number: status = 400, want 200
--- FAIL: TestListSavedFoodsV1TieBreakMatchesLegacy (0.16s)
    v1_foods_list_test.go:208: ordering diverges at position 4:
          v1     = [used-most used-twice-newer used-twice-older used-once never-used-a never-used-b never-used-c]
          legacy = [used-most used-twice-newer used-twice-older used-once never-used-c never-used-b never-used-a]
```

## Verification

`go build ./...`, `go vet ./...` and `go run ./cmd/apidocs -check` all clean; `api/openapi.json` and `docs/api-v1.md` regenerated and committed.

```
$ go test ./...
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	(cached)
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	(cached)
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	(cached)
ok  	schautrack/internal/handler	1.101s
ok  	schautrack/internal/middleware	(cached)
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	0.064s
ok  	schautrack/internal/release	(cached)
ok  	schautrack/internal/service	(cached)
ok  	schautrack/internal/session	(cached)
ok  	schautrack/internal/sse	(cached)
```

Against a live Postgres 18 (`postgres:18` container), so the new gated tests actually ran:

```
$ TEST_DATABASE_URL='postgres://...' go test ./internal/handler/... -run 'TestListSavedFoodsV1' -v
=== RUN   TestListSavedFoodsV1ReturnsEveryFood
--- PASS: TestListSavedFoodsV1ReturnsEveryFood (0.20s)
=== RUN   TestListSavedFoodsV1TieBreakMatchesLegacy
--- PASS: TestListSavedFoodsV1TieBreakMatchesLegacy (0.07s)
PASS
ok  	schautrack/internal/handler	0.277s
```

Full suite with the database available, confirming nothing else regressed:

```
$ TEST_DATABASE_URL='postgres://...' go test ./...
ok  	schautrack/internal/database	0.420s
ok  	schautrack/internal/handler	1.709s
ok  	schautrack/internal/service	0.429s
(all other packages ok / no test files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)