### PR TITLE
feat: expose every RATE_LIMIT_* knob as a Helm value

### DIFF
--- a/helm/schautrack/Chart.yaml
+++ b/helm/schautrack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: schautrack
 description: A simple nutrition tracking web application
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: "0.1.9"
 keywords:
   - nutrition

--- a/helm/schautrack/README.md
+++ b/helm/schautrack/README.md
@@ -192,6 +192,33 @@ smtp:
   secure: false
 ```
 
+### Tuning rate limits
+
+Every limit the application enforces is exposed under `config.rateLimit`. Each
+one is **optional**: leave it empty and the chart omits the environment
+variable entirely, so the application's own default applies.
+
+```yaml
+config:
+  # Trust X-Forwarded-For — decides whether buckets key on the real client IP
+  # or on your ingress controller's. Leave at the default (true) behind an
+  # ingress; set "false" for direct-access deployments.
+  trustProxy: ""
+  rateLimit:
+    strict: 15   # let API clients run 15 AI estimates per 5 min instead of 5
+    apiToken: 120
+```
+
+> **Do not paste the defaults in.** Setting `auth: 10` looks harmless but pins
+> your deployment to the value the chart author last copied; if the application
+> changes its default, your release will not follow. Set only what you actually
+> want to differ. A value of `0` is treated as unset by the application, so it
+> means "use the default" rather than "block everything".
+
+Behind an ingress, `config.trustProxy` must stay at its default (`true`) or
+every request will share one bucket keyed by the ingress controller's IP, and
+the per-IP limits below become effectively global.
+
 ## Parameters
 
 ### Global
@@ -227,6 +254,26 @@ smtp:
 | `config.stepUpTTL` | Step-up auth grace window after login before sensitive auth-method changes require re-prompting. Any Go duration (e.g. `5s`, `10m`, `1h`); empty = server default of 30m | `""` |
 | `config.androidPackageName` | Package name for Android App Links (`/.well-known/assetlinks.json`) | `to.schauer.schautrack` |
 | `config.androidCertFingerprints` | Comma-separated SHA-256 signing-cert fingerprint(s) for App Links (**deployment-specific**; empty disables the endpoint) | `""` |
+
+### Rate limiting
+
+All optional. An empty value omits the environment variable, leaving the
+application's own default in force — the "Default" column below is that
+application default, not a value this chart writes into the ConfigMap. See
+[Tuning rate limits](#tuning-rate-limits).
+
+| Parameter | Env var | Description | Default |
+|-----------|---------|-------------|---------|
+| `config.rateLimit.auth` | `RATE_LIMIT_AUTH` | Authentication attempts per IP per **15 minutes** on login, register, and step-up re-auth | `""` (`10`) |
+| `config.rateLimit.strict` | `RATE_LIMIT_STRICT` | Requests per IP per **5 minutes** on sensitive endpoints: password-reset request/confirm, 2FA reset, email-change request, and **AI estimate**. Raise this to give users more AI throughput. | `""` (`5`) |
+| `config.rateLimit.api` | `RATE_LIMIT_API` | Requests per IP per **minute** on the public API (`/api/v1`). The outer guard and the only limit that throttles unauthenticated traffic; keep it well above the auth limiters. | `""` (`120`) |
+| `config.rateLimit.apiToken` | `RATE_LIMIT_API_TOKEN` | Requests per personal access token per **minute** on `/api/v1`. The limit a legitimate API client hits; per-IP alone means everyone behind one NAT shares a bucket. | `""` (`60`) |
+| `config.trustProxy` | `TRUST_PROXY` | Whether the limiters above key on `X-Forwarded-For` / `X-Real-Ip` instead of the socket peer. Leave default behind an ingress. | `""` (`true`) |
+
+Both API limits reject with `429` and a `Retry-After` header.
+
+The barcode-lookup limiter (30 per minute) is not configurable in this release;
+see [issue #366](https://github.com/schaurian/schautrack/issues/366).
 
 ### AI
 
@@ -336,7 +383,14 @@ smtp:
 ## Upgrading
 
 The chart follows semantic versioning; no breaking changes have been released
-through the current `0.2.x` series. `helm upgrade` in place is safe.
+through the current `0.3.x` series. `helm upgrade` in place is safe.
+
+### 0.3.0
+
+- Exposed the rate limits (`config.rateLimit.auth`, `.strict`, `.api`,
+  `.apiToken`). All default to empty, which omits the environment variable and
+  leaves the application's own default in force — so upgrading from `0.2.x`
+  changes no running limit.
 
 ### 0.2.x
 

--- a/helm/schautrack/templates/configmap.yaml
+++ b/helm/schautrack/templates/configmap.yaml
@@ -57,6 +57,20 @@ data:
   {{- if .Values.config.trustProxy }}
   TRUST_PROXY: {{ .Values.config.trustProxy | quote }}
   {{- end }}
+  {{- with .Values.config.rateLimit }}
+  {{- if .auth }}
+  RATE_LIMIT_AUTH: {{ .auth | quote }}
+  {{- end }}
+  {{- if .strict }}
+  RATE_LIMIT_STRICT: {{ .strict | quote }}
+  {{- end }}
+  {{- if .api }}
+  RATE_LIMIT_API: {{ .api | quote }}
+  {{- end }}
+  {{- if .apiToken }}
+  RATE_LIMIT_API_TOKEN: {{ .apiToken | quote }}
+  {{- end }}
+  {{- end }}
   {{- if .Values.config.robotsIndex }}
   ROBOTS_INDEX: {{ .Values.config.robotsIndex | quote }}
   {{- end }}

--- a/helm/schautrack/values.yaml
+++ b/helm/schautrack/values.yaml
@@ -122,6 +122,30 @@ config:
   # Trust X-Forwarded-For headers for rate limiting (default: true)
   # Set to "false" for direct-access deployments without a reverse proxy
   trustProxy: ""
+  # Rate limits. Every value here is OPTIONAL: leave it empty and the chart
+  # omits the environment variable entirely, so the app's own compiled-in
+  # default applies. Do not copy the defaults in — pinning them here freezes
+  # your deployment at whatever the app shipped when you wrote the file.
+  # A value of 0 is treated as unset by the app, so it also means "default".
+  # Which client each bucket is keyed by depends on config.trustProxy.
+  rateLimit:
+    # RATE_LIMIT_AUTH — auth attempts per IP per 15 minutes on
+    # login / register / step-up (app default: 10)
+    auth: ""
+    # RATE_LIMIT_STRICT — requests per IP per 5 minutes on sensitive endpoints:
+    # password-reset request/confirm, 2FA reset, email-change request, and AI
+    # estimate (app default: 5). This is the AI-estimate ceiling — raise it if
+    # your users hit "too many requests" on photo estimation.
+    strict: ""
+    # RATE_LIMIT_API — requests per IP per minute on the public API /api/v1
+    # (app default: 120). The outer guard, and the only limit that throttles
+    # unauthenticated traffic. Keep well above the auth limiters: a client
+    # syncing a day of entries makes dozens of calls in a burst.
+    api: ""
+    # RATE_LIMIT_API_TOKEN — requests per personal access token per minute on
+    # /api/v1 (app default: 60). The limit a legitimate API client actually
+    # runs into; per-IP alone means everyone behind one NAT shares a bucket.
+    apiToken: ""
   # Allow search engine indexing (sets ROBOTS_INDEX env var)
   robotsIndex: false
   # Base URL for SEO meta tags (leave empty to auto-detect from request)


### PR DESCRIPTION
Closes #333

The chart templated exactly one variable from the rate-limiting group, `TRUST_PROXY`. `RATE_LIMIT_AUTH`, `RATE_LIMIT_STRICT`, `RATE_LIMIT_API` and `RATE_LIMIT_API_TOKEN` had no key in `values.yaml` and were never written to the ConfigMap, so anyone deploying via the chart — the primary supported path — was pinned to the compiled-in defaults. Patching the ConfigMap by hand works until the next `helm upgrade` reverts it.

`RATE_LIMIT_STRICT` is the sharpest case: after #292 / PR #330 it governs the `/api/v1` AI-estimate ceiling as well as the session route's, so a chart user who wants more (or less) AI throughput had no knob at all. `RATE_LIMIT_API_TOKEN` — the one limit a legitimate API client actually runs into — has been unreachable since the public API shipped.

Chart-only diff (`helm/`), no Go changes.

## Values added

| Value | Env var | Limits | App default |
|-------|---------|--------|-------------|
| `config.rateLimit.auth` | `RATE_LIMIT_AUTH` | Auth attempts per IP per **15 min** on login / register / step-up | `10` |
| `config.rateLimit.strict` | `RATE_LIMIT_STRICT` | Per IP per **5 min** on password-reset request/confirm, 2FA reset, email-change request, **AI estimate** | `5` |
| `config.rateLimit.api` | `RATE_LIMIT_API` | Per IP per **minute** on `/api/v1` — the outer guard, only limit that throttles unauthenticated traffic | `120` |
| `config.rateLimit.apiToken` | `RATE_LIMIT_API_TOKEN` | Per personal access token per **minute** on `/api/v1` | `60` |

`config.trustProxy` stays where it is — moving it under `rateLimit` would be a breaking rename for no gain.

## Conditional templating

Follows the `{{- if }}` idiom already used for the AI and OIDC blocks: **an empty value omits the environment variable entirely**, so the app's own default applies.

The defaults are deliberately **not** written into `values.yaml`. Copying them in would freeze each deployment at whatever the chart author last transcribed and silently stop tracking the app — which is the failure mode the issue calls out. The chart README says so explicitly, since `auth: 10` looks harmless.

Two edge cases handled:

- **`0` is omitted too.** The app treats `0` as "use the default" (`if rateLimitAuth == 0 { rateLimitAuth = 10 }`), so emitting it would be misleading either way. Documented as meaning "default", not "reject everything".
- **The block is wrapped in `{{- with }}`**, so a release that sets `config.rateLimit: null` renders empty instead of erroring on a nil-map lookup.

## Verification

All run against the final commit.

### `helm lint`

```
$ helm lint helm/schautrack
==> Linting helm/schautrack
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

