### PR TITLE
fix: clear entry name on {"name": null} instead of storing "<nil>"

### DIFF
--- a/e2e/entry-edit.spec.ts
+++ b/e2e/entry-edit.spec.ts
@@ -92,6 +92,101 @@ test.describe('Entry Inline Edit', () => {
     await ctx.close();
   });
 
+  /**
+   * Find a just-created entry by name without knowing which calendar day the
+   * server filed it under. Entry dates are resolved in the user's timezone,
+   * which need not match the runner's, so probe yesterday/today/tomorrow.
+   */
+  async function findEntryByName(page: Page, name: string): Promise<{ id: number; date: string }> {
+    const now = Date.now();
+    for (const offset of [0, -1, 1]) {
+      const date = new Date(now + offset * 86400000).toISOString().split('T')[0];
+      const res = await page.request.get(`${baseURL}/entries/day?date=${date}`);
+      if (!res.ok()) continue;
+      const body = await res.json();
+      const hit = (body.entries || []).find((e: { name: string | null }) => e.name === name);
+      if (hit) return { id: hit.id, date };
+    }
+    throw new Error(`entry ${name} not found on any nearby date`);
+  }
+
+  /**
+   * Regression for #303.
+   *
+   * POST /entries/:id/update decodes into map[string]any and used to coerce
+   * every value with fmt.Sprintf("%v", …) before inspecting it, which renders
+   * a JSON null as the four-character string "<nil>". The entry-name path did
+   * not compare against that sentinel (the amount and macro paths did), so
+   * {"name": null} — the documented way to clear the name — renamed the entry
+   * to <nil> and the card rendered those four characters to the user.
+   *
+   * The SPA itself sends "" when the inline editor is emptied, so this state is
+   * only reachable from a client that sends a real JSON null; hence the direct
+   * request rather than a UI interaction.
+   */
+  test('clearing a name with an explicit JSON null does not render <nil>', async ({ browser }) => {
+    const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+    const page = await ctx.newPage();
+    await loginAndGo(page);
+    await createEntry(page, 'Null name test');
+
+    await expect(page.getByRole('button', { name: 'Null name test', exact: true })).toBeVisible({ timeout: 10000 });
+    const entry = await findEntryByName(page, 'Null name test');
+
+    const { token } = await (await page.request.get(`${baseURL}/api/csrf`)).json();
+    const res = await page.request.post(`${baseURL}/entries/${entry.id}/update`, {
+      data: { name: null },
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': token },
+    });
+    expect(res.status()).toBe(200);
+
+    // The server's own view of the entry: the name is cleared, not renamed.
+    const updated = await res.json();
+    expect(updated.entry.name).toBeNull();
+
+    // And the card the user sees renders the unnamed placeholder, never <nil>.
+    // Deliberately not waitForLoadState('networkidle'): the dashboard holds an
+    // SSE stream open, so the network never goes idle.
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.getByRole('button', { name: '—', exact: true }).first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: 'Null name test', exact: true })).toHaveCount(0);
+    await expect(page.getByText('<nil>')).toHaveCount(0);
+
+    await page.request.post(`${baseURL}/entries/${entry.id}/delete`, {
+      headers: { 'X-CSRF-Token': token },
+    });
+    await ctx.close();
+  });
+
+  test('clearing a name through the inline editor does not render <nil>', async ({ browser }) => {
+    const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+    const page = await ctx.newPage();
+    await loginAndGo(page);
+    await createEntry(page, 'Empty name test');
+
+    const nameBtn = page.getByRole('button', { name: 'Empty name test', exact: true });
+    await nameBtn.scrollIntoViewIfNeeded({ timeout: 10000 });
+    // Grab the id while the entry is still findable by name — once the name is
+    // cleared there is nothing left to look it up by.
+    const entry = await findEntryByName(page, 'Empty name test');
+    await nameBtn.click();
+
+    const editInput = page.locator('input:focus');
+    await expect(editInput).toBeVisible({ timeout: 5000 });
+    await editInput.fill('');
+    await editInput.press('Enter');
+
+    await expect(page.getByRole('button', { name: 'Empty name test', exact: true })).toHaveCount(0, { timeout: 10000 });
+    await expect(page.getByText('<nil>')).toHaveCount(0);
+
+    const { token } = await (await page.request.get(`${baseURL}/api/csrf`)).json();
+    await page.request.post(`${baseURL}/entries/${entry.id}/delete`, {
+      headers: { 'X-CSRF-Token': token },
+    });
+    await ctx.close();
+  });
+
   test('edit entry calorie value inline', async ({ browser }) => {
     const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
     const page = await ctx.newPage();

--- a/internal/handler/entries_crud.go
+++ b/internal/handler/entries_crud.go
@@ -25,7 +25,13 @@ func (h *EntriesHandler) CreateEntry(w http.ResponseWriter, r *http.Request) {
 	userTz := getUserTimezone(r, user)
 	mu := service.ParseMacroUser(user.MacrosEnabled, user.MacroGoals, user.DailyGoal, user.GoalThreshold)
 
-	rawAmount := fmt.Sprintf("%v", body["amount"])
+	// An absent or null amount reads as the empty string, which ParseAmount
+	// rejects — the same outcome the old fmt.Sprintf("%v", nil) => "<nil>"
+	// coercion reached, without the sentinel.
+	rawAmount := ""
+	if v, _ := optionalString(body, "amount"); v != nil {
+		rawAmount = *v
+	}
 	amountResult := service.ParseAmount(rawAmount, MaxEntryCalories)
 	hasCalorieEntry := amountResult.Ok && amountResult.Value != 0
 
@@ -38,22 +44,18 @@ func (h *EntriesHandler) CreateEntry(w http.ResponseWriter, r *http.Request) {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid date")
 		return
 	}
-	entryName := ""
-	if v, ok := body["entry_name"].(string); ok {
-		entryName = truncateUTF8(strings.TrimSpace(v), 120)
-	}
+	// Absent and null both mean "no name"; there is nothing to preserve on a
+	// create, so the two collapse to a NULL entry_name.
+	entryName, _ := optionalEntryName(body, "entry_name")
 
 	// Parse weight (frontend may send as string or number)
 	var weightVal float64
 	hasWeight := false
-	if wv, exists := body["weight"]; exists && wv != nil {
-		weightStr := fmt.Sprintf("%v", wv)
-		if weightStr != "" && weightStr != "<nil>" {
-			wr := service.ParseWeight(weightStr)
-			if wr.Ok {
-				weightVal = wr.Value
-				hasWeight = true
-			}
+	if wv, _ := optionalString(body, "weight"); wv != nil && *wv != "" {
+		wr := service.ParseWeight(*wv)
+		if wr.Ok {
+			weightVal = wr.Value
+			hasWeight = true
 		}
 	}
 
@@ -67,19 +69,16 @@ func (h *EntriesHandler) CreateEntry(w http.ResponseWriter, r *http.Request) {
 	macroValues := map[string]int{}
 	for _, key := range service.MacroKeys {
 		fieldName := key + "_g"
-		if v, exists := body[fieldName]; exists {
-			vStr := fmt.Sprintf("%v", v)
-			vStr = strings.TrimSpace(vStr)
-			if vStr == "" || vStr == "<nil>" {
-				continue
-			}
-			n, err := strconv.Atoi(vStr)
-			if err != nil || n < 0 || n > MaxEntryMacro {
-				ErrorJSON(w, http.StatusBadRequest, fmt.Sprintf("Macro values must be between 0 and %d", MaxEntryMacro))
-				return
-			}
-			macroValues[key] = n
+		v, _ := optionalString(body, fieldName)
+		if v == nil || *v == "" {
+			continue
 		}
+		n, err := strconv.Atoi(*v)
+		if err != nil || n < 0 || n > MaxEntryMacro {
+			ErrorJSON(w, http.StatusBadRequest, fmt.Sprintf("Macro values must be between 0 and %d", MaxEntryMacro))
+			return
+		}
+		macroValues[key] = n
 	}
 	hasMacroEntry := len(macroValues) > 0
 
@@ -99,7 +98,7 @@ func (h *EntriesHandler) CreateEntry(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if rawAmount != "" && rawAmount != "<nil>" && !amountResult.Ok {
+	if rawAmount != "" && !amountResult.Ok {
 		ErrorJSON(w, http.StatusBadRequest, fmt.Sprintf("Calories must be between -%d and %d", MaxEntryCalories, MaxEntryCalories))
 		return
 	}
@@ -124,7 +123,7 @@ func (h *EntriesHandler) CreateEntry(w http.ResponseWriter, r *http.Request) {
 		// Build dynamic query
 		cols := "user_id, entry_date, amount, entry_name"
 		vals := "$1, $2, $3, $4"
-		args := []any{user.ID, entryDate, entryAmount, nilString(entryName)}
+		args := []any{user.ID, entryDate, entryAmount, entryName}
 		idx := 5
 		for _, key := range service.MacroKeys {
 			if v, ok := macroValues[key]; ok {
@@ -179,60 +178,20 @@ func (h *EntriesHandler) UpdateEntry(w http.ResponseWriter, r *http.Request) {
 	autoCalc := service.IsAutoCalcCalories(mu)
 	userTz := getUserTimezone(r, user)
 
-	var updates []string
-	var values []any
-	idx := 1
-
-	if v, ok := body["name"]; ok {
-		name := truncateUTF8(strings.TrimSpace(fmt.Sprintf("%v", v)), 120)
-		updates = append(updates, fmt.Sprintf("entry_name = $%d", idx))
-		values = append(values, nilString(name))
-		idx++
-	}
-
-	if v, ok := body["amount"]; ok && !autoCalc {
-		vStr := strings.TrimSpace(fmt.Sprintf("%v", v))
-		if vStr == "" || vStr == "<nil>" || vStr == "0" {
-			updates = append(updates, fmt.Sprintf("amount = $%d", idx))
-			values = append(values, 0)
-			idx++
-		} else {
-			result := service.ParseAmount(vStr, MaxEntryCalories)
-			if !result.Ok {
-				ErrorJSON(w, http.StatusBadRequest, fmt.Sprintf("Calories must be between -%d and %d", MaxEntryCalories, MaxEntryCalories))
-				return
-			}
-			updates = append(updates, fmt.Sprintf("amount = $%d", idx))
-			values = append(values, result.Value)
-			idx++
-		}
-	}
-
-	for _, key := range service.MacroKeys {
-		fieldName := key + "_g"
-		if v, ok := body[fieldName]; ok {
-			vStr := strings.TrimSpace(fmt.Sprintf("%v", v))
-			if vStr == "" || vStr == "<nil>" || vStr == "0" {
-				updates = append(updates, fmt.Sprintf("%s = $%d", fieldName, idx))
-				values = append(values, nil)
-				idx++
-			} else {
-				n, err := strconv.Atoi(vStr)
-				if err != nil || n < 0 || n > MaxEntryMacro {
-					ErrorJSON(w, http.StatusBadRequest, fmt.Sprintf("Macro values must be between 0 and %d", MaxEntryMacro))
-					return
-				}
-				updates = append(updates, fmt.Sprintf("%s = $%d", fieldName, idx))
-				values = append(values, n)
-				idx++
-			}
-		}
+	updates, values, badRequest := buildEntryUpdates(body, autoCalc)
+	if badRequest != "" {
+		ErrorJSON(w, http.StatusBadRequest, badRequest)
+		return
 	}
 
 	if len(updates) == 0 {
 		ErrorJSON(w, http.StatusBadRequest, "No updates provided")
 		return
 	}
+
+	// buildEntryUpdates numbered its placeholders $1..$len(updates), so the id
+	// and user_id predicates continue from there.
+	idx := len(updates) + 1
 
 	query := fmt.Sprintf(
 		"UPDATE calorie_entries SET %s WHERE id = $%d AND user_id = $%d RETURNING id, entry_date, amount, entry_name, created_at, protein_g, carbs_g, fat_g, fiber_g, sugar_g",

--- a/internal/handler/entries_helpers.go
+++ b/internal/handler/entries_helpers.go
@@ -2,10 +2,12 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"math"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +22,9 @@ const (
 	DefaultRangeDays = 14
 	MaxEntryCalories = 9999
 	MaxEntryMacro    = 999
+	// MaxEntryNameBytes bounds entry_name. Enforced in bytes rather than
+	// runes because that is what the column is sized in.
+	MaxEntryNameBytes = 120
 )
 
 var dateRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
@@ -238,6 +243,120 @@ func buildMacroMap(enabledMacros []string, proteinG, carbsG, fatG, fiberG, sugar
 		return nil
 	}
 	return macros
+}
+
+// optionalString reads key out of a JSON body that was decoded into a
+// map[string]any and reports the three states a field can be in: absent
+// (present=false), explicitly null (present=true, value=nil), or present with
+// a value (present=true, value non-nil).
+//
+// It is the map[string]any counterpart of Optional[T] (v1_common.go), which
+// the v1 PATCH handlers use to make the same distinction from a typed struct.
+// The legacy SPA surface decodes into a bare map, so the distinction has to be
+// recovered from the map itself: a missing key is absent, and a key holding a
+// nil interface value is an explicit JSON null.
+//
+// Checking that interface for nil BEFORE coercing is the whole point. The call
+// sites used to do it the other way around — fmt.Sprintf("%v", v) first — which
+// renders a JSON null as the literal string "<nil>". Some of them then compared
+// against that "<nil>" sentinel to detect a null, and one (the entry-name path
+// in UpdateEntry) did not, so POST /entries/:id/update with {"name": null}
+// renamed the entry to the four characters <nil> instead of clearing it. The
+// sentinel was never sound either way: a user who legitimately types <nil> as
+// an entry name is indistinguishable from a null once the type is thrown away.
+//
+// The returned value is whitespace-trimmed. Non-string JSON values (numbers,
+// booleans, objects, arrays) are still rendered with %v, matching what this
+// loosely-typed surface has always accepted from clients that send numbers as
+// numbers on one screen and as strings on another.
+func optionalString(body map[string]any, key string) (value *string, present bool) {
+	raw, present := body[key]
+	if !present || raw == nil {
+		return nil, present
+	}
+	s := strings.TrimSpace(fmt.Sprintf("%v", raw))
+	return &s, true
+}
+
+// optionalEntryName layers the entry-name rules on top of optionalString: cap
+// the value at MaxEntryNameBytes on a UTF-8 rune boundary, then collapse an
+// empty result to nil so the column is cleared rather than storing "".
+//
+// The three states map onto the column as:
+//
+//	present=false             -> key absent; leave the stored name alone
+//	present=true, value=nil   -> clear the name (explicit null, "", or blanks)
+//	present=true, value!=nil  -> set the name
+func optionalEntryName(body map[string]any, key string) (value *string, present bool) {
+	raw, present := optionalString(body, key)
+	if !present || raw == nil {
+		return nil, present
+	}
+	return nilString(truncateUTF8(*raw, MaxEntryNameBytes)), true
+}
+
+// buildEntryUpdates turns a decoded POST /entries/:id/update body into the SET
+// fragments and bind values of the UPDATE statement, using $1..$n in the order
+// the fragments are returned.
+//
+// It is deliberately pure — no request, no pool — so the absent/null/present
+// semantics of every field can be asserted without a database. Needing one is
+// exactly why the "<nil>" entry-name bug shipped untested.
+//
+// The third return value is a client-facing message, empty on success; a
+// non-empty message always means 400. This mirrors parseSavedFoodPayload, the
+// same-shaped validator on the saved-foods handler.
+func buildEntryUpdates(body map[string]any, autoCalc bool) ([]string, []any, string) {
+	var updates []string
+	var values []any
+	idx := 1
+
+	if name, present := optionalEntryName(body, "name"); present {
+		updates = append(updates, fmt.Sprintf("entry_name = $%d", idx))
+		values = append(values, name)
+		idx++
+	}
+
+	// When calories are auto-calculated from macros, an incoming amount is
+	// ignored: the post-update recompute would immediately overwrite it.
+	if raw, present := optionalString(body, "amount"); present && !autoCalc {
+		amount := 0
+		if raw != nil && *raw != "" && *raw != "0" {
+			result := service.ParseAmount(*raw, MaxEntryCalories)
+			if !result.Ok {
+				return nil, nil, fmt.Sprintf("Calories must be between -%d and %d", MaxEntryCalories, MaxEntryCalories)
+			}
+			amount = result.Value
+		}
+		updates = append(updates, fmt.Sprintf("amount = $%d", idx))
+		values = append(values, amount)
+		idx++
+	}
+
+	for _, key := range service.MacroKeys {
+		fieldName := key + "_g"
+		raw, present := optionalString(body, fieldName)
+		if !present {
+			continue
+		}
+		// A cleared macro becomes NULL, not 0 — the column is nullable and
+		// "no reading" is not the same as "zero grams". A literal "0" clears
+		// too: this surface has always read an entered zero as "remove it",
+		// which is what the SPA relies on (EntryList sends null for "0").
+		var value any
+		if raw != nil && *raw != "" && *raw != "0" {
+			n, err := strconv.Atoi(*raw)
+			if err != nil || n < 0 || n > MaxEntryMacro {
+				return nil, nil, fmt.Sprintf("Macro values must be between 0 and %d", MaxEntryMacro)
+			}
+			value = n
+		}
+		updates = append(updates, fmt.Sprintf("%s = $%d", fieldName, idx))
+		values = append(values, value)
+		idx++
+	}
+
+	return updates, values, ""
 }
 
 func nilString(s string) *string {

--- a/internal/handler/entries_test.go
+++ b/internal/handler/entries_test.go
@@ -1,7 +1,10 @@
 package handler
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"schautrack/internal/service"
 )
@@ -328,5 +331,355 @@ func TestBuildDayOptionsBetweenInvalid(t *testing.T) {
 	days := service.BuildDayOptionsBetween("invalid", "2025-03-15", 10)
 	if days != nil {
 		t.Errorf("expected nil for invalid start date, got %v", days)
+	}
+}
+
+// --- optionalString / optionalEntryName / buildEntryUpdates ---------------
+//
+// Regression coverage for #303. The legacy SPA surface decodes request bodies
+// into map[string]any and used to coerce every value with fmt.Sprintf("%v", …)
+// before inspecting it, which renders a JSON null as the four-character string
+// "<nil>". Two of the three coercion sites in entries_crud.go then compared
+// against that "<nil>" sentinel to recover "this was null"; the entry-name site
+// did not, so POST /entries/:id/update with {"name": null} renamed the entry to
+// <nil> instead of clearing it. The v1 surface never had the bug because
+// Optional[T] keeps the three states apart in the type system
+// (v1_optional_test.go); these tests are the map[string]any equivalent.
+
+// TestOptionalString covers the coercion matrix: which JSON shapes are absent,
+// which are null, and what a present value coerces to.
+func TestOptionalString(t *testing.T) {
+	// 118 ASCII bytes then a 4-byte avocado: 122 bytes total, so a 120-byte
+	// cap lands two bytes inside the emoji. optionalString does no truncating,
+	// so it must come back whole; TestOptionalEntryName checks the cut.
+	longUTF8 := strings.Repeat("a", 118) + "🥑"
+
+	tests := []struct {
+		name        string
+		body        string
+		key         string
+		wantPresent bool
+		wantNil     bool
+		wantValue   string
+	}{
+		{"key absent", `{"other":"x"}`, "name", false, true, ""},
+		{"empty body", `{}`, "name", false, true, ""},
+		{"explicit null", `{"name":null}`, "name", true, true, ""},
+		{"empty string", `{"name":""}`, "name", true, false, ""},
+		{"whitespace only", `{"name":"   "}`, "name", true, false, ""},
+		{"tabs and newlines", `{"name":"\t\n "}`, "name", true, false, ""},
+		{"normal string", `{"name":"Porridge"}`, "name", true, false, "Porridge"},
+		{"string is trimmed", `{"name":"  Porridge  "}`, "name", true, false, "Porridge"},
+		// The bug's mirror image: a user who legitimately types <nil> gets
+		// those four characters stored, not a cleared field. Under the old
+		// sentinel comparison this was indistinguishable from null.
+		{"literal <nil> string", `{"name":"<nil>"}`, "name", true, false, "<nil>"},
+		{"integer number", `{"name":42}`, "name", true, false, "42"},
+		{"fractional number", `{"name":42.5}`, "name", true, false, "42.5"},
+		{"negative number", `{"name":-7}`, "name", true, false, "-7"},
+		{"zero", `{"name":0}`, "name", true, false, "0"},
+		{"boolean true", `{"name":true}`, "name", true, false, "true"},
+		{"boolean false", `{"name":false}`, "name", true, false, "false"},
+		{"object", `{"name":{"a":1}}`, "name", true, false, "map[a:1]"},
+		{"empty object", `{"name":{}}`, "name", true, false, "map[]"},
+		{"array", `{"name":[1,2]}`, "name", true, false, "[1 2]"},
+		{"empty array", `{"name":[]}`, "name", true, false, "[]"},
+		{"over-120-byte string is not truncated here", `{"name":"` + longUTF8 + `"}`, "name", true, false, longUTF8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, present := optionalString(decodeBody(t, tt.body), tt.key)
+			if present != tt.wantPresent {
+				t.Fatalf("present = %v, want %v", present, tt.wantPresent)
+			}
+			if (got == nil) != tt.wantNil {
+				t.Fatalf("value nil = %v, want %v (got %v)", got == nil, tt.wantNil, got)
+			}
+			if got != nil && *got != tt.wantValue {
+				t.Errorf("value = %q, want %q", *got, tt.wantValue)
+			}
+		})
+	}
+}
+
+// TestOptionalEntryName checks the entry-name layer: the 120-byte cap, the
+// UTF-8 boundary walk-back, and the collapse of a blank value to nil so the
+// column is cleared rather than set to "".
+func TestOptionalEntryName(t *testing.T) {
+	ascii130 := strings.Repeat("b", 130)
+	// 118 'a' + 🥑 = 122 bytes; cutting at 120 lands mid-emoji, so
+	// truncateUTF8 must walk back to 118 and drop the emoji entirely.
+	utf8Boundary := strings.Repeat("a", 118) + "🥑"
+
+	tests := []struct {
+		name        string
+		body        string
+		wantPresent bool
+		wantNil     bool
+		wantValue   string
+	}{
+		{"key absent leaves the name alone", `{"amount":100}`, false, true, ""},
+		{"explicit null clears the name", `{"name":null}`, true, true, ""},
+		{"empty string clears the name", `{"name":""}`, true, true, ""},
+		{"whitespace clears the name", `{"name":"   "}`, true, true, ""},
+		{"a value sets the name", `{"name":"Porridge"}`, true, false, "Porridge"},
+		{"literal <nil> is a real name", `{"name":"<nil>"}`, true, false, "<nil>"},
+		{"a number becomes its text", `{"name":42}`, true, false, "42"},
+		{"long ASCII is capped at 120 bytes", `{"name":"` + ascii130 + `"}`, true, false, strings.Repeat("b", 120)},
+		{"cap walks back off a split rune", `{"name":"` + utf8Boundary + `"}`, true, false, strings.Repeat("a", 118)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, present := optionalEntryName(decodeBody(t, tt.body), "name")
+			if present != tt.wantPresent {
+				t.Fatalf("present = %v, want %v", present, tt.wantPresent)
+			}
+			if (got == nil) != tt.wantNil {
+				t.Fatalf("value nil = %v, want %v (got %v)", got == nil, tt.wantNil, got)
+			}
+			if got == nil {
+				return
+			}
+			if *got != tt.wantValue {
+				t.Errorf("value = %q (%d bytes), want %q (%d bytes)", *got, len(*got), tt.wantValue, len(tt.wantValue))
+			}
+			if len(*got) > MaxEntryNameBytes {
+				t.Errorf("value is %d bytes, over the %d-byte cap", len(*got), MaxEntryNameBytes)
+			}
+			if !utf8.ValidString(*got) {
+				t.Errorf("value %q is not valid UTF-8; Postgres would reject it (22021)", *got)
+			}
+		})
+	}
+}
+
+// TestBuildEntryUpdatesNameThreeStates is the #303 regression proper: it walks
+// the same absent / null / present matrix TestEntryPatchThreeStates walks on
+// the v1 surface, but through the map[string]any path POST /entries/:id/update
+// actually takes.
+func TestBuildEntryUpdatesNameThreeStates(t *testing.T) {
+	t.Run("absent leaves the column alone", func(t *testing.T) {
+		updates, values, msg := buildEntryUpdates(decodeBody(t, `{"amount":"250"}`), false)
+		if msg != "" {
+			t.Fatalf("unexpected rejection: %s", msg)
+		}
+		for _, u := range updates {
+			if strings.HasPrefix(u, "entry_name") {
+				t.Fatalf("entry_name in SET clause %v for a body that never mentioned it", updates)
+			}
+		}
+		if len(values) != 1 {
+			t.Fatalf("values = %v, want just the amount", values)
+		}
+	})
+
+	t.Run("null clears the column", func(t *testing.T) {
+		updates, values, msg := buildEntryUpdates(decodeBody(t, `{"name":null}`), false)
+		if msg != "" {
+			t.Fatalf("unexpected rejection: %s", msg)
+		}
+		if len(updates) != 1 || updates[0] != "entry_name = $1" {
+			t.Fatalf("updates = %v, want [entry_name = $1]", updates)
+		}
+		if len(values) != 1 {
+			t.Fatalf("values = %v, want one", values)
+		}
+		// The bug: this used to be a *string pointing at "<nil>", so the
+		// entry was renamed to <nil> instead of having its name cleared.
+		got, _ := values[0].(*string)
+		if got != nil {
+			t.Errorf("bound value = %q, want NULL — {\"name\": null} must clear the name, not rename the entry", *got)
+		}
+	})
+
+	t.Run("a value sets the column", func(t *testing.T) {
+		_, values, msg := buildEntryUpdates(decodeBody(t, `{"name":"  Porridge  "}`), false)
+		if msg != "" {
+			t.Fatalf("unexpected rejection: %s", msg)
+		}
+		got, _ := values[0].(*string)
+		if got == nil || *got != "Porridge" {
+			t.Errorf("bound value = %v, want a pointer to \"Porridge\"", got)
+		}
+	})
+
+	t.Run("an empty string clears the column", func(t *testing.T) {
+		// What the SPA sends when the user empties the inline name input.
+		_, values, msg := buildEntryUpdates(decodeBody(t, `{"name":""}`), false)
+		if msg != "" {
+			t.Fatalf("unexpected rejection: %s", msg)
+		}
+		if got, _ := values[0].(*string); got != nil {
+			t.Errorf("bound value = %q, want NULL", *got)
+		}
+	})
+
+	t.Run("a literal <nil> is stored verbatim", func(t *testing.T) {
+		_, values, msg := buildEntryUpdates(decodeBody(t, `{"name":"<nil>"}`), false)
+		if msg != "" {
+			t.Fatalf("unexpected rejection: %s", msg)
+		}
+		got, _ := values[0].(*string)
+		if got == nil || *got != "<nil>" {
+			t.Errorf("bound value = %v, want a pointer to \"<nil>\" — a user may legitimately name an entry that", got)
+		}
+	})
+}
+
+// TestBuildEntryUpdatesAmount pins the amount column's three states. amount is
+// NOT NULL, so "cleared" means 0 rather than NULL.
+func TestBuildEntryUpdatesAmount(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		autoCalc  bool
+		wantSet   bool
+		wantValue int
+		wantMsg   bool
+	}{
+		{"absent leaves the column alone", `{"name":"x"}`, false, false, 0, false},
+		{"null zeroes it", `{"amount":null}`, false, true, 0, false},
+		{"empty string zeroes it", `{"amount":""}`, false, true, 0, false},
+		{"explicit zero zeroes it", `{"amount":"0"}`, false, true, 0, false},
+		{"a string value sets it", `{"amount":"250"}`, false, true, 250, false},
+		{"a number value sets it", `{"amount":250}`, false, true, 250, false},
+		{"an expression is evaluated", `{"amount":"100+150"}`, false, true, 250, false},
+		{"garbage is rejected", `{"amount":"abc"}`, false, false, 0, true},
+		// Previously "<nil>" was a magic zero. Now it is what it looks like:
+		// an unparseable amount, and the caller gets a 400 instead of a
+		// silent overwrite with 0.
+		{"literal <nil> is rejected, not silently zeroed", `{"amount":"<nil>"}`, false, false, 0, true},
+		{"over the cap is rejected", `{"amount":"99999"}`, false, false, 0, true},
+		{"auto-calc ignores the field", `{"amount":"250"}`, true, false, 0, false},
+		{"auto-calc ignores a null too", `{"amount":null}`, true, false, 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updates, values, msg := buildEntryUpdates(decodeBody(t, tt.body), tt.autoCalc)
+			if (msg != "") != tt.wantMsg {
+				t.Fatalf("message = %q, wantMsg = %v", msg, tt.wantMsg)
+			}
+			if tt.wantMsg {
+				return
+			}
+			idx := -1
+			for i, u := range updates {
+				if strings.HasPrefix(u, "amount") {
+					idx = i
+				}
+			}
+			if (idx >= 0) != tt.wantSet {
+				t.Fatalf("updates = %v, wantSet = %v", updates, tt.wantSet)
+			}
+			if !tt.wantSet {
+				return
+			}
+			if got, ok := values[idx].(int); !ok || got != tt.wantValue {
+				t.Errorf("bound value = %v, want %d", values[idx], tt.wantValue)
+			}
+		})
+	}
+}
+
+// TestBuildEntryUpdatesMacros pins the macro columns. Unlike amount these are
+// nullable, and 0 means "clear" rather than "zero grams" — a deliberate legacy
+// quirk of this surface, preserved here so a refactor cannot drop it silently.
+func TestBuildEntryUpdatesMacros(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantSet   bool
+		wantNull  bool
+		wantValue int
+		wantMsg   bool
+	}{
+		{"absent leaves the column alone", `{"name":"x"}`, false, false, 0, false},
+		{"null clears it", `{"protein_g":null}`, true, true, 0, false},
+		{"empty string clears it", `{"protein_g":""}`, true, true, 0, false},
+		{"whitespace clears it", `{"protein_g":"   "}`, true, true, 0, false},
+		{"zero clears it", `{"protein_g":"0"}`, true, true, 0, false},
+		{"a string value sets it", `{"protein_g":"30"}`, true, false, 30, false},
+		{"a number value sets it", `{"protein_g":30}`, true, false, 30, false},
+		{"literal <nil> is rejected, not silently cleared", `{"protein_g":"<nil>"}`, false, false, 0, true},
+		{"a negative value is rejected", `{"protein_g":"-1"}`, false, false, 0, true},
+		{"over the cap is rejected", `{"protein_g":"1000"}`, false, false, 0, true},
+		{"a non-integer is rejected", `{"protein_g":"abc"}`, false, false, 0, true},
+		{"a fractional number is rejected", `{"protein_g":30.5}`, false, false, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updates, values, msg := buildEntryUpdates(decodeBody(t, tt.body), false)
+			if (msg != "") != tt.wantMsg {
+				t.Fatalf("message = %q, wantMsg = %v", msg, tt.wantMsg)
+			}
+			if tt.wantMsg {
+				return
+			}
+			idx := -1
+			for i, u := range updates {
+				if strings.HasPrefix(u, "protein_g") {
+					idx = i
+				}
+			}
+			if (idx >= 0) != tt.wantSet {
+				t.Fatalf("updates = %v, wantSet = %v", updates, tt.wantSet)
+			}
+			if !tt.wantSet {
+				return
+			}
+			if tt.wantNull {
+				if values[idx] != nil {
+					t.Errorf("bound value = %v, want NULL", values[idx])
+				}
+				return
+			}
+			if got, ok := values[idx].(int); !ok || got != tt.wantValue {
+				t.Errorf("bound value = %v, want %d", values[idx], tt.wantValue)
+			}
+		})
+	}
+}
+
+// TestBuildEntryUpdatesPlaceholdersAreSequential guards the contract UpdateEntry
+// relies on to append the WHERE-clause binds: fragment i uses $(i+1), and there
+// are exactly as many values as fragments. Getting this wrong misbinds every
+// column, which no amount of field-level testing would reveal.
+func TestBuildEntryUpdatesPlaceholdersAreSequential(t *testing.T) {
+	body := decodeBody(t, `{"name":"Porridge","amount":"250","protein_g":"30","carbs_g":null,"fat_g":"10","fiber_g":"5","sugar_g":"2"}`)
+	updates, values, msg := buildEntryUpdates(body, false)
+	if msg != "" {
+		t.Fatalf("unexpected rejection: %s", msg)
+	}
+	if len(updates) != len(values) {
+		t.Fatalf("%d fragments but %d values", len(updates), len(values))
+	}
+	if len(updates) != 7 {
+		t.Fatalf("updates = %v, want 7 fragments (name, amount, 5 macros)", updates)
+	}
+	for i, u := range updates {
+		want := fmt.Sprintf("$%d", i+1)
+		if !strings.HasSuffix(u, "= "+want) {
+			t.Errorf("fragment %d = %q, want it to bind %s", i, u, want)
+		}
+	}
+}
+
+// TestBuildEntryUpdatesEmptyBody documents that a body with nothing recognised
+// produces no fragments, which UpdateEntry turns into "No updates provided"
+// rather than an UPDATE with an empty SET clause (a SQL syntax error, i.e. a
+// 500 for the caller).
+func TestBuildEntryUpdatesEmptyBody(t *testing.T) {
+	for _, raw := range []string{`{}`, `{"unknown":"x"}`, `{"amount":"250"}`} {
+		updates, _, msg := buildEntryUpdates(decodeBody(t, raw), true) // autoCalc drops amount
+		if msg != "" {
+			t.Fatalf("%s: unexpected rejection: %s", raw, msg)
+		}
+		if len(updates) != 0 {
+			t.Errorf("%s: updates = %v, want none", raw, updates)
+		}
 	}
 }


### PR DESCRIPTION
Closes #303

## The bug

`POST /entries/:id/update` decodes into `map[string]any` and coerced every value with `fmt.Sprintf("%v", …)` **before** inspecting it. That renders a JSON `null` as the four-character string `"<nil>"`.

The `amount` and macro paths compared the coerced string against that `"<nil>"` sentinel to recover "this was null". The entry-name path did not:

```go
if v, ok := body["name"]; ok {
    name := truncateUTF8(strings.TrimSpace(fmt.Sprintf("%v", v)), 120)  // nil -> "<nil>"
    values = append(values, nilString(name))                            // non-empty -> stored
}
```

So `{"name": null}` — the documented way to clear a name — **renamed the entry to `<nil>`** and the card rendered those four characters to the user.

The sentinel was never sound in the other two paths either: a user who legitimately types `<nil>` as an entry name is indistinguishable from a null once the type has been thrown away. Designing that out is what this PR does.

## What changed

**`internal/handler/entries_helpers.go`**

- `optionalString(body, key) (*string, bool)` — the `map[string]any` counterpart of the v1 surface's `Optional[T]` (invariant #7). It checks the interface for nil **before** coercing, so absent / null / present stay apart and no sentinel is needed.
- `optionalEntryName(body, key)` — layers the entry-name rules on top: `MaxEntryNameBytes` (120) cap on a UTF-8 rune boundary, blank collapses to nil so the column is cleared rather than set to `""`.
- `buildEntryUpdates(body, autoCalc)` — `UpdateEntry`'s SET-clause construction, extracted **pure**. No request, no pool. This is what lets the absent/null/present matrix be asserted without a database; needing one is precisely why the bug shipped untested.

**`internal/handler/entries_crud.go`** — all four paths now agree. `CreateEntry` (`entry_name`, `amount`, `weight`, macros) and `UpdateEntry` (`name`, `amount`, macros) go through the helper. Every `"<nil>"` string comparison in the file is gone.

## Three-state semantics, now asserted

| body | column |
| --- | --- |
| key absent | left alone (no SET fragment emitted) |
| `{"name": null}` | cleared (`entry_name = NULL`) |
| `{"name": ""}` / `"   "` | cleared — what the SPA sends when the inline editor is emptied |
| `{"name": "<nil>"}` | stored verbatim as those four characters |
| `{"name": "Porridge"}` | set |

## Behaviour changes beyond the fix

Both narrow, both deliberate:

1. `amount` / macros sent as the **literal string** `"<nil>"` are now rejected with 400 instead of being silently overwritten with `0` / `NULL`. No client sends that string; only Go's own `%v` of a nil produces it.
2. `CreateEntry`'s `entry_name` now accepts non-string JSON (number, bool) and coerces it, as `UpdateEntry` has always done, instead of dropping it via a `.(string)` assertion. This is the "so all four agree" part of the issue's plan.

## Tests

`internal/handler/entries_test.go`, ~60 new table-driven cases:

- `TestOptionalString` — the full coercion matrix: key absent, empty body, `null`, `""`, `"   "`, tabs/newlines, a normal string, an untrimmed string, the literal `"<nil>"`, integer / fractional / negative / zero numbers, `true`, `false`, object, empty object, array, empty array, and an over-120-byte UTF-8 string (which this layer must **not** truncate).
- `TestOptionalEntryName` — the 120-byte cap, the rune-boundary walk-back (118 ASCII + a 4-byte 🥑 = 122 bytes, so cutting at 120 lands mid-emoji and must fall back to 118), a `utf8.ValidString` check so Postgres 22021 can't recur, and blank-clears-the-column.
- `TestBuildEntryUpdatesNameThreeStates` — the #303 regression proper, walking the same absent/null/present matrix `TestEntryPatchThreeStates` walks on v1 but through the `map[string]any` path this endpoint actually takes.
- `TestBuildEntryUpdatesAmount` / `TestBuildEntryUpdatesMacros` — three states per column plus the rejection cases (`amount` is NOT NULL so "cleared" is 0; macros are nullable and a literal `"0"` clears, preserved deliberately since `EntryList.tsx` relies on it).
- `TestBuildEntryUpdatesPlaceholdersAreSequential` — fragment *i* binds `$(i+1)` and `len(updates) == len(values)`, the contract `UpdateEntry` relies on to append the WHERE binds. Getting this wrong misbinds every column and no field-level test would notice.
- `TestBuildEntryUpdatesEmptyBody` — no fragments means "No updates provided" rather than an `UPDATE … SET  WHERE` syntax error (a 500 for the caller).

`e2e/entry-edit.spec.ts`, two Playwright regressions:

- clearing a name with an explicit JSON `null` (via `page.request`, since the SPA itself sends `""` — the null path is only reachable from a non-browser client) asserts the response payload's `name` is `null`, then reloads and asserts the card renders the `—` placeholder and `<nil>` appears **nowhere** on the page;
- clearing through the inline editor asserts the same.

## Verification

```
$ export GOFLAGS=-p=2 GOMAXPROCS=2
$ go build ./...
$ go vet ./...
$ go test ./...
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	(cached)
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	(cached)
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	(cached)
ok  	schautrack/internal/handler	1.400s
ok  	schautrack/internal/middleware	(cached)
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	(cached)
ok  	schautrack/internal/release	(cached)
ok  	schautrack/internal/service	(cached)
ok  	schautrack/internal/session	(cached)
ok  	schautrack/internal/sse	(cached)
```

All 60 new cases pass under `go test ./internal/handler/ -run 'Entr|Optional' -v`. `gofmt -l` reports none of the four touched files. `go vet ./...` is silent.

## ⚠️ The Playwright spec was NOT executed locally

`npm run test:e2e` builds Docker images and stands up a full app + Postgres stack; it was too heavy to run in this environment. **The two new specs in `e2e/entry-edit.spec.ts` are unrun** and should be treated as unverified until CI or a manual run exercises them. The Go tests above cover the same regression at the unit level and *were* run.

## Typecheck note

The repo has **no root `tsconfig.json`** covering `e2e/`, so the requested `npx tsc --noEmit -p .` does not apply — `e2e/` is not type-checked by CI at all (only `client/` is, via its own tsconfig). As a substitute the new spec was compiled standalone with the client's `tsc` (`--strict --target es2022 --moduleResolution bundler`) plus an ambient shim for the Node globals that `@types/node` would provide (it is not installed at the repo root): **exit 0, no errors**.

## Left alone deliberately

The same `"<nil>"` sentinel still lives in `internal/handler/weight.go` (`parseBodyFatUpdate`, `WeightDay` date handling) and `internal/handler/saved_foods.go` (`parseSavedFoodPayload` — name, emoji, amount, macros). Neither is *wrong* today (both nil-check first), but both would mishandle a user who types the literal `<nil>`, and `parseSavedFoodPayload`'s name path has the same shape the entry-name path had. Out of scope for #303 and owned by other specs; filed as a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)