### PR TITLE
feat: expose body_fat on the v1 weight API

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -3072,7 +3072,7 @@
       "put": {
         "operationId": "putWeight",
         "summary": "Record a day's weight",
-        "description": "Idempotent: repeating the same request is harmless, which makes it safe for a scale integration to retry. Returns 201 the first time a date is written and 200 thereafter.",
+        "description": "Idempotent: repeating the same request is harmless, which makes it safe for a scale integration to retry. Returns 201 the first time a date is written and 200 thereafter. `body_fat` is three-state: omit it and any stored reading for that day is left alone, send `null` to clear it, send a number to record it.",
         "tags": [
           "Weight"
         ],
@@ -4436,6 +4436,13 @@
         "type": "object",
         "description": "A weight reading. One per account per day.",
         "properties": {
+          "body_fat": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Body fat as a percentage, or `null` when the day carries no measurement."
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -4469,6 +4476,7 @@
         "required": [
           "date",
           "weight",
+          "body_fat",
           "unit",
           "created_at",
           "updated_at"
@@ -4478,6 +4486,15 @@
         "type": "object",
         "description": "A weight reading.",
         "properties": {
+          "body_fat": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Body fat as a percentage, rounded to one decimal. **Omit** to leave any stored reading for that day untouched — which is what makes a weight-only scale integration safe to retry. Send `null` to clear it. Writing a value switches the account's body-fat field on if it was off, so the reading is visible in the app; clearing never switches it back off.",
+            "minimum": 0.1,
+            "maximum": 75
+          },
           "weight": {
             "type": "number",
             "description": "The reading, in the account's unit.",

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -390,7 +390,7 @@ PUT /api/v1/weight/{date}
 
 **Scope:** `weight:write`
 
-Idempotent: repeating the same request is harmless, which makes it safe for a scale integration to retry. Returns 201 the first time a date is written and 200 thereafter.
+Idempotent: repeating the same request is harmless, which makes it safe for a scale integration to retry. Returns 201 the first time a date is written and 200 thereafter. `body_fat` is three-state: omit it and any stored reading for that day is left alone, send `null` to clear it, send a number to record it.
 
 | Parameter | In | Required | Description |
 | --- | --- | --- | --- |
@@ -1197,6 +1197,7 @@ A weight reading. One per account per day.
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
+| `body_fat` | `number` or `null` | yes | Body fat as a percentage, or `null` when the day carries no measurement. |
 | `created_at` | `string` (date-time) | yes | When first recorded (UTC). |
 | `date` | `string` (date) | yes | The day this reading belongs to. |
 | `unit` | `string` | yes | The account's weight unit. Readings are stored as entered and never converted. |
@@ -1209,6 +1210,7 @@ A weight reading.
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
+| `body_fat` | `number` or `null` |  | Body fat as a percentage, rounded to one decimal. **Omit** to leave any stored reading for that day untouched — which is what makes a weight-only scale integration safe to retry. Send `null` to clear it. Writing a value switches the account's body-fat field on if it was off, so the reading is visible in the app; clearing never switches it back off. |
 | `weight` | `number` | yes | The reading, in the account's unit. |
 
 ### WeightList

--- a/internal/handler/v1_weight.go
+++ b/internal/handler/v1_weight.go
@@ -1,12 +1,15 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"schautrack/internal/apierr"
+	"schautrack/internal/model"
 	"schautrack/internal/service"
 )
 
@@ -16,8 +19,14 @@ import (
 // converts — so the unit travels with every reading. A client that assumed
 // kilograms would silently mis-plot a pounds account.
 type v1Weight struct {
-	Date      string    `json:"date"`
-	Weight    float64   `json:"weight"`
+	Date   string  `json:"date"`
+	Weight float64 `json:"weight"`
+	// BodyFat is the optional percentage recorded with the reading. Always
+	// present in the JSON, null when the day carries no measurement — a
+	// composition scale reports weight and body fat together, and a client
+	// mirroring the app's data must be able to tell "not measured" apart from
+	// "field not returned".
+	BodyFat   *float64  `json:"body_fat"`
 	Unit      string    `json:"unit"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
@@ -90,7 +99,7 @@ func (h *V1Handler) ListWeight(w http.ResponseWriter, r *http.Request) {
 	args = append(args, limit+1)
 
 	rows, err := h.Pool.Query(r.Context(), fmt.Sprintf(
-		`SELECT entry_date, weight, created_at, updated_at FROM weight_entries
+		`SELECT entry_date, weight, body_fat, created_at, updated_at FROM weight_entries
 		 WHERE %s ORDER BY entry_date DESC LIMIT $%d`,
 		strings.Join(where, " AND "), len(args)), args...)
 	if err != nil {
@@ -107,7 +116,7 @@ func (h *V1Handler) ListWeight(w http.ResponseWriter, r *http.Request) {
 	out := []v1Weight{}
 	for rows.Next() {
 		e := v1Weight{Unit: unit}
-		if err := rows.Scan(&e.Date, &e.Weight, &e.CreatedAt, &e.UpdatedAt); err != nil {
+		if err := rows.Scan(&e.Date, &e.Weight, &e.BodyFat, &e.CreatedAt, &e.UpdatedAt); err != nil {
 			apierr.Write(w, r, dbFail("scan weight", err))
 			return
 		}
@@ -149,13 +158,49 @@ func (h *V1Handler) GetWeightV1(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeV1(w, http.StatusOK, v1Weight{
-		Date: entry.Date, Weight: entry.Weight, Unit: h.weightUnit(r),
+		Date: entry.Date, Weight: entry.Weight, BodyFat: entry.BodyFat,
+		Unit:      h.weightUnit(r),
 		CreatedAt: entry.CreatedAt, UpdatedAt: entry.UpdatedAt,
 	})
 }
 
 type v1WeightInput struct {
 	Weight float64 `json:"weight"`
+
+	// BodyFat is three-state, which is the whole reason it is Optional and not
+	// a *float64: absent leaves any stored reading alone, null clears it, a
+	// number sets it. Absent-means-keep is what lets a weight-only scale
+	// integration retry without erasing a measurement taken in the app.
+	BodyFat Optional[float64] `json:"body_fat"`
+}
+
+// bodyFatUpdate maps the Optional body_fat of a v1 request onto the three
+// states of a service.BodyFatUpdate. It is the same mapping the session route's
+// parseBodyFatUpdate performs, expressed against Optional rather than a decoded
+// map[string]any — the semantics are deliberately identical, so a reading
+// written through the API and one written in the app behave the same way.
+//
+// ok is false only when a value was supplied but is unusable, so the caller can
+// answer 422 rather than silently dropping it.
+func bodyFatUpdate(in Optional[float64]) (service.BodyFatUpdate, bool) {
+	if !in.Set {
+		return service.KeepBodyFat, true
+	}
+	if in.Value == nil {
+		return service.BodyFatUpdate{Set: true}, true
+	}
+	// service.ParseBodyFat takes a string because the UI and the import path
+	// both hand it one; reusing it is what keeps the API's accepted range
+	// identical to the app's. Formatting at fixed precision rather than %v
+	// keeps a float that Go would render as 22.499999999999996 within the
+	// parser's 12-byte input cap — the parser rounds to one decimal anyway, so
+	// nothing meaningful is lost, and a client computing a percentage is not
+	// rejected over spurious digits.
+	pct, ok := service.ParseBodyFat(strconv.FormatFloat(*in.Value, 'f', 4, 64))
+	if !ok {
+		return service.BodyFatUpdate{}, false
+	}
+	return service.BodyFatUpdate{Set: true, Value: &pct}, true
 }
 
 // PutWeightV1 handles PUT /api/v1/weight/{date} — an upsert.
@@ -185,6 +230,19 @@ func (h *V1Handler) PutWeightV1(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validated before anything touches the database, so an out-of-range
+	// percentage is a 422 problem+json and never reaches the CHECK constraint
+	// that would surface it as a 500.
+	bodyFat, ok := bodyFatUpdate(in.BodyFat)
+	if !ok {
+		apierr.Write(w, r, apierr.Unprocessable("The body fat value is not usable.",
+			apierr.InvalidParam{
+				Name:   "body_fat",
+				Reason: fmt.Sprintf("must be a number greater than 0 and at most %g, or null to clear it", service.MaxBodyFatPct),
+			}))
+		return
+	}
+
 	user := v1User(r)
 	existing, err := service.GetWeightEntry(r.Context(), h.Pool, user.ID, date)
 	if err != nil {
@@ -192,10 +250,10 @@ func (h *V1Handler) PutWeightV1(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// KeepBodyFat: v1 does not expose the optional body-fat reading yet, and a
-	// weight-only writer (typically a smart-scale integration) must not erase
-	// one recorded in the app for the same day.
-	entry, err := service.UpsertWeightEntry(r.Context(), h.Pool, user.ID, date, parsed.Value, service.KeepBodyFat)
+	// An omitted body_fat still means KeepBodyFat: a weight-only writer
+	// (typically a smart-scale integration) must not erase a reading recorded
+	// in the app for the same day.
+	entry, err := h.upsertWeight(r.Context(), user, date, parsed.Value, bodyFat)
 	if err != nil {
 		apierr.Write(w, r, dbFail("upsert weight", err))
 		return
@@ -208,9 +266,48 @@ func (h *V1Handler) PutWeightV1(w http.ResponseWriter, r *http.Request) {
 	}
 	h.broadcastEntries(user.ID)
 	writeV1(w, status, v1Weight{
-		Date: entry.Date, Weight: entry.Weight, Unit: h.weightUnit(r),
+		Date: entry.Date, Weight: entry.Weight, BodyFat: entry.BodyFat,
+		Unit:      h.weightUnit(r),
 		CreatedAt: entry.CreatedAt, UpdatedAt: entry.UpdatedAt,
 	})
+}
+
+// upsertWeight writes the reading and, when the request actually carries a body
+// fat for an account that has never switched the field on, turns the opt-in on
+// in the same transaction.
+//
+// The flip mirrors what import already does, for the same reason: without it a
+// reading written by a composition scale is stored, feeds the planner's
+// Katch-McArdle BMR, and is nonetheless invisible and uneditable in the app
+// until the user happens to find the setting. `users.body_fat_enabled` governs
+// only whether the UI offers the field (see ToggleBodyFatEnabled) — it is not
+// an authorization gate — so turning it on grants nothing and destroys nothing.
+//
+// It is one-way. Clearing a reading with `null` must not switch the field back
+// off: other days may still carry measurements, and hiding the input as a side
+// effect of clearing one day would be a surprise the caller never asked for.
+func (h *V1Handler) upsertWeight(ctx context.Context, user *model.User, date string, weight float64, bodyFat service.BodyFatUpdate) (*service.WeightResult, error) {
+	if bodyFat.Value == nil || user.BodyFatEnabled {
+		return service.UpsertWeightEntry(ctx, h.Pool, user.ID, date, weight, bodyFat)
+	}
+
+	tx, err := h.Pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	entry, err := service.UpsertWeightEntry(ctx, tx, user.ID, date, weight, bodyFat)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := tx.Exec(ctx, "UPDATE users SET body_fat_enabled = TRUE WHERE id = $1", user.ID); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return entry, nil
 }
 
 // DeleteWeightV1 handles DELETE /api/v1/weight/{date}.

--- a/internal/handler/v1_weight_test.go
+++ b/internal/handler/v1_weight_test.go
@@ -1,0 +1,322 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"schautrack/internal/apierr"
+	"schautrack/internal/database"
+	"schautrack/internal/middleware"
+	"schautrack/internal/model"
+	"schautrack/internal/service"
+)
+
+// decodeWeightInput runs a raw body through the real v1 decoder, so these tests
+// exercise Optional's UnmarshalJSON rather than a hand-built struct — the whole
+// point of the type is that absent and explicit-null decode differently, and a
+// literal `v1WeightInput{}` would assert nothing about that.
+func decodeWeightInput(t *testing.T, raw string) v1WeightInput {
+	t.Helper()
+	var in v1WeightInput
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/weight/2026-08-08", strings.NewReader(raw))
+	if prob := decodeV1(httptest.NewRecorder(), req, &in); prob != nil {
+		t.Fatalf("decodeV1(%s) = problem %d %s", raw, prob.Status, prob.Detail)
+	}
+	return in
+}
+
+// TestV1WeightBodyFatOptionalStates pins the three-state mapping the public API
+// promises. Absent-means-keep is the load-bearing one: a smart scale that
+// reports weight only must never wipe a body fat recorded in the app for the
+// same day.
+func TestV1WeightBodyFatOptionalStates(t *testing.T) {
+	t.Run("absent leaves the stored reading alone", func(t *testing.T) {
+		in := decodeWeightInput(t, `{"weight":82.4}`)
+		got, ok := bodyFatUpdate(in.BodyFat)
+		if !ok {
+			t.Fatal("a weight-only body was rejected")
+		}
+		if got != service.KeepBodyFat {
+			t.Errorf("bodyFatUpdate = %+v, want KeepBodyFat — a weight-only writer would erase a reading", got)
+		}
+	})
+
+	t.Run("explicit null clears it", func(t *testing.T) {
+		in := decodeWeightInput(t, `{"weight":82.4,"body_fat":null}`)
+		got, ok := bodyFatUpdate(in.BodyFat)
+		if !ok {
+			t.Fatal("an explicit null was rejected")
+		}
+		if !got.Set || got.Value != nil {
+			t.Errorf("bodyFatUpdate = %+v, want {Set:true Value:nil}", got)
+		}
+	})
+
+	t.Run("a number sets it", func(t *testing.T) {
+		in := decodeWeightInput(t, `{"weight":82.4,"body_fat":22.5}`)
+		got, ok := bodyFatUpdate(in.BodyFat)
+		if !ok {
+			t.Fatal("a valid percentage was rejected")
+		}
+		if !got.Set || got.Value == nil {
+			t.Fatalf("bodyFatUpdate = %+v, want a value", got)
+		}
+		if *got.Value != 22.5 {
+			t.Errorf("value = %v, want 22.5", *got.Value)
+		}
+	})
+
+	// The column is NUMERIC(4,1) and ParseBodyFat rounds to match it. A client
+	// computing a percentage in floating point routinely produces digits past
+	// the first; those must round, not be rejected.
+	t.Run("float noise rounds instead of failing", func(t *testing.T) {
+		in := decodeWeightInput(t, `{"weight":82.4,"body_fat":22.499999999999996}`)
+		got, ok := bodyFatUpdate(in.BodyFat)
+		if !ok {
+			t.Fatal("a percentage with float noise was rejected; a computed value must round")
+		}
+		if got.Value == nil || *got.Value != 22.5 {
+			t.Errorf("value = %v, want 22.5", got.Value)
+		}
+	})
+
+	for _, raw := range []string{
+		`{"weight":82.4,"body_fat":0}`,
+		`{"weight":82.4,"body_fat":-3}`,
+		`{"weight":82.4,"body_fat":75.1}`,
+		`{"weight":82.4,"body_fat":1000}`,
+	} {
+		t.Run("out of range rejected: "+raw, func(t *testing.T) {
+			in := decodeWeightInput(t, raw)
+			if got, ok := bodyFatUpdate(in.BodyFat); ok {
+				t.Errorf("bodyFatUpdate = %+v, ok — the value is outside ParseBodyFat's range", got)
+			}
+		})
+	}
+}
+
+// putWeightRequest drives PutWeightV1 directly, wiring the {date} path param
+// chi would normally supply.
+func putWeightRequest(t *testing.T, h *V1Handler, ctx context.Context, date, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/weight/"+date, strings.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("date", date)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	h.PutWeightV1(rec, req)
+	return rec
+}
+
+// TestPutWeightV1RejectsOutOfRangeBodyFat is the guard against a 500.
+//
+// weight_entries carries a CHECK on the body_fat range; without validation in
+// the handler an out-of-bounds percentage would reach the database and come
+// back as a driver error, which dbFail turns into an opaque 500. The value must
+// be rejected before anything touches the pool — which is exactly why this test
+// can run with a nil pool and therefore runs in CI, unlike the round-trip below.
+func TestPutWeightV1RejectsOutOfRangeBodyFat(t *testing.T) {
+	h := &V1Handler{} // no pool: reaching one would panic and fail the test
+	rec := putWeightRequest(t, h, context.Background(), "2026-08-08", `{"weight":82.4,"body_fat":140}`)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422 (body %s)", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != apierr.ContentType {
+		t.Errorf("Content-Type = %q, want %q", ct, apierr.ContentType)
+	}
+
+	var prob struct {
+		Status        int    `json:"status"`
+		Type          string `json:"type"`
+		InvalidParams []struct {
+			Name   string `json:"name"`
+			Reason string `json:"reason"`
+		} `json:"invalid_params"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &prob); err != nil {
+		t.Fatalf("response is not JSON: %v (%s)", err, rec.Body.String())
+	}
+	if prob.Status != http.StatusUnprocessableEntity {
+		t.Errorf("problem.status = %d, want 422", prob.Status)
+	}
+	if len(prob.InvalidParams) != 1 || prob.InvalidParams[0].Name != "body_fat" {
+		t.Errorf("invalid_params = %+v, want one naming body_fat", prob.InvalidParams)
+	}
+}
+
+// TestV1WeightBodyFatRoundTrip walks the three Optional states through the real
+// handlers and the real database, and pins the body_fat_enabled flip.
+//
+// Skipped unless TEST_DATABASE_URL is set, matching the other integration tests:
+//
+//	docker run -d --rm --name pg-test -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:18
+//	TEST_DATABASE_URL='postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable' \
+//	  go test ./internal/handler/ -run TestV1WeightBodyFatRoundTrip -v
+func TestV1WeightBodyFatRoundTrip(t *testing.T) {
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// database.NewPool, not pgxpool.New: it registers the codec that returns
+	// DATE columns as "YYYY-MM-DD" strings, which every weight reader relies on.
+	pool, err := database.NewPool(ctx, url)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	if err := database.InitSchemaWithRetry(ctx, pool, 1); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	const email = "v1-body-fat@handler.test"
+	cleanup := func() { pool.Exec(ctx, `DELETE FROM users WHERE email = $1`, email) }
+	cleanup()
+	t.Cleanup(cleanup)
+
+	var userID int
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email, password_hash, email_verified, weight_unit, body_fat_enabled)
+		 VALUES ($1, 'x', true, 'kg', false) RETURNING id`, email).Scan(&userID); err != nil {
+		t.Fatalf("seeding the user failed: %v", err)
+	}
+
+	h := &V1Handler{Pool: pool}
+	const date = "2026-08-08"
+
+	// Reload the user the way RequireAPIToken would on each request, so the
+	// handler sees the real body_fat_enabled rather than a stale copy.
+	userCtx := func() context.Context {
+		t.Helper()
+		u := &model.User{ID: userID, Email: email, WeightUnit: "kg"}
+		if err := pool.QueryRow(ctx,
+			`SELECT body_fat_enabled FROM users WHERE id = $1`, userID).Scan(&u.BodyFatEnabled); err != nil {
+			t.Fatalf("reloading the user failed: %v", err)
+		}
+		return middleware.WithTestUser(ctx, u)
+	}
+	decodeWeight := func(rec *httptest.ResponseRecorder) v1Weight {
+		t.Helper()
+		var got v1Weight
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("response is not a weight: %v (%s)", err, rec.Body.String())
+		}
+		return got
+	}
+	storedBodyFat := func() *float64 {
+		t.Helper()
+		var pct *float64
+		if err := pool.QueryRow(ctx,
+			`SELECT body_fat FROM weight_entries WHERE user_id = $1 AND entry_date = $2`,
+			userID, date).Scan(&pct); err != nil {
+			t.Fatalf("reading body_fat back failed: %v", err)
+		}
+		return pct
+	}
+	bodyFatEnabled := func() bool {
+		t.Helper()
+		var on bool
+		if err := pool.QueryRow(ctx, `SELECT body_fat_enabled FROM users WHERE id = $1`, userID).Scan(&on); err != nil {
+			t.Fatalf("reading body_fat_enabled failed: %v", err)
+		}
+		return on
+	}
+
+	// 1. A number sets it — and switches the opt-in on, so the reading is not
+	//    stored invisibly behind a preference the user never found.
+	rec := putWeightRequest(t, h, userCtx(), date, `{"weight":82.4,"body_fat":22.5}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("first write: status = %d, want 201 (body %s)", rec.Code, rec.Body.String())
+	}
+	if got := decodeWeight(rec); got.BodyFat == nil || *got.BodyFat != 22.5 {
+		t.Errorf("first write returned body_fat = %v, want 22.5", got.BodyFat)
+	}
+	if pct := storedBodyFat(); pct == nil || *pct != 22.5 {
+		t.Errorf("stored body_fat = %v, want 22.5", pct)
+	}
+	if !bodyFatEnabled() {
+		t.Error("writing a body fat via the API left body_fat_enabled false; the reading is invisible in the app")
+	}
+
+	// 2. Absent leaves it alone. This is the scale-integration case: a
+	//    weight-only PUT for the same day must not erase the measurement.
+	rec = putWeightRequest(t, h, userCtx(), date, `{"weight":82.1}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("weight-only write: status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+	if got := decodeWeight(rec); got.BodyFat == nil || *got.BodyFat != 22.5 {
+		t.Errorf("weight-only write returned body_fat = %v, want the stored 22.5", got.BodyFat)
+	}
+	if pct := storedBodyFat(); pct == nil || *pct != 22.5 {
+		t.Errorf("a weight-only write changed the stored body_fat to %v; it must be left alone", pct)
+	}
+
+	// The readers must surface it too, or a client cannot mirror the app.
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/weight/"+date, nil)
+	getRctx := chi.NewRouteContext()
+	getRctx.URLParams.Add("date", date)
+	getRec := httptest.NewRecorder()
+	h.GetWeightV1(getRec, getReq.WithContext(context.WithValue(userCtx(), chi.RouteCtxKey, getRctx)))
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET: status = %d, want 200 (body %s)", getRec.Code, getRec.Body.String())
+	}
+	if got := decodeWeight(getRec); got.BodyFat == nil || *got.BodyFat != 22.5 {
+		t.Errorf("GET returned body_fat = %v, want 22.5", got.BodyFat)
+	}
+
+	listRec := httptest.NewRecorder()
+	h.ListWeight(listRec, httptest.NewRequest(http.MethodGet, "/api/v1/weight", nil).WithContext(userCtx()))
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("LIST: status = %d, want 200 (body %s)", listRec.Code, listRec.Body.String())
+	}
+	var page v1List[v1Weight]
+	if err := json.Unmarshal(listRec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("list response is not a page: %v (%s)", err, listRec.Body.String())
+	}
+	if len(page.Data) != 1 {
+		t.Fatalf("list returned %d readings, want 1", len(page.Data))
+	}
+	if page.Data[0].BodyFat == nil || *page.Data[0].BodyFat != 22.5 {
+		t.Errorf("list returned body_fat = %v, want 22.5", page.Data[0].BodyFat)
+	}
+
+	// 3. Explicit null clears it — but must not switch the opt-in back off:
+	//    other days may still carry readings.
+	rec = putWeightRequest(t, h, userCtx(), date, `{"weight":82.1,"body_fat":null}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clearing write: status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+	if got := decodeWeight(rec); got.BodyFat != nil {
+		t.Errorf("clearing write returned body_fat = %v, want null", *got.BodyFat)
+	}
+	if pct := storedBodyFat(); pct != nil {
+		t.Errorf("stored body_fat = %v after an explicit null, want NULL", *pct)
+	}
+	if !bodyFatEnabled() {
+		t.Error("clearing one day's body fat switched body_fat_enabled off; the flip is one-way")
+	}
+
+	// An out-of-range value is a 422 against a real database too — the CHECK
+	// constraint must never be the thing that rejects it.
+	rec = putWeightRequest(t, h, userCtx(), date, fmt.Sprintf(`{"weight":82.1,"body_fat":%g}`, service.MaxBodyFatPct+1))
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("out-of-range write: status = %d, want 422 (body %s)", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != apierr.ContentType {
+		t.Errorf("Content-Type = %q, want %q", ct, apierr.ContentType)
+	}
+}

--- a/internal/openapi/spec.go
+++ b/internal/openapi/spec.go
@@ -305,12 +305,20 @@ func schemas() map[string]*Schema {
 		"Weight": object("A weight reading. One per account per day.", map[string]*Schema{
 			"date":       dateStr("The day this reading belongs to."),
 			"weight":     number("The reading, in `unit`."),
+			"body_fat":   nullable(number("Body fat as a percentage, or `null` when the day carries no measurement.")),
 			"unit":       {Type: "string", Enum: []any{"kg", "lb"}, Description: "The account's weight unit. Readings are stored as entered and never converted."},
 			"created_at": dateTime("When first recorded (UTC)."),
 			"updated_at": dateTime("When last changed (UTC)."),
-		}, "date", "weight", "unit", "created_at", "updated_at"),
+		}, "date", "weight", "body_fat", "unit", "created_at", "updated_at"),
 		"WeightInput": object("A weight reading.", map[string]*Schema{
 			"weight": withRange(number("The reading, in the account's unit."), 0.01, 1500),
+			"body_fat": nullable(withRange(number(
+				"Body fat as a percentage, rounded to one decimal. **Omit** to leave any stored "+
+					"reading for that day untouched — which is what makes a weight-only scale "+
+					"integration safe to retry. Send `null` to clear it. Writing a value switches "+
+					"the account's body-fat field on if it was off, so the reading is visible in "+
+					"the app; clearing never switches it back off."),
+				0.1, service.MaxBodyFatPct)),
 		}, "weight"),
 		"WeightList": object("A page of weight readings, newest first.", map[string]*Schema{
 			"data":        array(ref("Weight"), "The readings."),
@@ -696,7 +704,8 @@ func paths() map[string]*PathItem {
 			},
 			Put: &Operation{
 				OperationID: "putWeight", Summary: "Record a day's weight",
-				Description: "Idempotent: repeating the same request is harmless, which makes it safe for a scale integration to retry. Returns 201 the first time a date is written and 200 thereafter.",
+				Description: "Idempotent: repeating the same request is harmless, which makes it safe for a scale integration to retry. Returns 201 the first time a date is written and 200 thereafter. " +
+					"`body_fat` is three-state: omit it and any stored reading for that day is left alone, send `null` to clear it, send a number to record it.",
 				Tags:        []string{"Weight"}, Scope: service.ScopeWeightWrite,
 				Security:    []SecurityRequirement{{"bearerAuth": {service.ScopeWeightWrite}}},
 				Parameters:  []Parameter{dateParam},


### PR DESCRIPTION
Closes #296

## What changed

Body fat was first-class everywhere except the public API. `/api/v1` can now read and write it.

- **`v1Weight` gains `body_fat`** (nullable, always present in the JSON so a client can tell "not measured" from "not returned"). `ListWeight` selects it alongside the other columns; `GetWeightV1` already read it via `service.GetWeightEntry` and now returns it.
- **`v1WeightInput` accepts `body_fat` as `Optional[float64]`** — invariant #7, never `**T`. Absent leaves the stored reading alone (today's `KeepBodyFat`, which is what stops a scale integration from wiping a measurement taken in the app), `null` clears it, a number sets it. That is exactly the mapping `parseBodyFatUpdate` already does on the session route; `bodyFatUpdate` is the same semantics expressed against `Optional` instead of a decoded `map[string]any`.
- **Validated through `service.ParseBodyFat`**, so the API and the UI accept the same range, and validated *before* anything touches the pool — an out-of-range percentage is a `422` `application/problem+json` naming `body_fat`, never the `weight_entries` CHECK constraint surfacing as a 500.
- `api/openapi.json` + `docs/api-v1.md` regenerated via `go run ./cmd/apidocs` (invariant #4), both committed.

One detail worth flagging: `ParseBodyFat` takes a string, so the float is formatted at fixed precision rather than with `%v`. A client that computes a percentage and sends `22.499999999999996` would otherwise blow the parser's 12-byte input cap and be rejected; it now rounds to `22.5`, which is what the `NUMERIC(4,1)` column stores anyway. Covered by a test.

## Decision: writing a body fat DOES flip `body_fat_enabled`

The issue flagged this as open. **Yes — it flips, one-way, in the same transaction as the upsert.**

Reasoning:

1. **It is the same situation import already handles, for the same reason.** Without the flip, a reading written by a composition scale is stored, feeds the planner's Katch-McArdle BMR, and is nonetheless invisible and uneditable in the app until the user stumbles on the setting. Import's comment says exactly this; there is no principled reason the API should behave differently from a restored export.
2. **The flag is not an authorization gate.** `ToggleBodyFatEnabled`'s own comment states it "only governs whether the UI offers the field — the upsert endpoints accept a `body_fat` regardless". Nothing in the planner or `service/bodycomp.go` consults it either. Flipping it grants no capability and destroys no data; it makes an already-stored value visible.
3. **Only an explicit non-null write flips it, and only from off.** An omitted `body_fat` never touches it, so a weight-only scale writer cannot enable a UI field the user never asked for.
4. **Clearing with `null` does NOT switch it back off.** Other days may still carry readings, and hiding the input as a side effect of clearing one day would be a surprise the caller never asked for. Asymmetry here is deliberate.

The flip runs inside a transaction with the upsert, so the two cannot half-land. The transaction is opened *only* when the flip is actually needed — the common weight-only path stays a single statement.

## Coordination with #295

No session-surface handler is touched. `service.UpsertWeightEntry` and `service.BodyFatUpdate` are used as-is — no signature change, nothing removed — so the `KeepWeight` three-state that #295 adds to the session weight upsert should merge on top without conflict. The only shared-layer contact point is that both changes revolve around `UpsertWeightEntry`; if #295 changes its signature, this call site (`internal/handler/v1_weight.go`, `upsertWeight`) needs the same treatment as the session one.

## Tests

`internal/handler/v1_weight_test.go`:

- `TestV1WeightBodyFatOptionalStates` — all three `Optional` states decoded through the real `decodeV1` (so `Optional.UnmarshalJSON` is genuinely exercised, not a hand-built struct), plus float-noise rounding and four out-of-range rejections. Runs in CI, no database.
- `TestPutWeightV1RejectsOutOfRangeBodyFat` — full handler, **nil pool**: proves validation happens before any database access. Asserts `422`, `application/problem+json`, and an `invalid_params` entry naming `body_fat`. Runs in CI.
- `TestV1WeightBodyFatRoundTrip` — `TEST_DATABASE_URL`-gated. Walks all three states through the real handlers and a real Postgres: a number sets it and flips `body_fat_enabled`; a weight-only PUT for the same day leaves the stored 22.5 untouched; `GET` and `LIST` both surface it; `null` clears the reading in the response and in the database but leaves the opt-in on; an out-of-range value is still `422` against a live database.

The round-trip test uses `database.NewPool` rather than `pgxpool.New` — the former registers the codec that returns `DATE` as `YYYY-MM-DD` strings, which every weight reader depends on. (`internal/handler/onboarding_test.go` uses raw `pgxpool.New` and gets away with it only because it scans no dates.)

## Verification

```
$ export GOFLAGS=-p=2 GOMAXPROCS=2
$ go build ./... && go vet ./...
$ go run ./cmd/apidocs
wrote api/openapi.json and docs/api-v1.md

$ go test ./...
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	0.023s
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	0.008s
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	0.007s
ok  	schautrack/internal/handler	1.439s
ok  	schautrack/internal/middleware	0.072s
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	0.035s
ok  	schautrack/internal/release	0.009s
ok  	schautrack/internal/service	0.234s
ok  	schautrack/internal/session	0.009s
ok  	schautrack/internal/sse	0.023s
```

Integration test against a real Postgres 18:

```
$ docker run -d --rm --name pg-296 -e POSTGRES_PASSWORD=postgres -p 55296:5432 postgres:18
$ TEST_DATABASE_URL='postgres://postgres:postgres@localhost:55296/postgres?sslmode=disable' \
    go test ./internal/handler/ -run TestV1WeightBodyFatRoundTrip -v
=== RUN   TestV1WeightBodyFatRoundTrip
2026/08/08 08:41:16 Schema initialization successful
--- PASS: TestV1WeightBodyFatRoundTrip (0.17s)
PASS
ok  	schautrack/internal/handler	0.181s

$ TEST_DATABASE_URL='...' go test ./internal/handler/...
ok  	schautrack/internal/handler	1.274s
```

`go test ./...` passing includes the docs-staleness check in `cmd/apidocs`, so the committed `api/openapi.json` and `docs/api-v1.md` match the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
