### PR TITLE
fix: validate email and password at every credential write path

### DIFF
--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -227,13 +227,21 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *AuthHandler) registerCredentials(w http.ResponseWriter, r *http.Request, sess *session.Session, email, password, timezone, inviteCode string, legalAccepted, healthConsent bool) {
-	emailClean := strings.ToLower(strings.TrimSpace(email))
-	if emailClean == "" || password == "" {
+	if strings.TrimSpace(email) == "" || password == "" {
 		ErrorJSON(w, http.StatusBadRequest, "Email and password are required.")
 		return
 	}
-	if len(password) < 10 {
-		ErrorJSON(w, http.StatusBadRequest, "Password must be at least 10 characters.")
+	// Both gates run before anything touches the database or argon2id: a
+	// syntactically impossible address must never reach users.email (the
+	// verification mail would be unsendable and the account unrecoverable),
+	// and an oversized password must never reach hashPassword.
+	emailClean, err := validateEmail(email)
+	if err != nil {
+		ErrorJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := validatePassword(password); err != nil {
+		ErrorJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -288,7 +296,7 @@ func (h *AuthHandler) registerCredentials(w http.ResponseWriter, r *http.Request
 	}
 
 	var exists bool
-	err := h.Pool.QueryRow(r.Context(), "SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)", emailClean).Scan(&exists)
+	err = h.Pool.QueryRow(r.Context(), "SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)", emailClean).Scan(&exists)
 	if err != nil {
 		ErrorJSON(w, http.StatusInternalServerError, "Could not register.")
 		return

--- a/internal/handler/auth_email.go
+++ b/internal/handler/auth_email.go
@@ -186,10 +186,14 @@ func (h *AuthHandler) EmailChangeRequest(w http.ResponseWriter, r *http.Request)
 	}
 
 	user := middleware.GetCurrentUser(r)
-	newEmail := strings.ToLower(strings.TrimSpace(body.NewEmail))
 
-	if newEmail == "" || !strings.Contains(newEmail, "@") {
-		ErrorJSON(w, http.StatusBadRequest, "Please enter a valid email address.")
+	// Same gate as registration and OIDC auto-provisioning. Without it the
+	// registration check is trivially bypassed: sign up with a good address,
+	// then change it to anything. The old check here ("contains an @") let
+	// "<script>@x" and a 5 MB string straight through.
+	newEmail, err := validateEmail(body.NewEmail)
+	if err != nil {
+		ErrorJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if newEmail == strings.ToLower(user.Email) {

--- a/internal/handler/auth_password.go
+++ b/internal/handler/auth_password.go
@@ -164,8 +164,8 @@ func (h *AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 		ErrorJSON(w, http.StatusBadRequest, "Passwords do not match.")
 		return
 	}
-	if len(body.Password) < 10 {
-		ErrorJSON(w, http.StatusBadRequest, "Password must be at least 10 characters.")
+	if err := validatePassword(body.Password); err != nil {
+		ErrorJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/internal/handler/oidc.go
+++ b/internal/handler/oidc.go
@@ -304,6 +304,25 @@ func (h *OIDCHandler) handleLogin(w http.ResponseWriter, r *http.Request, sess *
 		return
 	}
 
+	// Auto-provisioning is a user-creating write, so it goes through the same
+	// gate as credential registration: an IdP that asserts a malformed or
+	// absurdly long address must not be able to plant it in users.email.
+	//
+	// Note this is deliberately below the auto-link lookup above. That lookup
+	// is a read against an existing account, and an account created before
+	// this validator existed must keep being able to sign in.
+	emailClean, verr := validateEmail(email)
+	if verr != nil {
+		slog.Warn("OIDC auto-create rejected: invalid email from IdP",
+			"provider", provider, "subject", subject, "error", verr)
+		// Reuse the existing invalid_claims code rather than minting a new
+		// one: it already means "the IdP returned invalid information", and
+		// it is already translated in every locale.
+		http.Redirect(w, r, "/login?error=invalid_claims", http.StatusFound)
+		return
+	}
+	email = emailClean
+
 	tx, err := h.Pool.Begin(ctx)
 	if err != nil {
 		http.Redirect(w, r, "/login?error=internal", http.StatusFound)

--- a/internal/handler/registration_test.go
+++ b/internal/handler/registration_test.go
@@ -2,12 +2,19 @@ package handler
 
 import (
 	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"schautrack/internal/config"
 	"schautrack/internal/database"
+	"schautrack/internal/middleware"
+	"schautrack/internal/model"
 )
 
 func TestRegistrationMode(t *testing.T) {
@@ -151,5 +158,489 @@ func TestRegisterCredentials_LegalDisabled_NoConsentNeeded(t *testing.T) {
 	h.Register(w, r)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want %d (invite gate, no consent gate)", w.Code, http.StatusForbidden)
+	}
+}
+
+// =============================================================================
+// Credential validation (issue #306)
+// =============================================================================
+
+// Building blocks for addresses at exact byte lengths. The RFC 5321 maximum
+// is 320 bytes: a 64-byte local part, "@", and a 255-byte domain (four
+// 63-byte labels joined by three dots).
+const (
+	emailLocal64   = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"          // 64
+	emailLabel63   = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"           // 63
+	emailDomain255 = emailLabel63 + "." + emailLabel63 + "." + emailLabel63 + "." + emailLabel63 // 255
+)
+
+func TestValidateEmail(t *testing.T) {
+	emailAddr320 := emailLocal64 + "@" + emailDomain255                     // exactly 320 bytes
+	emailAddr1000 := emailLocal64 + "@" + strings.Repeat("b", 931) + ".com" // 1000 bytes
+	if len(emailAddr320) != MaxEmailBytes {
+		t.Fatalf("test fixture emailAddr320 is %d bytes, want %d", len(emailAddr320), MaxEmailBytes)
+	}
+	if len(emailAddr1000) != 1000 {
+		t.Fatalf("test fixture emailAddr1000 is %d bytes, want 1000", len(emailAddr1000))
+	}
+
+	tests := []struct {
+		name string
+		in   string
+		want string // "" means: expect rejection
+		why  string
+	}{
+		// The whole point of the issue: before the fix every one of these
+		// registered successfully and produced an account whose verification
+		// mail could never be sent.
+		{"empty", "", "", "no address at all"},
+		{"single letter", "a", "", "no @, no domain"},
+		{"local part only", "a@", "", "no domain"},
+		{"domain only", "@b.com", "", "no local part"},
+		{"space in local part", "a b@c.com", "", "unquoted space is not an addr-spec"},
+		{"prose", "not an email", "", "the literal example from the issue"},
+		{"markup", "<script>", "", "the literal example from the issue"},
+		{"two addresses", "a@b.com, c@d.com", "", "a single mailbox is required"},
+
+		// Accepted, with the stored (canonical) form.
+		{"plain address", "a@b.com", "a@b.com", ""},
+		{"dotless domain accepted", "a@b", "a@b",
+			"RFC-valid and deliverable on intranet/self-hosted deployments; validEmail accepts it too"},
+		{"uppercase is lowercased", "A@B.COM", "a@b.com",
+			"users.email is UNIQUE and compared with =, so the case must be canonical"},
+		{"surrounding whitespace is trimmed", "  a@b.com\t", "a@b.com", ""},
+		{"mixed case with whitespace", "  Foo.Bar@Example.COM  ", "foo.bar@example.com", ""},
+		{"320 bytes is the RFC 5321 maximum", emailAddr320, strings.ToLower(emailAddr320), ""},
+
+		// Length.
+		{"321 bytes is one over the cap", emailAddr320 + "x", "", "cap is inclusive at 320"},
+		{"1000 bytes", emailAddr1000, "", "oversized key in the users.email UNIQUE btree index"},
+
+		// Header injection. net/mail rejects this on its own today, but the
+		// explicit control-character check means that does not have to stay
+		// true for us to be safe.
+		{"embedded newline", "a@b.com\nBcc: x@y.com", "", "SMTP header injection shape"},
+		{"embedded CR", "a@b.com\rBcc: x@y.com", "", "SMTP header injection shape"},
+		{"embedded CRLF", "a@b.com\r\nBcc: x@y.com", "", "SMTP header injection shape"},
+		{"embedded NUL", "a@b.com\x00", "", "control character"},
+
+		// Decision pinned: the display-name form is REJECTED. net/mail
+		// accepts it, but "Foo <a@b.com>" is not a bare mailbox — storing it
+		// would let two rows denote the same mailbox while still satisfying
+		// the UNIQUE constraint, and it is the shape an injection attempt
+		// takes. Same reasoning for a quoted local part, which net/mail
+		// un-quotes into an address containing a literal space.
+		{"display-name form rejected", "Foo <a@b.com>", "",
+			"parses, but is not a bare address"},
+		{"bare angle-addr rejected", "<a@b.com>", "",
+			"parses, but is not a bare address"},
+		{"quoted local part rejected", `"a b"@c.com`, "",
+			"net/mail un-quotes this to 'a b@c.com' — a stored address with a space in it"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateEmail(tt.in)
+			if tt.want == "" {
+				if err == nil {
+					t.Fatalf("validateEmail(%q) = %q, want a rejection (%s)", tt.in, got, tt.why)
+				}
+				if got != "" {
+					t.Errorf("validateEmail(%q) returned %q alongside its error; a rejected address must yield no value", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateEmail(%q) = error %v, want %q (%s)", tt.in, err, tt.want, tt.why)
+			}
+			if got != tt.want {
+				t.Errorf("validateEmail(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			// The canonical form must be a fixed point: feeding a stored
+			// address back in has to yield the identical string, or the
+			// email-change flow could produce a duplicate of an existing row.
+			again, err := validateEmail(got)
+			if err != nil || again != got {
+				t.Errorf("validateEmail(%q) = (%q, %v), want (%q, nil) — normalization is not idempotent", got, again, err, got)
+			}
+		})
+	}
+}
+
+func TestValidatePassword(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+		why     string
+	}{
+		{"empty", "", true, ""},
+		{"nine ascii characters", "123456789", true, "one under the minimum"},
+		{"ten ascii characters", "1234567890", false, "exactly the minimum"},
+		{"eleven ascii characters", "12345678901", false, ""},
+
+		// Decision pinned: the minimum counts RUNES, not bytes. The message
+		// says "10 characters", so it must mean characters. Under the old
+		// len() check this 4-character passphrase (12 bytes) was accepted
+		// while a 9-character ASCII one was not.
+		{"four-rune CJK passphrase rejected", "電気自動", true,
+			"the case from the issue: 4 runes / 12 bytes — passed the old byte check"},
+		{"five-rune CJK passphrase rejected", "電気自動車", true, "5 runes / 15 bytes"},
+		{"ten-rune CJK passphrase accepted", "電気自動車電気自動車", false,
+			"10 runes / 30 bytes"},
+		{"nine-rune CJK passphrase rejected", "電気自動車電気自動", true, "9 runes"},
+		{"ten combining-heavy runes accepted", "ééééééééét", false, "10 runes, 19 bytes"},
+
+		// Whitespace-only is rejected rather than trimmed: trimming would
+		// silently change the secret the user typed.
+		{"ten spaces", "          ", true, "whitespace-only"},
+		{"mixed whitespace", " \t\n\r \t\n\r \t", true, "whitespace-only"},
+		{"padded real password accepted", "  hunter2hunter2  ", false,
+			"interior content, so it is a real password; must NOT be trimmed away"},
+
+		// Upper bound: argon2id has no intrinsic length limit, so an
+		// unbounded password lets a client make the server Blake2b-hash
+		// megabytes on every write.
+		{"exactly the byte cap", strings.Repeat("x", MaxPasswordBytes), false, ""},
+		{"one byte over the cap", strings.Repeat("x", MaxPasswordBytes+1), true, ""},
+		{"five megabytes", strings.Repeat("x", 5<<20), true, "the CPU-burn vector from the issue"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePassword(tt.in)
+			if tt.wantErr && err == nil {
+				t.Fatalf("validatePassword(len=%d) = nil, want an error (%s)", len(tt.in), tt.why)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validatePassword(len=%d) = %v, want nil (%s)", len(tt.in), err, tt.why)
+			}
+		})
+	}
+}
+
+// The password minimum must stay expressible to users as "10 characters" —
+// the client placeholder says so and the server message says so.
+func TestValidatePasswordMessageMatchesPolicy(t *testing.T) {
+	err := validatePassword("123456789")
+	if err == nil {
+		t.Fatal("a 9-character password must be rejected")
+	}
+	if !strings.Contains(err.Error(), "10 characters") {
+		t.Errorf("error = %q, want it to state the 10-character minimum", err)
+	}
+}
+
+// =============================================================================
+// The validator at each entry point
+// =============================================================================
+
+// Every one of these registers successfully before the fix. A nil Pool proves
+// the rejection happens before any database access — and, for the oversized
+// password, before argon2id is handed megabytes.
+func TestRegisterCredentials_RejectsInvalidEmail(t *testing.T) {
+	bad := []string{
+		"a",
+		"not an email",
+		"<script>",
+		"a@",
+		"@b.com",
+		"a b@c.com",
+		"Foo <a@b.com>",
+		"a@b.com\nBcc: x@y.com", // real newline; json.Marshal encodes it, the server decodes it back
+		emailLocal64 + "@" + strings.Repeat("b", 931) + ".com",
+		strings.Repeat("x", 5<<20) + "@example.com",
+	}
+	for _, email := range bad {
+		h := &AuthHandler{
+			Pool:     nil, // must not be touched
+			Cfg:      &config.Config{EnableRegistration: "open"},
+			Settings: database.NewSettingsCache(nil),
+		}
+		body, _ := json.Marshal(map[string]any{
+			"step": "credentials", "email": email,
+			"password": "longenoughpassword", "timezone": "UTC",
+		})
+		r := newRequestWithSession("POST", "/api/auth/register", string(body))
+		w := httptest.NewRecorder()
+		h.Register(w, r)
+
+		label := email
+		if len(label) > 40 {
+			label = label[:40] + "…"
+		}
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("email %q: status = %d, want %d", label, w.Code, http.StatusBadRequest)
+		}
+	}
+}
+
+func TestRegisterCredentials_RejectsOversizedPassword(t *testing.T) {
+	h := &AuthHandler{
+		Pool:     nil, // argon2id must never see this
+		Cfg:      &config.Config{EnableRegistration: "open"},
+		Settings: database.NewSettingsCache(nil),
+	}
+	body, _ := json.Marshal(map[string]any{
+		"step": "credentials", "email": "a@b.com",
+		"password": strings.Repeat("x", 5<<20), "timezone": "UTC",
+	})
+	r := newRequestWithSession("POST", "/api/auth/register", string(body))
+	w := httptest.NewRecorder()
+	h.Register(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRegisterCredentials_RejectsWhitespaceOnlyPassword(t *testing.T) {
+	h := &AuthHandler{
+		Pool:     nil,
+		Cfg:      &config.Config{EnableRegistration: "open"},
+		Settings: database.NewSettingsCache(nil),
+	}
+	body := `{"step":"credentials","email":"a@b.com","password":"          ","timezone":"UTC"}`
+	r := newRequestWithSession("POST", "/api/auth/register", body)
+	w := httptest.NewRecorder()
+	h.Register(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+// A valid address must still clear the email gate and reach the next one
+// (invite mode → 403). Without this, "reject everything" would pass the tests
+// above.
+func TestRegisterCredentials_ValidEmailReachesNextGate(t *testing.T) {
+	for _, email := range []string{"a@b.com", "  A.User+tag@Example.COM ", "a@b"} {
+		h := &AuthHandler{
+			Pool:     nil,
+			Cfg:      &config.Config{EnableRegistration: "invite"},
+			Settings: database.NewSettingsCache(nil),
+		}
+		body, _ := json.Marshal(map[string]any{
+			"step": "credentials", "email": email,
+			"password": "longenoughpassword", "timezone": "UTC",
+		})
+		r := newRequestWithSession("POST", "/api/auth/register", string(body))
+		w := httptest.NewRecorder()
+		h.Register(w, r)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("email %q: status = %d, want %d (invite gate)", email, w.Code, http.StatusForbidden)
+		}
+	}
+}
+
+// Email CHANGE is the bypass the issue calls out: register with a good
+// address, then change it to anything. The old check here was
+// `strings.Contains(newEmail, "@")`.
+func TestEmailChangeRequest_RejectsInvalidEmail(t *testing.T) {
+	bad := []string{
+		"a",
+		"@b.com",
+		"<script>@x",
+		"a b@c.com",
+		"Foo <a@b.com>",
+		emailLocal64 + "@" + strings.Repeat("b", 931) + ".com",
+		strings.Repeat("x", 5<<20) + "@example.com",
+	}
+	for _, email := range bad {
+		h := &AuthHandler{Pool: nil} // must not be touched
+		body, _ := json.Marshal(map[string]any{"new_email": email})
+		r := newRequestWithSession("POST", "/settings/email/request", string(body))
+		r = r.WithContext(middleware.WithTestUser(r.Context(), &model.User{ID: 1, Email: "old@example.com"}))
+		w := httptest.NewRecorder()
+		h.EmailChangeRequest(w, r)
+
+		label := email
+		if len(label) > 40 {
+			label = label[:40] + "…"
+		}
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("new_email %q: status = %d, want %d", label, w.Code, http.StatusBadRequest)
+		}
+	}
+}
+
+// ...and a valid one must get past the validator to the "same as current"
+// check, which is also pre-database. Proves the gate is not a blanket reject
+// and that normalization runs (the current address differs only in case).
+func TestEmailChangeRequest_NormalizesAndReachesSameEmailCheck(t *testing.T) {
+	h := &AuthHandler{Pool: nil}
+	body := `{"new_email":"  OLD@Example.COM  "}`
+	r := newRequestWithSession("POST", "/settings/email/request", body)
+	r = r.WithContext(middleware.WithTestUser(r.Context(), &model.User{ID: 1, Email: "old@example.com"}))
+	w := httptest.NewRecorder()
+	h.EmailChangeRequest(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if msg, _ := resp["error"].(string); !strings.Contains(msg, "same as your current email") {
+		t.Errorf("error = %q, want the same-email message (proves normalization ran and the address was accepted)", msg)
+	}
+}
+
+// =============================================================================
+// The validator gates EVERY write, and gates no read
+// =============================================================================
+
+// parseHandlerPackage parses the handler package sources (no test files) so
+// the assertions below can look at real call graphs rather than at strings.
+func parseHandlerPackage(t *testing.T) map[string]*ast.FuncDecl {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the handler package directory: %v", err)
+	}
+	fset := token.NewFileSet()
+	funcs := map[string]*ast.FuncDecl{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		for _, d := range f.Decls {
+			if fd, ok := d.(*ast.FuncDecl); ok {
+				funcs[fd.Name.Name] = fd
+			}
+		}
+	}
+	if len(funcs) == 0 {
+		t.Fatal("no functions parsed from the handler package — the test is not looking at real code")
+	}
+	return funcs
+}
+
+// callsFunc reports whether fn's body contains a call to the named
+// package-level function.
+func funcCallsIdent(fn *ast.FuncDecl, name string) bool {
+	found := false
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if id, ok := call.Fun.(*ast.Ident); ok && id.Name == name {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// TestCredentialValidatorsGateEveryWrite is the structural half of issue #306:
+// "a validator that only guards one of the three is not a validator". A new
+// user-creating or email-changing path that forgets the gate fails here even
+// if it has no test of its own.
+func TestCredentialValidatorsGateEveryWrite(t *testing.T) {
+	funcs := parseHandlerPackage(t)
+
+	emailWrites := []string{
+		"registerCredentials", // credential registration (auth.go)
+		"handleLogin",         // OIDC auto-provisioning (oidc.go)
+		"EmailChangeRequest",  // email change (auth_email.go)
+	}
+	for _, name := range emailWrites {
+		fn, ok := funcs[name]
+		if !ok {
+			t.Errorf("%s not found — was it renamed? The email validator must follow it", name)
+			continue
+		}
+		if !funcCallsIdent(fn, "validateEmail") {
+			t.Errorf("%s does not call validateEmail; every path that writes users.email must go through it", name)
+		}
+	}
+
+	passwordWrites := []string{
+		"registerCredentials", // auth.go
+		"ResetPassword",       // auth_password.go
+		"Password",            // settings.go (SettingsHandler.Password)
+	}
+	for _, name := range passwordWrites {
+		fn, ok := funcs[name]
+		if !ok {
+			t.Errorf("%s not found — was it renamed? The password validator must follow it", name)
+			continue
+		}
+		if !funcCallsIdent(fn, "validatePassword") {
+			t.Errorf("%s does not call validatePassword; every path that writes a password hash must go through it", name)
+		}
+	}
+}
+
+// TestCredentialValidatorsDoNotGateLogin pins the other half: the validators
+// gate writes, NOT reads. Accounts created before #306 may hold an address
+// that validateEmail now rejects, and a password that validatePassword now
+// rejects. They must keep being able to log in.
+func TestCredentialValidatorsDoNotGateLogin(t *testing.T) {
+	funcs := parseHandlerPackage(t)
+
+	readPaths := []string{
+		"Login",          // auth.go — password login
+		"ForgotPassword", // auth_password.go — reset request, looks the user up by email
+		"VerifyEmail",    // auth_email.go — consumes a token for an existing address
+		"verifyPassword", // auth_helpers.go — the hash comparison itself
+	}
+	for _, name := range readPaths {
+		fn, ok := funcs[name]
+		if !ok {
+			t.Errorf("%s not found — was it renamed?", name)
+			continue
+		}
+		if funcCallsIdent(fn, "validateEmail") {
+			t.Errorf("%s calls validateEmail; that would lock out every account whose address predates the validator", name)
+		}
+		if funcCallsIdent(fn, "validatePassword") {
+			t.Errorf("%s calls validatePassword; that would lock out every account whose password predates the validator", name)
+		}
+	}
+}
+
+// In the OIDC handler the gate must sit in the auto-CREATE branch, below the
+// FindOIDCAccount / auto-link lookups. Validating before them would turn a
+// grandfathered address into a failed login instead of a successful one.
+func TestOIDCEmailValidationRunsAfterTheLookups(t *testing.T) {
+	funcs := parseHandlerPackage(t)
+	fn, ok := funcs["handleLogin"]
+	if !ok {
+		t.Fatal("handleLogin not found")
+	}
+
+	var lookupPos, validatePos token.Pos
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch f := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			if f.Sel.Name == "FindOIDCAccount" && lookupPos == token.NoPos {
+				lookupPos = call.Pos()
+			}
+		case *ast.Ident:
+			if f.Name == "validateEmail" && validatePos == token.NoPos {
+				validatePos = call.Pos()
+			}
+		}
+		return true
+	})
+
+	if lookupPos == token.NoPos {
+		t.Fatal("FindOIDCAccount call not found in handleLogin")
+	}
+	if validatePos == token.NoPos {
+		t.Fatal("validateEmail call not found in handleLogin")
+	}
+	if validatePos < lookupPos {
+		t.Error("validateEmail runs before the OIDC account lookup; it must gate only the auto-create branch, or existing accounts with grandfathered addresses can no longer sign in")
 	}
 }

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -320,8 +320,8 @@ func (h *SettingsHandler) Password(w http.ResponseWriter, r *http.Request) {
 		ErrorJSON(w, http.StatusBadRequest, "New passwords do not match.")
 		return
 	}
-	if len(body.NewPassword) < 10 {
-		ErrorJSON(w, http.StatusBadRequest, "New password must be at least 10 characters.")
+	if err := validatePassword(body.NewPassword); err != nil {
+		ErrorJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/internal/handler/validate.go
+++ b/internal/handler/validate.go
@@ -1,7 +1,12 @@
 package handler
 
 import (
+	"errors"
+	"fmt"
+	"net/mail"
+	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -11,6 +16,126 @@ const (
 	minDateYear = 1900
 	maxDateYear = 2200
 )
+
+// Credential bounds shared by every path that creates or changes a user's
+// email address or password.
+const (
+	// MaxEmailBytes is the RFC 5321 maximum reverse-path/forward-path length
+	// (64-byte local part + "@" + 255-byte domain). Anything longer cannot be
+	// delivered to, and would take an oversized key in the users.email UNIQUE
+	// btree index.
+	MaxEmailBytes = 320
+
+	// MinPasswordRunes is the minimum password length in *runes*, not bytes.
+	// The user-facing message says "characters", so it must count characters:
+	// with a byte count, a 4-character CJK passphrase (12 bytes) passed while
+	// a 9-character ASCII one did not.
+	MinPasswordRunes = 10
+
+	// MaxPasswordBytes caps the password at hashing time. argon2id has no
+	// intrinsic length limit, so without a cap a client can make the server
+	// Blake2b-hash a multi-megabyte string on every write — a cheap CPU-burn
+	// vector. The bound is in bytes because hashing cost is byte-driven.
+	MaxPasswordBytes = 1024
+)
+
+// Sentinel errors returned by validateEmail / validatePassword. Callers
+// surface err.Error() directly to the client, so the strings are written as
+// user-facing messages.
+var (
+	errEmailRequired = errors.New("Email is required.")
+	errEmailTooLong  = fmt.Errorf("Email address must be at most %d characters.", MaxEmailBytes)
+	errEmailInvalid  = errors.New("Please enter a valid email address.")
+
+	errPasswordRequired   = errors.New("Password is required.")
+	errPasswordTooShort   = fmt.Errorf("Password must be at least %d characters.", MinPasswordRunes)
+	errPasswordTooLong    = fmt.Errorf("Password must be at most %d bytes.", MaxPasswordBytes)
+	errPasswordWhitespace = errors.New("Password cannot consist only of whitespace.")
+)
+
+// validateEmail normalizes and validates a user-supplied email address,
+// returning the canonical form to store (trimmed and lowercased).
+//
+// It is the single gate in front of every write that creates or changes a
+// user's email: credential registration, OIDC auto-provisioning, and the
+// email-change request. A validator that guards only one of those is not a
+// validator — registering with a good address and then changing it would
+// bypass the check entirely.
+//
+// It deliberately does NOT gate reads or logins. Accounts created before this
+// existed may hold addresses that fail here; they must keep being able to log
+// in, reset their password, and be looked up by email.
+//
+// Rules, and why:
+//
+//   - Trim + lowercase first, so "  A@B.com " and "a@b.com" are the same
+//     account (users.email is UNIQUE and compared with =, not case-insensitively).
+//   - Reject anything longer than MaxEmailBytes (RFC 5321).
+//   - Reject any control character or interior whitespace. mail.ParseAddress
+//     already rejects "a@b.com\nBcc: x@y.com", but SMTP header injection is
+//     exactly the class of bug that must not depend on a stdlib implementation
+//     detail, so it is checked explicitly.
+//   - Parse with net/mail, matching validEmail in admin_settings.go.
+//   - Require a *bare* address: no display name and byte-identical to the
+//     input. mail.ParseAddress happily accepts "Foo <a@b.com>" (display-name
+//     form) and `"a b"@c.com` (quoted local part, which it un-quotes to
+//     "a b@c.com" — a stored address containing a space). Neither is a bare
+//     mailbox, both would let two rows denote the same mailbox while passing
+//     the UNIQUE constraint, and both are what an injection attempt looks
+//     like. Rejected.
+//
+// Deliberately accepted: a dotless domain such as "a@b". It is RFC-valid and
+// deliverable on the intranet/self-hosted deployments this app supports, and
+// validEmail accepts it too.
+func validateEmail(raw string) (string, error) {
+	email := strings.ToLower(strings.TrimSpace(raw))
+	if email == "" {
+		return "", errEmailRequired
+	}
+	if len(email) > MaxEmailBytes {
+		return "", errEmailTooLong
+	}
+	// After trimming, any remaining space/control byte is interior — a CR/LF
+	// header-injection attempt, a NUL, or a malformed address.
+	if strings.ContainsFunc(email, func(r rune) bool {
+		return r == utf8.RuneError || r < 0x20 || r == 0x7f || unicode.IsSpace(r)
+	}) {
+		return "", errEmailInvalid
+	}
+	addr, err := mail.ParseAddress(email)
+	if err != nil {
+		return "", errEmailInvalid
+	}
+	if addr.Name != "" || addr.Address != email {
+		return "", errEmailInvalid
+	}
+	return email, nil
+}
+
+// validatePassword enforces the password policy on every write that sets a
+// password: registration, password reset, and the change-password setting.
+//
+// Like validateEmail it gates writes only. Login must keep accepting whatever
+// an existing account was created with, so verifyPassword never calls this.
+//
+// The whitespace-only rejection is a rejection, not a trim: trimming would
+// silently change the secret the user typed.
+func validatePassword(password string) error {
+	if password == "" {
+		return errPasswordRequired
+	}
+	// Cheapest check first: bail on an oversized body before touching it.
+	if len(password) > MaxPasswordBytes {
+		return errPasswordTooLong
+	}
+	if strings.TrimSpace(password) == "" {
+		return errPasswordWhitespace
+	}
+	if utf8.RuneCountInString(password) < MinPasswordRunes {
+		return errPasswordTooShort
+	}
+	return nil
+}
 
 // truncateUTF8 caps s at maxBytes bytes without splitting a multi-byte UTF-8
 // rune. Byte-index slicing (s[:n]) can cut an emoji or other multi-byte rune


### PR DESCRIPTION
Closes #306

## The defect

`registerCredentials` checked only that the email was non-empty. `a`, `not an email`,
`<script>` and a 5 MB string all registered successfully; the verification mail was then
unsendable and password reset unreachable, so the account existed but could never be
verified. `users.email` is `TEXT NOT NULL UNIQUE` with no length cap, so the only bound
was the 15 MB body limit. Admin config (`validEmail`) was validated more strictly than
user sign-up. Password validation was `len(password) < 10` — bytes, not runes, with no
upper bound, so argon2id would hash a multi-megabyte password.

## What changed

Two shared validators in `internal/handler/validate.go`:

| | rule |
|---|---|
| `validateEmail` | trim + lowercase → 320-byte cap (RFC 5321) → reject control chars / interior whitespace → `mail.ParseAddress` → require a *bare* address. Returns the canonical form to store. |
| `validatePassword` | reject empty → reject > 1024 bytes → reject whitespace-only → require ≥ 10 **runes**. |

The control-character check is redundant with `net/mail` today (it already rejects
`a@b.com\nBcc: x@y.com`), but SMTP header injection is not a thing that should depend on
a stdlib implementation detail.

### Applied at every write, and only at writes

Email writes — all three, because a validator that guards one of them is not a validator:

- `internal/handler/auth.go` — credential registration
- `internal/handler/oidc.go` — OIDC auto-provisioning
- `internal/handler/auth_email.go` — email **change**, which previously checked only
  `strings.Contains(newEmail, "@")` and was therefore a trivial bypass of the
  registration check

Password writes:

- `internal/handler/auth.go` — registration
- `internal/handler/auth_password.go` — reset
- `internal/handler/settings.go` — change

**Not** applied to reads or logins. Accounts created before this may hold an address or a
password the validators now reject, and they must keep being able to sign in, reset their
password and be looked up by email. In `oidc.go` the gate deliberately sits *below* the
`FindOIDCAccount` / auto-link lookups for the same reason — validating above them would
turn a grandfathered address into a failed login. Two structural tests pin both halves of
this (see below).

`admin_settings.go`'s `validEmail` is **untouched** and its observable behaviour is
unchanged — #309 is testing it. `validateEmail` is deliberately a separate, stricter
function rather than a refactor of it.

The OIDC rejection redirects with the existing `invalid_claims` error code rather than a
new one: it already means "the IdP returned invalid information" and is already
translated in every locale, so there is no client or i18n change in this PR.

## Decisions pinned

**Display-name form `"Foo <a@b.com>"` → rejected.** `mail.ParseAddress` accepts it, but it
is not a bare mailbox. Storing it would let two rows denote the same mailbox while still
satisfying the `UNIQUE` constraint, and it is the shape an injection attempt takes. Same
reasoning rejects `<a@b.com>` and `"a b"@c.com` — `net/mail` un-quotes the latter into
`a b@c.com`, an address containing a literal space. Enforced as
`addr.Name == "" && addr.Address == input`.

**Dotless domain `"a@b"` → accepted.** RFC-valid, deliverable on the intranet/self-hosted
deployments this app supports, and `validEmail` accepts it too. Rejecting it would be
stricter than the admin surface for no delivery benefit on those instances.

**Password minimum counts runes (10), not bytes.** The message says "10 characters" and
the client placeholder says "Minimum 10 characters", so it must mean characters. Under
the old `len()` check a 4-rune CJK passphrase (12 bytes) passed while a 9-character ASCII
one did not. This tightens the policy for non-ASCII passwords on *new* writes only;
existing accounts are unaffected because login is not gated.

**Password maximum counts bytes (1024).** Hashing cost is byte-driven, so the bound that
matters for the CPU-burn vector is a byte bound. 1024 bytes is ~256 CJK characters — far
beyond any real passphrase.

**Email cap is 320 bytes, inclusive.** The RFC 5321 maximum (64-byte local part + `@` +
255-byte domain). A 320-byte address passes, 321 does not.

## Tests

`internal/handler/registration_test.go`:

- `TestValidateEmail` — the full table from the issue (`""`, `a`, `a@`, `@b.com`, `a@b`,
  `a b@c.com`, `a@b.com`, uppercase, surrounding whitespace, 320 bytes, 321 bytes,
  1000 bytes, embedded `\n`/`\r`/`\r\n`/NUL, display-name form) plus `not an email`,
  `<script>`, two-address input, and the quoted local part. Every accepted case also
  asserts normalization is **idempotent** — feeding a stored address back in must return
  it unchanged, or email-change could mint a duplicate row.
- `TestValidatePassword` — 9 vs 10 vs 11 ASCII, 4-rune and 5-rune and 9-rune CJK
  (rejected) vs 10-rune (accepted), all-whitespace, a padded-but-real password (must not
  be trimmed), exactly 1024 bytes, 1025 bytes, 5 MB.
- Handler tests driving `Register` and `EmailChangeRequest` with a **nil `Pool`**, which
  proves every rejection happens before any database access — and, for the 5 MB password,
  before argon2id sees it. Positive counterparts assert a valid address still reaches the
  next gate, so "reject everything" would not pass.
- `TestCredentialValidatorsGateEveryWrite` / `TestCredentialValidatorsDoNotGateLogin` —
  AST walks of the real handler package asserting `registerCredentials`, `handleLogin`
  and `EmailChangeRequest` call `validateEmail`; that `registerCredentials`,
  `ResetPassword` and `SettingsHandler.Password` call `validatePassword`; and that
  `Login`, `ForgotPassword`, `VerifyEmail` and `verifyPassword` call **neither**. A new
  user-creating path that forgets the gate fails here even with no test of its own.
- `TestOIDCEmailValidationRunsAfterTheLookups` — asserts by source position that the
  `validateEmail` call sits after `FindOIDCAccount`, so the gate cannot drift up into the
  login path.

Mutation-checked: reverting the `auth_email.go` gate to the old `Contains("@")` check
makes `TestEmailChangeRequest_RejectsInvalidEmail` fail — with a nil-pointer panic inside
`pgxpool.QueryRow`, i.e. the bad address reaching the database, which is the bug itself.

## Verification

```
$ export GOFLAGS=-p=2 GOMAXPROCS=2
$ go build ./...
$ go vet ./...
$ go test ./...
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	(cached)
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	(cached)
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	(cached)
ok  	schautrack/internal/handler	1.719s
ok  	schautrack/internal/middleware	(cached)
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	(cached)
ok  	schautrack/internal/release	(cached)
ok  	schautrack/internal/service	(cached)
ok  	schautrack/internal/session	(cached)
ok  	schautrack/internal/sse	(cached)

$ go test ./internal/handler/ -run 'Registration|Email|Password'
ok  	schautrack/internal/handler	0.906s
```

`go build` and `go vet` both produced no output. Client checks were not run: this PR adds
no client-side string and no i18n key (the OIDC rejection reuses the already-translated
`invalid_claims` code).

## Deliberately out of scope

The password cap gates **writes**. `Login`, `Reset2FA` and step-up still hand an unbounded
client-supplied password to argon2id (`verifyPassword` / `equalizeLoginTiming`), so the
CPU-burn vector is narrowed but not closed — capping there risks locking out any account
whose password predates this. Filed separately, along with `AdminHandler.CreateInvite`
storing an unvalidated invite email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