### Unset -> no keys emitted

```
$ helm template test helm/schautrack | sed -n "/kind: ConfigMap/,/^---/p"
kind: ConfigMap
metadata:
  name: test-schautrack
  labels:
    helm.sh/chart: schautrack-0.3.0
    app.kubernetes.io/name: schautrack
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.1.9"
    app.kubernetes.io/managed-by: Helm
data:
  PORT: "3000"
  IMPRINT_URL: "/imprint"
  SMTP_PORT: "587"
  AI_DAILY_LIMIT: "10"
  ANDROID_PACKAGE_NAME: "to.schauer.schautrack"
---
```

No `RATE_LIMIT_*` key. Identical to the pre-change output — existing releases are untouched by the upgrade.

### Set -> keys appear with the given values

```
$ helm template test helm/schautrack \
    --set config.rateLimit.auth=25 --set config.rateLimit.strict=9 \
    --set config.rateLimit.api=300 --set config.rateLimit.apiToken=150 \
    | sed -n "/kind: ConfigMap/,/^---/p"
kind: ConfigMap
metadata:
  name: test-schautrack
  labels:
    helm.sh/chart: schautrack-0.3.0
    app.kubernetes.io/name: schautrack
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.1.9"
    app.kubernetes.io/managed-by: Helm
data:
  PORT: "3000"
  IMPRINT_URL: "/imprint"
  SMTP_PORT: "587"
  AI_DAILY_LIMIT: "10"
  RATE_LIMIT_AUTH: "25"
  RATE_LIMIT_STRICT: "9"
  RATE_LIMIT_API: "300"
  RATE_LIMIT_API_TOKEN: "150"
  ANDROID_PACKAGE_NAME: "to.schauer.schautrack"
---
```

