### PR TITLE
test: hash E2E seed passwords with bcryptjs instead of shelling out to python3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,10 +60,15 @@ go test ./...
 Playwright suite in `e2e/`:
 
 ```bash
-npm install                       # installs @playwright/test + tsx (root deps)
+npm ci                            # installs the root harness deps
 npx playwright install chromium   # one-time: download the browser
 npm run test:e2e
 ```
+
+Docker, Node.js and a browser are the only prerequisites — everything else the
+suite needs is a root `devDependency`, so `npm ci` is sufficient. (The seeds hash
+legacy bcrypt passwords with `bcryptjs`, which is pure JavaScript and needs no
+native build step and no Python.)
 
 Related scripts:
 

--- a/e2e/fixtures/bcrypt.ts
+++ b/e2e/fixtures/bcrypt.ts
@@ -1,0 +1,31 @@
+/**
+ * bcrypt hashing for the E2E database seeds.
+ *
+ * New passwords are stored as argon2id, but the app still *verifies* legacy bcrypt
+ * hashes and transparently migrates them on the next successful login — see
+ * `verifyPassword` / `migratePasswordHash` in `internal/handler/auth_helpers.go`.
+ * Several specs seed a bcrypt hash straight into the `users` table to exercise that
+ * path, so the suite has to be able to mint one.
+ *
+ * This used to shell out to `python3 -c "import bcrypt; ..."`, an undocumented host
+ * prerequisite that `npm ci` could not satisfy and whose failure mode was an opaque
+ * subprocess error before a single spec ran. `bcryptjs` is pure JavaScript with no
+ * native build step, so `npm ci` is now enough — and the password is passed as a
+ * value, so one containing a quote or a backslash can no longer break the command.
+ *
+ * Hash compatibility: `verifyPassword` only routes `$2a$`/`$2b$` prefixes to
+ * `golang.org/x/crypto/bcrypt`; bcryptjs emits `$2b$`, which that verifier accepts.
+ */
+import bcrypt from 'bcryptjs';
+
+/**
+ * bcrypt cost factor. Matches the cost the old Node.js backend wrote, which is what
+ * the migration specs are meant to be reproducing. Keep it low — this runs once per
+ * seeded user and every extra round doubles the time.
+ */
+const BCRYPT_COST = 10;
+
+/** Generate a bcrypt hash for the given password. */
+export function bcryptHash(password: string): string {
+  return bcrypt.hashSync(password, BCRYPT_COST);
+}

--- a/e2e/fixtures/helpers.ts
+++ b/e2e/fixtures/helpers.ts
@@ -1,6 +1,8 @@
 import { execSync, execFileSync } from 'child_process';
 import * as crypto from 'crypto';
 
+import { bcryptHash } from './bcrypt';
+
 const DB_CONTAINER = process.env.DB_CONTAINER || detectDbContainer();
 const DB_USER = process.env.POSTGRES_USER || 'schautrack';
 const DB_NAME = process.env.POSTGRES_DB || 'schautrack';
@@ -60,16 +62,10 @@ export function psql(sql: string, vars: Record<string, string | number> = {}): s
   return lines.join('\n').trim();
 }
 
-/** Generate a bcrypt hash for the given password. */
-export function bcryptHash(password: string): string {
-  // Pass the password as an argv element (read via sys.argv[1]) instead of interpolating it
-  // into the -c script string, so a password containing quotes can't break the shell command.
-  return execFileSync(
-    'python3',
-    ['-c', 'import bcrypt, sys; print(bcrypt.hashpw(sys.argv[1].encode(), bcrypt.gensalt(10)).decode())', password],
-    { encoding: 'utf-8' }
-  ).trim();
-}
+// Re-exported so the specs that already import bcryptHash from this module keep working.
+// The implementation lives in ./bcrypt so setup-test-user.ts can use it without pulling in
+// this module's container-detection side effects. See that file for why it is bcrypt at all.
+export { bcryptHash };
 
 /** Generate a valid TOTP code from a base32 secret.
  *  Waits if we're near the end of a 30s window to avoid edge-case expiry. */

--- a/e2e/setup-test-user.ts
+++ b/e2e/setup-test-user.ts
@@ -4,6 +4,8 @@
  */
 import { execSync } from 'child_process';
 
+import { bcryptHash } from './fixtures/bcrypt';
+
 const DB_CONTAINER = process.env.DB_CONTAINER || detectDbContainer();
 const DB_USER = process.env.POSTGRES_USER || 'schautrack';
 const DB_NAME = process.env.POSTGRES_DB || 'schautrack';
