### PR TITLE
fix: bound the body-fat reading that picks the plan's BMR formula

### DIFF
--- a/client/src/i18n/locales/de/dashboard.json
+++ b/client/src/i18n/locales/de/dashboard.json
@@ -148,7 +148,9 @@
       "addHeightWeight": "Größe & Gewicht hinzufügen",
       "healthyRangeLabel": "Gesunder Bereich",
       "bodyFatLabel": "Körperfett",
-      "leanFatSplit": "{{lean}} {{unit}} Magermasse · {{fat}} {{unit}} Fett"
+      "leanFatSplit": "{{lean}} {{unit}} Magermasse · {{fat}} {{unit}} Fett",
+      "bodyFatMeasured": "Gemessen am {{date}}",
+      "bodyFatStale": "{{days}} Tage alt – nicht für dein Budget verwendet"
     },
     "recommendedBudget": {
       "title": "Empfohlenes Budget",
@@ -156,7 +158,8 @@
       "clampedNotice": "Auf ein sicheres Minimum begrenzt",
       "applyButton": "Als mein Kalorienziel übernehmen",
       "formulaKatch": "Nach Katch-McArdle, aus {{lean}} {{unit}} Magermasse",
-      "formulaMifflin": "Nach Mifflin-St Jeor. Trag einen Körperfettanteil ein für eine Schätzung über die Magermasse."
+      "formulaMifflin": "Nach Mifflin-St Jeor. Trag einen Körperfettanteil ein für eine Schätzung über die Magermasse.",
+      "formulaMifflinStale": "Basiert auf Mifflin-St Jeor – dein Körperfettwert ist {{days}} Tage alt und damit zu alt, um die Magermasse zu schätzen. Miss neu."
     },
     "progress": {
       "title": "Fortschritt",

--- a/client/src/i18n/locales/en/dashboard.json
+++ b/client/src/i18n/locales/en/dashboard.json
@@ -213,12 +213,15 @@
       "currentGoalLabel": "Current calorie goal: {{value}} kcal/day",
       "formulaKatch": "Based on Katch-McArdle, from {{lean}} {{unit}} of lean mass",
       "formulaMifflin": "Based on Mifflin-St Jeor. Log a body-fat percentage for a lean-mass estimate.",
+      "formulaMifflinStale": "Based on Mifflin-St Jeor — your body-fat reading is {{days}} days old, too old to estimate lean mass from. Log a new one.",
       "title": "Recommended Budget"
     },
     "status": {
       "addHeightWeight": "Add height & weight",
       "bmiLabel": "BMI",
       "bodyFatLabel": "Body Fat",
+      "bodyFatMeasured": "Measured {{date}}",
+      "bodyFatStale": "{{days}} days old — not used for your budget",
       "currentWeightLabel": "Current Weight",
       "healthyRangeLabel": "Healthy Range",
       "leanFatSplit": "{{lean}} {{unit}} lean · {{fat}} {{unit}} fat",

--- a/client/src/i18n/locales/es/dashboard.json
+++ b/client/src/i18n/locales/es/dashboard.json
@@ -148,7 +148,9 @@
       "addHeightWeight": "Añade altura y peso",
       "healthyRangeLabel": "Rango saludable",
       "bodyFatLabel": "Grasa corporal",
-      "leanFatSplit": "{{lean}} {{unit}} de masa magra · {{fat}} {{unit}} de grasa"
+      "leanFatSplit": "{{lean}} {{unit}} de masa magra · {{fat}} {{unit}} de grasa",
+      "bodyFatMeasured": "Medido el {{date}}",
+      "bodyFatStale": "{{days}} días de antigüedad: no se usa para tu presupuesto"
     },
     "recommendedBudget": {
       "title": "Presupuesto recomendado",
@@ -156,7 +158,8 @@
       "clampedNotice": "Ajustado a un mínimo seguro",
       "applyButton": "Aplicar como mi objetivo de calorías",
       "formulaKatch": "Según Katch-McArdle, a partir de {{lean}} {{unit}} de masa magra",
-      "formulaMifflin": "Según Mifflin-St Jeor. Registra un porcentaje de grasa corporal para una estimación por masa magra."
+      "formulaMifflin": "Según Mifflin-St Jeor. Registra un porcentaje de grasa corporal para una estimación por masa magra.",
+      "formulaMifflinStale": "Basado en Mifflin-St Jeor: tu medición de grasa corporal tiene {{days}} días, demasiado antigua para estimar la masa magra. Registra una nueva."
     },
     "progress": {
       "title": "Progreso",

--- a/client/src/i18n/locales/fr/dashboard.json
+++ b/client/src/i18n/locales/fr/dashboard.json
@@ -148,7 +148,9 @@
       "addHeightWeight": "Ajoutez taille et poids",
       "healthyRangeLabel": "Plage saine",
       "bodyFatLabel": "Masse grasse",
-      "leanFatSplit": "{{lean}} {{unit}} de masse maigre · {{fat}} {{unit}} de masse grasse"
+      "leanFatSplit": "{{lean}} {{unit}} de masse maigre · {{fat}} {{unit}} de masse grasse",
+      "bodyFatMeasured": "Mesuré le {{date}}",
+      "bodyFatStale": "{{days}} jours d’ancienneté — non utilisé pour votre budget"
     },
     "recommendedBudget": {
       "title": "Budget recommandé",
@@ -156,7 +158,8 @@
       "clampedNotice": "Limité à un minimum sûr",
       "applyButton": "Appliquer comme objectif calorique",
       "formulaKatch": "Selon Katch-McArdle, à partir de {{lean}} {{unit}} de masse maigre",
-      "formulaMifflin": "Selon Mifflin-St Jeor. Enregistrez un pourcentage de masse grasse pour une estimation par masse maigre."
+      "formulaMifflin": "Selon Mifflin-St Jeor. Enregistrez un pourcentage de masse grasse pour une estimation par masse maigre.",
+      "formulaMifflinStale": "Basé sur Mifflin-St Jeor — votre mesure de masse grasse date de {{days}} jours, trop ancienne pour estimer la masse maigre. Enregistrez-en une nouvelle."
     },
     "progress": {
       "title": "Progression",

--- a/client/src/i18n/locales/it/dashboard.json
+++ b/client/src/i18n/locales/it/dashboard.json
@@ -148,7 +148,9 @@
       "addHeightWeight": "Aggiungi altezza e peso",
       "healthyRangeLabel": "Intervallo salutare",
       "bodyFatLabel": "Grasso corporeo",
-      "leanFatSplit": "{{lean}} {{unit}} di massa magra · {{fat}} {{unit}} di grasso"
+      "leanFatSplit": "{{lean}} {{unit}} di massa magra · {{fat}} {{unit}} di grasso",
+      "bodyFatMeasured": "Misurato il {{date}}",
+      "bodyFatStale": "{{days}} giorni fa — non usato per il tuo budget"
     },
     "recommendedBudget": {
       "title": "Budget consigliato",
@@ -156,7 +158,8 @@
       "clampedNotice": "Limitato a un minimo sicuro",
       "applyButton": "Applica come mio obiettivo calorico",
       "formulaKatch": "Secondo Katch-McArdle, da {{lean}} {{unit}} di massa magra",
-      "formulaMifflin": "Secondo Mifflin-St Jeor. Registra una percentuale di grasso corporeo per una stima sulla massa magra."
+      "formulaMifflin": "Secondo Mifflin-St Jeor. Registra una percentuale di grasso corporeo per una stima sulla massa magra.",
+      "formulaMifflinStale": "Basato su Mifflin-St Jeor — la tua misurazione della massa grassa risale a {{days}} giorni fa, troppo vecchia per stimare la massa magra. Registrane una nuova."
     },
     "progress": {
       "title": "Progresso",

--- a/client/src/i18n/locales/nl/dashboard.json
+++ b/client/src/i18n/locales/nl/dashboard.json
@@ -148,7 +148,9 @@
       "addHeightWeight": "Voeg lengte & gewicht toe",
       "healthyRangeLabel": "Gezond bereik",
       "bodyFatLabel": "Vetpercentage",
-      "leanFatSplit": "{{lean}} {{unit}} vetvrije massa · {{fat}} {{unit}} vet"
+      "leanFatSplit": "{{lean}} {{unit}} vetvrije massa · {{fat}} {{unit}} vet",
+      "bodyFatMeasured": "Gemeten op {{date}}",
+      "bodyFatStale": "{{days}} dagen oud — niet gebruikt voor je budget"
     },
     "recommendedBudget": {
       "title": "Aanbevolen budget",
@@ -156,7 +158,8 @@
       "clampedNotice": "Beperkt tot een veilig minimum",
       "applyButton": "Toepassen als mijn caloriedoel",
       "formulaKatch": "Volgens Katch-McArdle, op basis van {{lean}} {{unit}} vetvrije massa",
-      "formulaMifflin": "Volgens Mifflin-St Jeor. Registreer een vetpercentage voor een schatting op basis van vetvrije massa."
+      "formulaMifflin": "Volgens Mifflin-St Jeor. Registreer een vetpercentage voor een schatting op basis van vetvrije massa.",
+      "formulaMifflinStale": "Gebaseerd op Mifflin-St Jeor — je vetpercentage is {{days}} dagen oud, te oud om vetvrije massa uit te schatten. Meet opnieuw."
     },
     "progress": {
       "title": "Voortgang",

--- a/client/src/i18n/locales/pl/dashboard.json
+++ b/client/src/i18n/locales/pl/dashboard.json
@@ -154,7 +154,9 @@
       "addHeightWeight": "Dodaj wzrost i wagę",
       "healthyRangeLabel": "Zdrowy zakres",
       "bodyFatLabel": "Tkanka tłuszczowa",
-      "leanFatSplit": "{{lean}} {{unit}} masy beztłuszczowej · {{fat}} {{unit}} tłuszczu"
+      "leanFatSplit": "{{lean}} {{unit}} masy beztłuszczowej · {{fat}} {{unit}} tłuszczu",
+      "bodyFatMeasured": "Zmierzono {{date}}",
+      "bodyFatStale": "sprzed {{days}} dni — nieużywane do Twojego budżetu"
     },
     "recommendedBudget": {
       "title": "Zalecany budżet",
@@ -162,7 +164,8 @@
       "clampedNotice": "Ograniczono do bezpiecznego minimum",
       "applyButton": "Zastosuj jako mój cel kaloryczny",
       "formulaKatch": "Według Katch-McArdle, na podstawie {{lean}} {{unit}} masy beztłuszczowej",
-      "formulaMifflin": "Według Mifflin-St Jeor. Zapisz procent tkanki tłuszczowej, aby oszacować na podstawie masy beztłuszczowej."
+      "formulaMifflin": "Według Mifflin-St Jeor. Zapisz procent tkanki tłuszczowej, aby oszacować na podstawie masy beztłuszczowej.",
+      "formulaMifflinStale": "Na podstawie Mifflin-St Jeor — Twój pomiar tkanki tłuszczowej ma {{days}} dni i jest zbyt stary, aby oszacować masę beztłuszczową. Zapisz nowy."
     },
     "progress": {
       "title": "Postęp",

--- a/client/src/i18n/locales/pt/dashboard.json
+++ b/client/src/i18n/locales/pt/dashboard.json
@@ -148,7 +148,9 @@
       "addHeightWeight": "Adicionar altura e peso",
       "healthyRangeLabel": "Intervalo Saudável",
       "bodyFatLabel": "Gordura Corporal",
-      "leanFatSplit": "{{lean}} {{unit}} de massa magra · {{fat}} {{unit}} de gordura"
+      "leanFatSplit": "{{lean}} {{unit}} de massa magra · {{fat}} {{unit}} de gordura",
+      "bodyFatMeasured": "Medido em {{date}}",
+      "bodyFatStale": "{{days}} dias de idade — não usado no teu orçamento"
     },
     "recommendedBudget": {
       "title": "Orçamento Recomendado",
@@ -156,7 +158,8 @@
       "clampedNotice": "Ajustado a um mínimo seguro",
       "applyButton": "Aplicar como o meu objetivo calórico",
       "formulaKatch": "Segundo Katch-McArdle, a partir de {{lean}} {{unit}} de massa magra",
-      "formulaMifflin": "Segundo Mifflin-St Jeor. Registe uma percentagem de gordura corporal para uma estimativa por massa magra."
+      "formulaMifflin": "Segundo Mifflin-St Jeor. Registe uma percentagem de gordura corporal para uma estimativa por massa magra.",
+      "formulaMifflinStale": "Baseado em Mifflin-St Jeor — a tua medição de gordura corporal tem {{days}} dias, demasiado antiga para estimar a massa magra. Regista uma nova."
     },
     "progress": {
       "title": "Progresso",

--- a/client/src/pages/Plan/Plan.tsx
+++ b/client/src/pages/Plan/Plan.tsx
@@ -7,6 +7,7 @@ import { useToastStore } from '@/stores/toastStore';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { cn } from '@/lib/utils';
+import { formatDate } from '@/lib/format';
 import MetricsForm from './MetricsForm';
 import GoalForm from './GoalForm';
 import PlanChart from './PlanChart';
@@ -154,6 +155,17 @@ export default function Plan() {
                   unit: weightUnit,
                 })}
               </div>