### Edge cases

```
$ helm template test helm/schautrack --set config.rateLimit.strict=9 | grep -E "RATE_LIMIT|^  PORT"
  PORT: "3000"
  RATE_LIMIT_STRICT: "9"          # partial set: only the set key appears

$ helm template test helm/schautrack --set config.rateLimit.api=0 | grep -c RATE_LIMIT
0                                  # 0 omitted, matching the app treating 0 as unset

$ helm template test helm/schautrack --set config.rateLimit=null 2>&1 | grep -cE "RATE_LIMIT|Error"
0                                  # nulled block renders, does not error
```

Realistic values file rather than `--set`, with `trustProxy` alongside:

```
$ cat rl.yaml
config:
  trustProxy: "false"
  rateLimit:
    strict: 15
    apiToken: 120

$ helm template test helm/schautrack -f rl.yaml | grep -E "RATE_LIMIT|TRUST_PROXY"
  TRUST_PROXY: "false"
  RATE_LIMIT_STRICT: "15"
  RATE_LIMIT_API_TOKEN: "120"
```

### Go

Unchanged by this PR, run to confirm no collateral damage:

```
$ go build ./...   # BUILD OK
$ go vet ./...     # VET OK
$ go test ./...    # EXIT=0, all 10 packages ok
```

## Chart version