@@ -21,13 +23,6 @@ function psql(sql: string): string {
   return execSync(
     `docker exec -i ${DB_CONTAINER} psql -U ${DB_USER} -d ${DB_NAME} -tA`,
     { input: sql + '\n', encoding: 'utf-8' }
-  ).trim();
-}
-
-function bcryptHash(password: string): string {
-  return execSync(
-    `python3 -c "import bcrypt; print(bcrypt.hashpw(b'${password}', bcrypt.gensalt(10)).decode())"`,
-    { encoding: 'utf-8' }
   ).trim();
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,8 +4,10 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "schautrack",
       "devDependencies": {
         "@playwright/test": "^1.59.1",
+        "bcryptjs": "^3.0.3",
         "tsx": "^4.19.0"
       }
     },
@@ -465,6 +467,16 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/esbuild": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "schautrack",
   "private": true,
   "scripts": {
     "screenshots": "sh scripts/screenshots.sh",
@@ -11,6 +12,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "bcryptjs": "^3.0.3",
     "tsx": "^4.19.0"
   }
 }


### PR DESCRIPTION
Closes #323

## What

The E2E seeds minted bcrypt hashes by shelling out to `python3 -c "import bcrypt; ..."` in
two places (`e2e/setup-test-user.ts`, `e2e/fixtures/helpers.ts`). This replaces that with
in-process hashing via **`bcryptjs`**, added as a root devDependency.

- New `e2e/fixtures/bcrypt.ts` — side-effect-free, holds the single implementation.
- `e2e/fixtures/helpers.ts` re-exports `bcryptHash`, so the six specs that import it
  (`backend-migration`, `bcrypt-migration`, `delete-account`, `forgot-password`,
  `reset-2fa`, `account-linking`, plus `stepup`/`two-factor`) are **unchanged**.
- `e2e/setup-test-user.ts` imports the same module instead of duplicating the function.
- `CONTRIBUTING.md`: `npm install` → `npm ci`, plus an explicit "Docker, Node.js and a
  browser are the only prerequisites" line.
- `package.json` gains `"name": "schautrack"` — without it npm derives the lockfile's
  package name from the checkout directory, so `npm install` from a git worktree rewrites
  `package-lock.json`'s name field. Unrelated churn, one line, fixed while I was here.

`grep -rn "python3" .` over the whole repo now returns exactly one hit: the comment in the
new file explaining what was removed.

## Why option 1 (in-process JS) and not the alternatives