+              {/* Say how old the reading is. The percentage is carried forward
+                  onto today's weight, so an undated number would present a
+                  months-old measurement as if it were current. */}
+              <div className={cn('text-xs mt-1', composition.stale ? 'text-yellow-400' : 'text-muted-foreground')}>
+                {t('plan.status.bodyFatMeasured', { date: formatDate(composition.date) })}
+                {composition.stale && (
+                  /* stale implies ageDays > the server's window, so the plural
+                     wording in this string is always the right one. */
+                  <> · {t('plan.status.bodyFatStale', { days: composition.ageDays })}</>
+                )}
+              </div>
             </div>
           )}
           <div>
@@ -196,11 +208,16 @@ export default function Plan() {
                 <div className="text-xs text-yellow-400 mt-1">{t('plan.recommendedBudget.clampedNotice')}</div>
               )}
               {/* Name the estimator: switching to Katch-McArdle is the payoff
-                  for logging body fat, and it would otherwise be invisible. */}
+                  for logging body fat, and it would otherwise be invisible.
+                  When a reading exists but is too old to use, say that too —
+                  otherwise the fallback to Mifflin looks like the app ignoring
+                  a number the user did log. */}
               <div className="text-xs text-muted-foreground mt-1">
                 {data.computed.bmrFormula === 'katch_mcardle' && composition
                   ? t('plan.recommendedBudget.formulaKatch', { lean: composition.leanMass.toFixed(1), unit: weightUnit })
-                  : t('plan.recommendedBudget.formulaMifflin')}
+                  : composition?.stale
+                    ? t('plan.recommendedBudget.formulaMifflinStale', { days: composition.ageDays })
+                    : t('plan.recommendedBudget.formulaMifflin')}
               </div>
             </div>
             <Button onClick={handleApplyBudget} loading={applying}>{t('plan.recommendedBudget.applyButton')}</Button>

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -249,10 +249,23 @@ export interface CurvePoint {
 export interface BodyComposition {
   date: string;
   bodyFatPct: number;
-  /** In the user's weight unit, like every other weight on PlanResponse. */
+  /**
+   * In the user's weight unit, like every other weight on PlanResponse. This is
+   * the measured percentage applied to the weight the plan works from, i.e. the
+   * same lean mass the BMR was computed at — not the weight the reading was
+   * originally taken at.
+   */
   leanMass: number;
   fatMass: number;
   category: 'essential' | 'athletic' | 'fitness' | 'average' | 'obese' | null;
+  /** Whole days between the reading and today. Negative if dated ahead. */
+  ageDays: number;
+  /**
+   * True when the reading is too old to pick the BMR formula (server-side
+   * window). A stale reading is still shown — it is the user's latest
+   * measurement — but `computed.bmrFormula` will be `mifflin_st_jeor`.
+   */
+  stale: boolean;
 }
 
 export interface PlanComputed {

--- a/internal/handler/plan.go
+++ b/internal/handler/plan.go
@@ -115,6 +115,13 @@ func (h *PlanHandler) buildPlanInputs(r *http.Request, user *model.User) (servic
 	// The latest body-fat reading may be older than the latest weight (body
 	// composition is typically measured less often), so it is looked up
 	// separately and carries the weight it was taken with.
+	//
+	// The lookup is deliberately unbounded: the most recent reading is always
+	// worth *showing*, however old. Whether it is recent enough to pick the BMR
+	// formula is a separate question, decided in AssemblePlan against
+	// service.BodyFatRecencyDays — bounding the query instead would hide the
+	// reading and its date, leaving the user no way to see why the plan
+	// silently went back to Mifflin-St Jeor.
 	var bodyFat *service.BodyFatReading
 	lastBodyFat, err := service.GetLastBodyFatEntry(ctx, h.Pool, user.ID, "")
 	if err != nil {

--- a/internal/service/plan_assemble.go
+++ b/internal/service/plan_assemble.go
@@ -71,12 +71,49 @@ type PlanComputed struct {
 // FatMass are weights and therefore converted to the user's display unit
 // alongside every other weight in the payload; BodyFatPct is a percentage and
 // is never converted.
+//
+// LeanMass/FatMass are the percentage carried onto the weight the plan works
+// from — the same weight the BMR is computed at, never the weight the reading
+// happened to be taken at. Splitting those two produced a displayed lean mass
+// that disagreed with the lean mass the budget came from.
 type BodyComposition struct {
 	Date       string  `json:"date"`
 	BodyFatPct float64 `json:"bodyFatPct"`
 	LeanMass   float64 `json:"leanMass"`
 	FatMass    float64 `json:"fatMass"`
 	Category   *string `json:"category"` // nil when sex is unknown
+	// AgeDays is how many whole days before today the reading was taken, and
+	// Stale reports whether that puts it outside BodyFatRecencyDays. A stale
+	// reading is still returned — it is the user's most recent measurement and
+	// worth showing — but it does not drive BMR. Both fields exist so the UI can
+	// say how old the number is instead of presenting a two-year-old percentage
+	// as current.
+	AgeDays int  `json:"ageDays"`
+	Stale   bool `json:"stale"`
+}
+
+// BodyFatRecencyDays bounds how old a body-fat reading may be and still choose
+// the BMR formula. Body composition drifts; a percentage measured long ago and
+// carried onto today's weight can move the daily budget by well over 100 kcal
+// while reporting itself as the *more* accurate Katch-McArdle estimate. 90 days
+// is about as long as a reading stays credible for someone who actually owns a
+// composition scale, and it mirrors the recency bound the plan already applies
+// to the weight series. Outside the window the plan falls back to
+// Mifflin-St Jeor, which needs no composition input at all.
+const BodyFatRecencyDays = 90
+
+// BodyFatReadingAgeDays returns how many whole days old a YYYY-MM-DD reading is
+// relative to now's calendar date, plus whether the date parsed at all. A
+// reading dated ahead of now yields a negative age (the reading date is the
+// user's local date while now is the server's, so a few hours of skew is
+// normal); callers treat that as fresh rather than as an error.
+func BodyFatReadingAgeDays(readingDate string, now time.Time) (int, bool) {
+	d, err := time.Parse("2006-01-02", readingDate)
+	if err != nil {
+		return 0, false
+	}
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	return int(today.Sub(d).Hours() / 24), true
 }
 
 const (
@@ -143,16 +180,46 @@ func AssemblePlan(in PlanInputs) PlanResponse {
 		out.Series = append(out.Series, SeriesPoint{Date: p.Date.Format("2006-01-02"), Weight: p.Weight, BodyFat: p.BodyFat})
 	}
 
+	// baseWeight is the single weight everything downstream is anchored on: the
+	// latest logged weight, or the goal's start weight when nothing has been
+	// logged yet. It is resolved here, above the composition block, so the
+	// lean/fat split shown to the user is derived from exactly the weight the
+	// BMR is derived from. Computing them from two different weights is what let
+	// the displayed lean mass disagree with the lean mass the budget came from.
+	var baseWeight float64
+	var haveBaseWeight bool
+	switch {
+	case in.CurrentWeight != nil:
+		baseWeight, haveBaseWeight = *in.CurrentWeight, true
+	case in.Goal != nil:
+		baseWeight, haveBaseWeight = in.Goal.StartWeight, true
+	}
+
 	// Composition needs only a body-fat reading — no height, age or sex — so it
 	// is derived before (and independently of) the metrics-complete gate below.
+	// bodyFatFresh is the one place the recency window is decided; the BMR
+	// branch further down consults it rather than re-deriving the rule.
+	bodyFatFresh := false
 	if r := in.CurrentBodyFat; r != nil {
-		lean := LeanBodyMass(r.WeightKg, r.Pct)
+		// Carry the percentage onto baseWeight, not onto the weight the reading
+		// was taken at, so the split reported here is the split the BMR uses.
+		compWeight := r.WeightKg
+		if haveBaseWeight {
+			compWeight = baseWeight
+		}
+		lean := LeanBodyMass(compWeight, r.Pct)
 		if lean > 0 {
+			ageDays, dated := BodyFatReadingAgeDays(r.Date, in.Now)
+			// An unparseable date cannot be shown to be recent, so it is not
+			// trusted to pick the formula.
+			bodyFatFresh = dated && ageDays <= BodyFatRecencyDays
 			comp := &BodyComposition{
 				Date:       r.Date,
 				BodyFatPct: r.Pct,
 				LeanMass:   round1(lean),
-				FatMass:    round1(FatMass(r.WeightKg, r.Pct)),
+				FatMass:    round1(FatMass(compWeight, r.Pct)),
+				AgeDays:    ageDays,
+				Stale:      !bodyFatFresh,
 			}
 			if in.Sex != nil {
 				if cat := BodyFatCategory(Sex(*in.Sex), r.Pct); cat != "" {
@@ -215,19 +282,22 @@ func AssemblePlan(in PlanInputs) PlanResponse {
 	heightCm := *in.HeightCm
 	ageYears := in.Now.Year() - *in.BirthYear
 
-	baseWeight := goal.StartWeight
-	if in.CurrentWeight != nil {
-		baseWeight = *in.CurrentWeight
-	}
+	// baseWeight was resolved above the composition block; reaching here implies
+	// a non-nil goal, so it is always set.
 
 	// A measured body fat beats an estimate from height/age/sex: Katch–McArdle
 	// works off lean mass, which is what actually burns the calories. Anchor it
 	// on baseWeight (not the reading's own weight) so the projection starts
 	// where the plan does; the percentage is carried over on the assumption
-	// that composition has not swung since it was measured.
+	// that composition has not swung since it was measured — an assumption that
+	// only holds for a recent reading, which is what bodyFatFresh enforces.
+	// Outside BodyFatRecencyDays the reading is still reported (see
+	// out.Composition) but Mifflin-St Jeor drives the budget, because a stale
+	// percentage dressed up as Katch-McArdle is a wrong answer claiming to be
+	// the more accurate one.
 	bmrModel := MifflinModel(sex, heightCm, ageYears)
 	formula := BMRFormulaMifflin
-	if r := in.CurrentBodyFat; r != nil && LeanBodyMass(baseWeight, r.Pct) > 0 {
+	if r := in.CurrentBodyFat; r != nil && bodyFatFresh {
 		bmrModel = KatchMcArdleModel(baseWeight, r.Pct)
 		formula = BMRFormulaKatch
 	}

--- a/internal/service/plan_assemble_test.go
+++ b/internal/service/plan_assemble_test.go
@@ -342,6 +342,322 @@ func TestAssemblePlan(t *testing.T) {
 	})
 }
 
+func TestBodyFatReadingAgeDays(t *testing.T) {
+	now := time.Date(2026, 7, 19, 13, 45, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		date   string
+		want   int
+		wantOK bool
+	}{
+		{"same day is zero, not one", "2026-07-19", 0, true},
+		{"yesterday", "2026-07-18", 1, true},
+		{"exactly the window", "2026-04-20", BodyFatRecencyDays, true},
+		{"one day past the window", "2026-04-19", BodyFatRecencyDays + 1, true},
+		{"across a leap day", "2026-02-28", 141, true},
+		{"future date is negative, not an error", "2026-07-21", -2, true},
+		{"garbage date does not parse", "not-a-date", 0, false},
+		{"empty date does not parse", "", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := BodyFatReadingAgeDays(tt.date, now)
+			if ok != tt.wantOK {
+				t.Fatalf("BodyFatReadingAgeDays(%q) ok = %v, want %v", tt.date, ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Errorf("BodyFatReadingAgeDays(%q) = %d, want %d", tt.date, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("the wall-clock time of day never shifts the age", func(t *testing.T) {
+		// now carries 13:45; the reading is a bare date. Truncating both to a
+		// calendar day is what keeps a reading from ageing by a day mid-morning.
+		early := time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC)
+		late := time.Date(2026, 7, 19, 23, 59, 59, 0, time.UTC)
+		a, _ := BodyFatReadingAgeDays("2026-06-01", early)
+		b, _ := BodyFatReadingAgeDays("2026-06-01", late)
+		if a != b {
+			t.Errorf("age changed within one calendar day: %d vs %d", a, b)
+		}
+	})
+}
+
+// TestAssemblePlanBodyFatRecency covers the recency window that decides whether
+// a body-fat reading may pick the BMR formula. The shared profile below is
+// 180cm / 40 / male / sedentary at 100kg with a 30% reading, chosen because the
+// two formulas are far apart there: Katch-McArdle on 70kg of lean mass gives
+// 370 + 21.6*70 = 1882, Mifflin gives 10*100 + 6.25*180 - 5*40 + 5 = 1930.
+// Neither number can be produced by the other formula, so every assertion below
+// fails loudly if the window is not honoured.
+func TestAssemblePlanBodyFatRecency(t *testing.T) {
+	now := time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC)
+	const (
+		katchBMR   = 1882.0
+		mifflinBMR = 1930.0
+	)
+
+	// planAt builds the shared profile with a body-fat reading taken ageDays ago.
+	planAt := func(ageDays int) PlanResponse {
+		birthYear := now.Year() - 40
+		sex := "male"
+		activity := "sedentary"
+		return AssemblePlan(PlanInputs{
+			CurrentWeight: f64(100),
+			CurrentBodyFat: &BodyFatReading{
+				Date:     now.AddDate(0, 0, -ageDays).Format("2006-01-02"),
+				WeightKg: 100,
+				Pct:      30,
+			},
+			HeightCm: f64(180), BirthYear: &birthYear, Sex: &sex, ActivityLevel: &activity,
+			Goal: &model.WeightGoal{
+				ID: 20, UserID: 1, StartWeight: 100, StartDate: "2026-07-01",
+				TargetWeight: 85, PaceMode: "rate", RateKgPerWeek: f64(0.5), Status: "active",
+			},
+			Now: now,
+		})
+	}
+
+	t.Run("a fresh reading selects Katch-McArdle", func(t *testing.T) {
+		out := planAt(30)
+		if out.Computed == nil {
+			t.Fatal("expected a computed plan")
+		}
+		if out.Computed.BMRFormula != BMRFormulaKatch {
+			t.Errorf("bmrFormula = %q, want %q for a 30-day-old reading", out.Computed.BMRFormula, BMRFormulaKatch)
+		}
+		if !almost(out.Computed.BMR, katchBMR, 0.05) {
+			t.Errorf("bmr = %v, want %v (Katch-McArdle)", out.Computed.BMR, katchBMR)
+		}
+		if out.Composition == nil {
+			t.Fatal("expected composition")
+		}
+		if out.Composition.Stale {
+			t.Error("expected stale = false for a 30-day-old reading")
+		}
+		if out.Composition.AgeDays != 30 {
+			t.Errorf("ageDays = %d, want 30", out.Composition.AgeDays)
+		}
+	})
+
+	t.Run("a stale reading falls back to Mifflin-St Jeor", func(t *testing.T) {
+		// Two years old: the exact scenario from issue #300. Before the window
+		// existed this reported katch_mcardle — i.e. announced itself as the
+		// more accurate estimate — off a percentage measured two years earlier.
+		out := planAt(730)
+		if out.Computed == nil {
+			t.Fatal("expected a computed plan")
+		}
+		if out.Computed.BMRFormula != BMRFormulaMifflin {
+			t.Errorf("bmrFormula = %q, want %q for a two-year-old reading", out.Computed.BMRFormula, BMRFormulaMifflin)
+		}
+		if !almost(out.Computed.BMR, mifflinBMR, 0.05) {
+			t.Errorf("bmr = %v, want %v (Mifflin-St Jeor)", out.Computed.BMR, mifflinBMR)
+		}
+	})
+
+	t.Run("a stale reading is still reported, flagged, and dated", func(t *testing.T) {
+		// Dropping the reading would be the easy fix and the wrong one: the user
+		// would lose the composition panel and any way to see why the plan
+		// changed formula.
+		out := planAt(730)
+		if out.Composition == nil {
+			t.Fatal("expected a stale reading to still be surfaced")
+		}
+		if !out.Composition.Stale {
+			t.Error("expected stale = true for a two-year-old reading")
+		}
+		if out.Composition.AgeDays != 730 {
+			t.Errorf("ageDays = %d, want 730", out.Composition.AgeDays)
+		}
+		if out.Composition.Date != now.AddDate(0, 0, -730).Format("2006-01-02") {
+			t.Errorf("composition date = %q, want the reading's own date", out.Composition.Date)
+		}
+		if out.Composition.BodyFatPct != 30 {
+			t.Errorf("bodyFatPct = %v, want the measured 30", out.Composition.BodyFatPct)
+		}
+	})
+
+	// The boundary is pinned on both sides so a future >= / > slip, or a change
+	// to BodyFatRecencyDays itself, cannot pass silently.
+	t.Run("the last day inside the window still selects Katch-McArdle", func(t *testing.T) {
+		out := planAt(BodyFatRecencyDays)
+		if out.Computed.BMRFormula != BMRFormulaKatch {
+			t.Errorf("bmrFormula at exactly %d days = %q, want %q — the window is inclusive",
+				BodyFatRecencyDays, out.Computed.BMRFormula, BMRFormulaKatch)
+		}
+		if out.Composition.Stale {
+			t.Errorf("stale = true at exactly %d days, want false", BodyFatRecencyDays)
+		}
+	})
+
+	t.Run("the first day outside the window falls back to Mifflin", func(t *testing.T) {
+		out := planAt(BodyFatRecencyDays + 1)
+		if out.Computed.BMRFormula != BMRFormulaMifflin {
+			t.Errorf("bmrFormula at %d days = %q, want %q",
+				BodyFatRecencyDays+1, out.Computed.BMRFormula, BMRFormulaMifflin)
+		}
+		if !out.Composition.Stale {
+			t.Errorf("stale = false at %d days, want true", BodyFatRecencyDays+1)
+		}
+	})
+
+	t.Run("the window is 90 days", func(t *testing.T) {
+		// Pinned so widening the window is a deliberate edit with a visible diff,
+		// not something a refactor drifts into.
+		if BodyFatRecencyDays != 90 {
+			t.Errorf("BodyFatRecencyDays = %d, want 90", BodyFatRecencyDays)
+		}
+	})
+
+	t.Run("a reading dated in the future counts as fresh", func(t *testing.T) {
+		// The reading date is the user's local date and Now is the server's, so
+		// a reading can legitimately look a few hours ahead. Treating that as
+		// "infinitely stale" would break the plan for anyone east of the server.
+		out := planAt(-1)
+		if out.Computed.BMRFormula != BMRFormulaKatch {
+			t.Errorf("bmrFormula = %q, want %q for a future-dated reading", out.Computed.BMRFormula, BMRFormulaKatch)
+		}
+		if out.Composition.Stale {
+			t.Error("expected stale = false for a future-dated reading")
+		}
+	})
+
+	t.Run("an unparseable reading date is not trusted to pick the formula", func(t *testing.T) {
+		birthYear := now.Year() - 40
+		sex := "male"
+		activity := "sedentary"
+		out := AssemblePlan(PlanInputs{
+			CurrentWeight:  f64(100),
+			CurrentBodyFat: &BodyFatReading{Date: "whenever", WeightKg: 100, Pct: 30},
+			HeightCm:       f64(180), BirthYear: &birthYear, Sex: &sex, ActivityLevel: &activity,
+			Goal: &model.WeightGoal{
+				ID: 21, UserID: 1, StartWeight: 100, StartDate: "2026-07-01",
+				TargetWeight: 85, PaceMode: "rate", RateKgPerWeek: f64(0.5), Status: "active",
+			},
+			Now: now,
+		})
+		if out.Computed.BMRFormula != BMRFormulaMifflin {
+			t.Errorf("bmrFormula = %q, want %q when the reading date cannot be parsed",
+				out.Computed.BMRFormula, BMRFormulaMifflin)
+		}
+		if out.Composition == nil || !out.Composition.Stale {
+			t.Error("expected an undateable reading to be marked stale")
+		}
+	})
+}
+
+// TestAssemblePlanCompositionMatchesBMRInput is the second half of issue #300:
+// the lean mass shown to the user must be the lean mass the budget was computed
+// from, not the lean mass at the weight the reading happened to be taken at.
+func TestAssemblePlanCompositionMatchesBMRInput(t *testing.T) {
+	now := time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC)
+
+	t.Run("displayed lean mass is the weight the BMR used, not the reading's own", func(t *testing.T) {
+		// 30% measured at 100kg, user now at 75kg — the worked example from the
+		// issue. The reading's own weight would show 70.0kg lean; the BMR is
+		// computed at 75kg, i.e. 52.5kg lean. Those are the two candidate
+		// answers, and only one of them matches the budget.
+		birthYear := now.Year() - 40
+		sex := "male"
+		activity := "sedentary"
+		out := AssemblePlan(PlanInputs{
+			CurrentWeight: f64(75),
+			CurrentBodyFat: &BodyFatReading{
+				Date: now.AddDate(0, 0, -10).Format("2006-01-02"), WeightKg: 100, Pct: 30,
+			},
+			HeightCm: f64(180), BirthYear: &birthYear, Sex: &sex, ActivityLevel: &activity,
+			Goal: &model.WeightGoal{
+				ID: 22, UserID: 1, StartWeight: 100, StartDate: "2026-07-01",
+				TargetWeight: 70, PaceMode: "rate", RateKgPerWeek: f64(0.5), Status: "active",
+			},
+			Now: now,
+		})
+
+		if out.Composition == nil || out.Computed == nil {
+			t.Fatal("expected composition and a computed plan")
+		}
+		if out.Computed.BMRFormula != BMRFormulaKatch {
+			t.Fatalf("bmrFormula = %q, want %q — the rest of this test is about the Katch path",
+				out.Computed.BMRFormula, BMRFormulaKatch)
+		}
+		if !almost(out.Composition.LeanMass, 52.5, 0.05) {
+			t.Errorf("leanMass = %v, want 52.5 (75kg at 30%%), not 70 (the reading's own 100kg)",
+				out.Composition.LeanMass)
+		}
+		if !almost(out.Composition.FatMass, 22.5, 0.05) {
+			t.Errorf("fatMass = %v, want 22.5 (75kg at 30%%)", out.Composition.FatMass)
+		}
+		// The invariant, stated independently of the numbers above: inverting the
+		// reported BMR through Katch-McArdle must land back on the reported lean
+		// mass. 370 + 21.6*52.5 = 1504.
+		leanFromBMR := (out.Computed.BMR - 370) / 21.6
+		if !almost(leanFromBMR, out.Composition.LeanMass, 0.05) {
+			t.Errorf("BMR %v implies %v kg of lean mass but composition reports %v — "+
+				"the displayed split does not match the budget it produced",
+				out.Computed.BMR, leanFromBMR, out.Composition.LeanMass)
+		}
+		if !almost(out.Computed.BMR, 1504, 0.05) {
+			t.Errorf("bmr = %v, want 1504 per the issue's worked example", out.Computed.BMR)
+		}
+		// Lean + fat must still reconcile to the weight they were derived from.
+		if !almost(out.Composition.LeanMass+out.Composition.FatMass, 75, 0.05) {
+			t.Errorf("leanMass + fatMass = %v, want the 75kg they were derived from",
+				out.Composition.LeanMass+out.Composition.FatMass)
+		}
+	})
+
+	t.Run("with no logged weight the goal's start weight anchors both", func(t *testing.T) {
+		// baseWeight falls back to goal.StartWeight; composition must follow it
+		// rather than quietly reverting to the reading's own weight.
+		birthYear := now.Year() - 40
+		sex := "male"
+		activity := "sedentary"
+		out := AssemblePlan(PlanInputs{
+			CurrentWeight: nil,
+			CurrentBodyFat: &BodyFatReading{
+				Date: now.AddDate(0, 0, -5).Format("2006-01-02"), WeightKg: 100, Pct: 30,
+			},
+			HeightCm: f64(180), BirthYear: &birthYear, Sex: &sex, ActivityLevel: &activity,
+			Goal: &model.WeightGoal{
+				ID: 23, UserID: 1, StartWeight: 90, StartDate: "2026-07-01",
+				TargetWeight: 80, PaceMode: "rate", RateKgPerWeek: f64(0.5), Status: "active",
+			},
+			Now: now,
+		})
+		if out.Composition == nil || out.Computed == nil {
+			t.Fatal("expected composition and a computed plan")
+		}
+		if !almost(out.Composition.LeanMass, 63, 0.05) {
+			t.Errorf("leanMass = %v, want 63 (90kg start weight at 30%%)", out.Composition.LeanMass)
+		}
+		leanFromBMR := (out.Computed.BMR - 370) / 21.6
+		if !almost(leanFromBMR, out.Composition.LeanMass, 0.05) {
+			t.Errorf("BMR implies %v kg lean, composition reports %v", leanFromBMR, out.Composition.LeanMass)
+		}
+	})
+
+	t.Run("with neither a weight nor a goal the reading's own weight is used", func(t *testing.T) {
+		// Nothing else exists to anchor on, and no BMR is computed either, so
+		// there is nothing to disagree with.
+		out := AssemblePlan(PlanInputs{
+			CurrentBodyFat: &BodyFatReading{Date: "2026-07-15", WeightKg: 80, Pct: 20},
+			Now:            now,
+		})
+		if out.Composition == nil {
+			t.Fatal("expected composition from the reading alone")
+		}
+		if !almost(out.Composition.LeanMass, 64, 0.05) {
+			t.Errorf("leanMass = %v, want 64 (the reading's own 80kg at 20%%)", out.Composition.LeanMass)
+		}
+		if out.Computed != nil {
+			t.Error("expected no computed plan without a goal")
+		}
+	})
+}
+
 func hasWarning(warnings []PlanWarning, code string) bool {
 	for _, w := range warnings {
 		if w.Code == code {

--- a/internal/service/plan_units.go
+++ b/internal/service/plan_units.go
@@ -32,8 +32,9 @@ func FromKg(v float64, unit string) float64 {
 // ConvertPlanResponseToDisplayUnit converts the weight-VALUED fields of a
 // kg-computed PlanResponse into the user's display unit, in place. Leaves
 // unit-independent fields untouched: BMI, BMICategory, BudgetKcal, ETAWeeks,
-// ProjectedWeeks, Status strings, Composition.BodyFatPct (a percentage), and
-// Metrics.HeightCm (cm, not a weight).
+// ProjectedWeeks, Status strings, Composition.BodyFatPct (a percentage),
+// Composition.AgeDays/Stale (a duration and a flag), and Metrics.HeightCm
+// (cm, not a weight).
 // Rounds to 1 decimal to match the app's weight display.
 func ConvertPlanResponseToDisplayUnit(r *PlanResponse, unit string) {
 	if normUnit(unit) == "kg" {

--- a/internal/service/plan_units_test.go
+++ b/internal/service/plan_units_test.go
@@ -49,7 +49,7 @@ func TestConvertPlanResponseToDisplayUnit(t *testing.T) {
 			BMI:           &bmi,
 			Series:        []SeriesPoint{{Date: "2026-07-01", Weight: 91}},
 			HealthyRange:  &HealthyRange{MinKg: 59.9, MaxKg: 80.7},
-			Composition:   &BodyComposition{Date: "2026-07-01", BodyFatPct: 24.3, LeanMass: 68.1, FatMass: 21.9},
+			Composition:   &BodyComposition{Date: "2026-07-01", BodyFatPct: 24.3, LeanMass: 68.1, FatMass: 21.9, AgeDays: 120, Stale: true},
 			Computed: &PlanComputed{
 				BudgetKcal:    2000,
 				RateKgPerWeek: 0.34,
@@ -117,6 +117,17 @@ func TestConvertPlanResponseToDisplayUnit(t *testing.T) {
 		// A percentage is the same number in kg and lb.
 		if r.Composition.BodyFatPct != 24.3 {
 			t.Errorf("Composition.BodyFatPct must not be converted, got %v", r.Composition.BodyFatPct)
+		}
+		// The reading's age is a duration and its staleness a verdict; a lb user
+		// must not be told their reading is 2.2x older than a kg user's.
+		if r.Composition.AgeDays != 120 {
+			t.Errorf("Composition.AgeDays must not be converted, got %d", r.Composition.AgeDays)
+		}
+		if !r.Composition.Stale {
+			t.Error("Composition.Stale must survive unit conversion")
+		}
+		if r.Composition.Date != "2026-07-01" {
+			t.Errorf("Composition.Date must not change, got %q", r.Composition.Date)
 		}
 	})
 


### PR DESCRIPTION
Closes #300

## The bug

`GetLastBodyFatEntry(ctx, pool, user.ID, "")` means "the newest reading that exists", however old, and `AssemblePlan` handed the whole calorie budget to it. A two-year-old reading silently switched the BMR from Mifflin-St Jeor to Katch-McArdle, moved the daily budget by ~175 kcal, propagated that into the projected curve and the ETA — and reported `bmrFormula: "katch_mcardle"`, i.e. announced itself as the *more* accurate estimate.

Second, smaller bug in the same code: `Composition.LeanMass` was computed from the weight the reading was taken at while the BMR used the current weight, so the lean mass shown to the user was not the lean mass the budget came from. The budget card literally prints that number ("Based on Katch-McArdle, from {lean} kg of lean mass") while the BMR behind it used a different one.

## The window: 90 days

A reading may pick the BMR formula only within `service.BodyFatRecencyDays = 90`. Reasoning:

- It matches how often a composition scale is realistically used — someone who owns one steps on it well inside a quarter, and someone who does not has no business driving a Katch-McArdle budget off a one-off reading.
- It mirrors the recency bound the plan already applies to the weight series (179 days) — the codebase already accepts that "how old is this data" is a real question here, the body-fat lookup just never asked it.
- Outside the window it falls back to Mifflin-St Jeor, which needs no composition input at all, so there is always a defined answer.

The boundary is inclusive: exactly 90 days old still selects Katch-McArdle, 91 falls back. Both sides are pinned by tests, as is the constant itself.

## The lookup stays unbounded — deliberately

Bounding the SQL query was the obvious reading of the issue, and it is the wrong fix: it would drop the reading entirely, taking the composition panel and `Composition.Date` with it, and leaving the user no way to see *why* the plan quietly went back to Mifflin. So the query still returns the latest reading; whether it is recent enough to choose a formula is decided in `AssemblePlan`, which is also the pure, DB-free place where it can be unit-tested. A comment at the call site in `plan.go` says so, since that is the line the issue points at.

## Changes

**`internal/service/plan_assemble.go`**
- `BodyFatRecencyDays = 90` and `BodyFatReadingAgeDays(readingDate, now)`, which compares calendar days so the age never shifts with the time of day, and returns a negative age (treated as fresh) for a reading dated ahead of the server — the reading date is the user's local date, so a few hours of skew is normal.
- `baseWeight` is resolved **once**, above the composition block, instead of separately inside the goal block. Composition and BMR now provably derive from the same weight. When nothing is logged and there is no goal, composition falls back to the reading's own weight — nothing else exists to anchor on, and no BMR is computed there either.
- `BodyComposition` gains `ageDays` and `stale`. A stale reading is still returned and still shown; it just does not drive BMR.

**`internal/handler/plan.go`** — comment only, explaining why the lookup is unbounded.

**`internal/service/plan_units.go`** — `ageDays`/`stale` documented as unit-independent (a lb user must not be told their reading is 2.2x older).

**Client** (small): the body-fat tile now states the measurement date, and when stale its age plus the fact that it is not driving the budget; the budget card explains the Mifflin fallback rather than looking like the app ignored a reading the user did log. Three new strings, translated into all eight locales.

## Note for #301 (`openapi-plan-schema`)

This adds two fields to `BodyComposition`: `ageDays` (integer) and `stale` (boolean). The `Plan` schema is currently `AdditionalProperties: true` with no declared properties, so **`api/openapi.json` and `docs/api-v1.md` are byte-identical after `go run ./cmd/apidocs`** — verified, no regeneration needed, no file conflict. #301 should include the two new fields when it declares the schema. Nothing else in the plan response shape changed.

## Verification

`go build ./... && go vet ./... && go test ./...`:

```
=== BUILD OK ===
=== VET OK ===
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	(cached)
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	(cached)
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	(cached)
ok  	schautrack/internal/handler	1.001s
ok  	schautrack/internal/middleware	(cached)
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	0.026s
ok  	schautrack/internal/release	(cached)
ok  	schautrack/internal/service	0.225s
ok  	schautrack/internal/session	(cached)
ok  	schautrack/internal/sse	(cached)
```

New tests (`go test ./internal/service/ -run 'TestBodyFatReadingAgeDays|TestAssemblePlanBodyFatRecency|TestAssemblePlanCompositionMatchesBMRInput' -v`):

```
--- PASS: TestBodyFatReadingAgeDays (0.00s)
    --- PASS: TestBodyFatReadingAgeDays/same_day_is_zero,_not_one (0.00s)
    --- PASS: TestBodyFatReadingAgeDays/yesterday (0.00s)
    --- PASS: TestBodyFatReadingAgeDays/exactly_the_window (0.00s)
    --- PASS: TestBodyFatReadingAgeDays/one_day_past_the_window (0.00s)
    --- PASS: TestBodyFatReadingAgeDays/across_a_leap_day (0.00s)
    --- PASS: TestBodyFatReadingAgeDays/future_date_is_negative,_not_an_error (0.00s)
    --- PASS: TestBodyFatReadingAgeDays/garbage_date_does_not_parse (0.00s)
    --- PASS: TestBodyFatReadingAgeDays/empty_date_does_not_parse (0.00s)
    --- PASS: TestBodyFatReadingAgeDays/the_wall-clock_time_of_day_never_shifts_the_age (0.00s)
--- PASS: TestAssemblePlanBodyFatRecency (0.00s)
    --- PASS: TestAssemblePlanBodyFatRecency/a_fresh_reading_selects_Katch-McArdle (0.00s)
    --- PASS: TestAssemblePlanBodyFatRecency/a_stale_reading_falls_back_to_Mifflin-St_Jeor (0.00s)
    --- PASS: TestAssemblePlanBodyFatRecency/a_stale_reading_is_still_reported,_flagged,_and_dated (0.00s)
    --- PASS: TestAssemblePlanBodyFatRecency/the_last_day_inside_the_window_still_selects_Katch-McArdle (0.00s)
    --- PASS: TestAssemblePlanBodyFatRecency/the_first_day_outside_the_window_falls_back_to_Mifflin (0.00s)
    --- PASS: TestAssemblePlanBodyFatRecency/the_window_is_90_days (0.00s)
    --- PASS: TestAssemblePlanBodyFatRecency/a_reading_dated_in_the_future_counts_as_fresh (0.00s)
    --- PASS: TestAssemblePlanBodyFatRecency/an_unparseable_reading_date_is_not_trusted_to_pick_the_formula (0.00s)
--- PASS: TestAssemblePlanCompositionMatchesBMRInput (0.00s)
    --- PASS: TestAssemblePlanCompositionMatchesBMRInput/displayed_lean_mass_is_the_weight_the_BMR_used,_not_the_reading's_own (0.00s)
    --- PASS: TestAssemblePlanCompositionMatchesBMRInput/with_no_logged_weight_the_goal's_start_weight_anchors_both (0.00s)
    --- PASS: TestAssemblePlanCompositionMatchesBMRInput/with_neither_a_weight_nor_a_goal_the_reading's_own_weight_is_used (0.00s)
PASS
ok  	schautrack/internal/service	0.008s
```

The lean-mass test reproduces the issue's worked example directly (30% measured at 100 kg, user now at 75 kg) and asserts the invariant independently of the literals: inverting the reported BMR through Katch-McArdle, `(bmr - 370) / 21.6`, must land back on the reported lean mass (52.5 kg, BMR 1504).

Client (`npm ci && npm run typecheck && npm test && npm run i18n:drift && npm run i18n:check`):

```
> typecheck
> tsc -b --force

 Test Files  9 passed (9)
      Tests  121 passed (121)

> i18n:drift
> i18next-cli extract --ci
✔ Extraction complete!
✅ No files were updated.

> i18n:check
> node scripts/i18n-parity.mjs
✓ de: 820 keys (parity with en: 818)
✓ es: 820 keys (parity with en: 818)
✓ fr: 820 keys (parity with en: 818)
✓ it: 820 keys (parity with en: 818)
✓ nl: 820 keys (parity with en: 818)
✓ pl: 844 keys (parity with en: 818)
✓ pt: 820 keys (parity with en: 818)

i18n parity check passed.
```

`go run ./cmd/apidocs` produced no change to `api/openapi.json` or `docs/api-v1.md` (verified with `git status`).

Not run, per instructions: `npm run test:e2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)