`0.2.1` -> **`0.3.0`**. New values, no behaviour change on upgrade — matching the `0.1.0` -> `0.2.0` bump that added `ROBOTS_INDEX` and `BASE_URL` config options (`0.2.0` -> `0.2.1` was a template fix, so patch). An "Upgrading / 0.3.0" note is added to the chart README.

Note the release workflow rewrites `version:` at publish time (`0.0.${run_number}` on staging, the app version on main), so the in-repo value is documentation of intent rather than what ships — bumped anyway to keep the `Upgrading` section honest.

## `RATE_LIMIT_BARCODE` decision: deferred, tracked in #366

**Not added here.** The issue flags that the barcode limiter's 30/min is hardcoded with no env var; I filed #366 for it rather than folding it in.

Reasoning — this is a coordination problem with **PR #330** (`v1-ai-barcode-rate-limits`, open, unmerged), which this branch does not contain:

- #330 replaces the `30` literal in `cmd/server/main.go` with `const barcodeRateLimit = 30`
- #330 adds a **second** consumer of it: `BarcodeLimiter: middleware.NewUserRateLimiter(barcodeRateLimit, time.Minute, cfg.TrustProxy)` on `GET /api/v1/barcode/{code}`

Adding a config field against `staging` would conflict on exactly the line #330 rewrites, and would wire up only the session-route call site — leaving #330's v1 limiter on a hardcoded number while the session route reads an env var. That is precisely the divergence #330 introduced the shared const to prevent, and it would land as a silent inconsistency rather than a merge conflict.

After #330 merges it is a mechanical change: read the var in `internal/config/`, delete the const, pass `cfg.RateLimitBarcode` to both call sites at once, with #330's tests already in place to catch a missed one. #366 spells out the full checklist. The chart README carries a one-line pointer at the gap in the meantime.

This also keeps the PR reviewable as what it is: a chart-only change whose entire contract is the two `helm template` outputs above.

## New issues filed

- **#366** — Add `RATE_LIMIT_BARCODE` (the deferral above).
- **#368** — Chart cannot set `UPDATE_CHECK_ENABLED`. Found by diffing every env var the app reads against everything the chart templates. Same class of gap as #333 and arguably worse: it defaults to **on**, and the README recommends setting it `false` for "privacy-sensitive or air-gapped self-hosts" — a setting the primary supported deployment path cannot apply. The instance calls `api.github.com` with no supported way to stop it. `UPDATE_PROVIDER` / `UPDATE_REPO` / `UPDATE_BASE_URL` (the knobs for pointing it at a self-hosted mirror instead) are equally unreachable, as is `LOGIN_CAPTCHA_GLOBAL_THRESHOLD`. `CAPTCHA_BYPASS` being unreachable is correct and noted as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)