**Option 2 (hash via the app's own Go code / seed through the registration endpoint) is
actively wrong here.** The app hashes *new* passwords with argon2id — `hashPassword()` in
`internal/handler/auth_helpers.go` is `argon2id.CreateHash`. The seeds deliberately write
**bcrypt** because `verifyPassword` treats `$2a$`/`$2b$` as the legacy format and migrates
it to argon2id on the next successful login, and `bcrypt-migration.spec.ts` /
`backend-migration.spec.ts` exist to exercise precisely that migration path. Seeding
through registration would produce argon2id and silently gut those two specs. A `go run`
helper would work but reintroduces a subprocess and makes the Node suite depend on a Go
toolchain — strictly worse than a 3 kB pure-JS module.

**Option 3 (document the prerequisite)** leaves the CI workaround and the host requirement
in place. Not needed once the dependency is gone.

`bcryptjs` specifics: v3.0.3, **BSD-3-Clause**, **zero runtime dependencies**, pure
JavaScript (no node-gyp, no prebuilt binaries), ships its own TypeScript types. Nothing for
`npm ci` to compile.

Bonus: the password is now passed as a value rather than interpolated into a shell string
inside a Python string literal, which closes the secondary quoting concern in #323.

## Verification — the hash is accepted by the app's real verifier

Hashes generated by the new `e2e/fixtures/bcrypt.ts`, then fed to the app's actual
`verifyPassword` (the `$2b$` branch → `golang.org/x/crypto/bcrypt.CompareHashAndPassword`)
via a throwaway test in `internal/handler`, since `verifyPassword` is unexported. The test
file was deleted after the run and is **not** part of this diff.

```
$ npx tsx gen.ts     # imports e2e/fixtures/bcrypt.ts
"test1234test"	$2b$10$sSBunF1xJ.f98tSTibFAVO8Gl9Bgkf3eQk9FftG6o1net0489E2oO
"bcrypttest1234"	$2b$10$827NOdvE4klftJ.ZnZtEmufsAVWQrfu0PIb6fgcqoOjH1LqsseqKG
"quote'and\"double"	$2b$10$DhOmbV.xrVjv8wb80De2yOO2lQZsFvi0YLdEfII2Zz8oU.zjF9hae
"back\\slash$dollar`tick"	$2b$10$UbmHQ9GjOPWj0dlHbTDF1eKRnD842q3/LmbkfMK8is7ZEZ993A3Qy

$ go test ./internal/handler -run TestBcryptJSHashesVerify -v
=== RUN   TestBcryptJSHashesVerify
    zz_bcryptjs_compat_test.go:23: OK  "test1234test"               -> $2b$10$sSBunF1xJ.f98tSTibFAVO8Gl9Bgkf3eQk9FftG6o1net0489E2oO
    zz_bcryptjs_compat_test.go:23: OK  "bcrypttest1234"             -> $2b$10$827NOdvE4klftJ.ZnZtEmufsAVWQrfu0PIb6fgcqoOjH1LqsseqKG
    zz_bcryptjs_compat_test.go:23: OK  "quote'and\"double"          -> $2b$10$DhOmbV.xrVjv8wb80De2yOO2lQZsFvi0YLdEfII2Zz8oU.zjF9hae
    zz_bcryptjs_compat_test.go:23: OK  "back\\slash$dollar`tick"    -> $2b$10$UbmHQ9GjOPWj0dlHbTDF1eKRnD842q3/LmbkfMK8is7ZEZ993A3Qy
--- PASS: TestBcryptJSHashesVerify (1.07s)
PASS
ok  	schautrack/internal/handler	1.078s
```

Each case also asserted that `verifyPassword` **rejects** `password + "x"` against the same
hash, so this isn't a verifier that says yes to everything. The two passwords with a quote /
backslash / backtick are the ones the old `python3 -c` variant in `setup-test-user.ts` would
have mangled.

### Other checks

```
$ go build ./... && go test ./...
ok  	schautrack/cmd/server	0.016s
ok  	schautrack/internal/clientip	0.007s
ok  	schautrack/internal/database	0.009s
ok  	schautrack/internal/handler	1.051s
ok  	schautrack/internal/middleware	0.069s
ok  	schautrack/internal/openapi	0.038s
ok  	schautrack/internal/release	0.007s
ok  	schautrack/internal/service	0.223s
ok  	schautrack/internal/session	0.009s
ok  	schautrack/internal/sse	0.018s

$ rm -rf node_modules && npm ci
added 7 packages, and audited 8 packages in 674ms
found 0 vulnerabilities

$ npm ls bcryptjs
schautrack@ /…/schautrack
└── bcryptjs@3.0.3

$ npm ls --depth=0
├── @playwright/test@1.62.1
├── bcryptjs@3.0.3
└── tsx@4.23.10

$ node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json parses')"
package.json parses

$ npx tsc --noEmit --skipLibCheck --module nodenext --moduleResolution nodenext --types node \
    e2e/setup-test-user.ts e2e/fixtures/helpers.ts e2e/fixtures/bcrypt.ts
(no output — clean)
```

There is **no root `tsconfig.json`** in this repo (only `client/tsconfig.json`), so
`npx tsc --noEmit -p .` has nothing to run against; the three changed files were
type-checked explicitly with the flags above instead. `e2e/fixtures/bcrypt.ts` also passes
under `--strict`.

`package-lock.json` is committed. Also worth noting as evidence that this prerequisite was
real: `python3 -c "import bcrypt"` on my machine is `ModuleNotFoundError: No module named
'bcrypt'` — the suite could not have seeded a user here before this change.

### Not verified

**The full Playwright suite was not executed** (no Docker stack brought up; `npm run
test:e2e` and `docker compose --build` were out of budget). What is proven is the link that
matters and that the issue was actually about: the hash the seed now writes is one the
running app will accept at login. The specs' own DB/UI plumbing is untouched by this diff —
only the function that produces the hash string changed, and it produces the same
`$2b$10$…` format at the same cost factor as the Python call it replaces.

## Coordination with #328

**#328's two Python steps can be deleted once both land.** I deliberately did **not** touch
`.github/workflows/build.yml` to avoid a conflict. On `origin/ci-e2e-job` the removable
block is `.github/workflows/build.yml` lines 162–173:

- the 4-line comment starting "`e2e/setup-test-user.ts` and `e2e/fixtures/helpers.ts` mint
  bcrypt hashes by shelling out to …"
- `- name: Setup Python` (`actions/setup-python@…v7.0.0`)
- `- name: Install bcrypt for the E2E seed script` (`run: pip install bcrypt`)

The existing `- name: Install E2E dependencies` / `run: npm ci` step immediately above is
now sufficient. Whichever of the two merges second should drop them.

## Follow-up filed

- #371 — no Go unit test covers `verifyPassword`'s bcrypt branch; nothing in `internal/`
  asserts that a `$2a$`/`$2b$` hash is accepted at all. That gap is why this PR needed a
  throwaway test to prove compatibility. Kept out of this diff for scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
