### PR TITLE
chore(deps): bump transitive nanoid to 3.3.18 to clear GHSA-2v37-7h3g-55p8

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4151,9 +4151,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "dependencyDashboard": false,
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "description": "Block PostgreSQL major upgrades: a new major (e.g. 18 -> 19) makes the existing /var/lib/postgresql data directory incompatible with no pg_upgrade path in these compose/helm deployments, so the db container crashloops. Majors require a deliberate manual migration plan.",


### PR DESCRIPTION
Closes #335

Bumps the transitive `nanoid` lockfile entry in `client/` from 3.3.16 to 3.3.18, clearing the one high-severity advisory `npm audit` reports.

## Honest scoping: this is build-time only

`nanoid` reaches us as `vite -> postcss -> nanoid`. Nothing in the app calls it, and it is not shipped in the browser bundle by this path — PostCSS uses it during the build. The advisory itself (GHSA-2v37-7h3g-55p8) needs a *custom* generator invoked with `size` zero, which we never do.

So this is **housekeeping, not an exposure.** The reason to do it is that a standing high-severity line in every `npm ci` trains people to ignore audit output, which is how a real one gets missed later.

## Before

```
$ cd client && npm audit
# npm audit report

nanoid  <3.3.17
Severity: high
nanoid: custom generators can loop indefinitely when size is zero - https://github.com/advisories/GHSA-2v37-7h3g-55p8
fix available via `npm audit fix`
node_modules/nanoid

1 high severity vulnerability

To address all issues, run:
  npm audit fix
```

## After

```
$ cd client && npm audit
found 0 vulnerabilities

$ npm ls nanoid
schautrack-client@ /.../client
└─┬ vite@8.2.1
  └─┬ postcss@8.5.25
    └── nanoid@3.3.18
```

## Why the lockfile entry was edited rather than `npm audit fix`-ed

`npm audit fix` (no `--force`) *does* resolve the advisory, but on this machine it also rewrote ~50 unrelated lines:

```
$ npm audit fix && git diff --stat
 client/package-lock.json | 89 +++++++++++++++++-------------------------------
 1 file changed, 32 insertions(+), 57 deletions(-)
```

It dropped the `@emnapi/core` / `@emnapi/runtime` entries, sprinkled `dev: true` / `peer: true` across the esbuild and react/vite/typescript entries, and — the one I actually cared about — **stripped the `libc: ["glibc"] / ["musl"]` fields from the `lightningcss` optional binaries**, which is what npm uses to pick the right native binary on Alpine vs glibc. Our client image is `node:24-alpine`, so quietly deleting musl/glibc discriminators is not churn I want to smuggle in under a security fix.

I checked whether that churn was caused by the fix or was pre-existing drift. It is pre-existing — a **no-op** `npm install --package-lock-only`, which fixes nothing at all, produces almost the same diff:

```
$ git checkout -- client/package-lock.json
$ npm install --package-lock-only --ignore-scripts && git diff --stat
 client/package-lock.json | 83 +++++++++++++++++-------------------------------
 1 file changed, 29 insertions(+), 54 deletions(-)
```

So 29/54 of those lines are just "the local npm 11.6.2 disagrees with whatever generated the committed lockfile", and only ~3 lines are the actual nanoid fix. That drift is a separate problem and does not belong in a security-fix PR — especially with ~19 other branches in flight against `staging`, where a 90-line lockfile rewrite is a conflict magnet.

The lockfile entry was therefore updated directly, with the version, tarball URL and integrity hash taken verbatim from the registry:

```
$ npm view nanoid@3.3.18 version dist.tarball dist.integrity
version = '3.3.18'
dist.tarball = 'https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz'
dist.integrity = 'sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=='
```

`postcss` declares `"nanoid": "^3.3.16"`, so 3.3.18 satisfies the existing range. **`client/package.json` is not touched — no direct dependency changed.**

Resulting diff:

```
$ git diff --stat
 client/package-lock.json | 6 +++---
 renovate.json            | 1 +
 2 files changed, 4 insertions(+), 3 deletions(-)
```

The lockfile hunk is exactly the three `version` / `resolved` / `integrity` lines of `node_modules/nanoid`, and `npm ci` leaves it byte-identical afterwards.

## Why Renovate never offered this

Worth flagging, because it is the more durable bug: **Renovate has no vulnerability data source for this repo at all.**

```
$ gh api repos/schaurian/schautrack --jq .security_and_analysis
{ "dependabot_security_updates": { "status": "disabled" }, ... }

$ gh api repos/schaurian/schautrack/vulnerability-alerts -i
HTTP/2.0 404 Not Found        # 404 == vulnerability alerts not enabled
```

Renovate's security remediation reads GitHub Dependabot alerts. Those are off. And from the official `renovate-schema.json`, `osvVulnerabilityAlerts` — the alternative that queries osv.dev directly and needs no Dependabot — defaults to `false` and was unset here. So its `vulnerabilityAlerts` defaults, which are already exactly right for this case (`rangeStrategy: "update-lockfile"`, `prCreation: "immediate"`), never had anything to fire on. It was not a schedule delay; the bot was structurally blind.

This PR includes the one-line fix:

```diff
   "dependencyDashboard": false,
+  "osvVulnerabilityAlerts": true,
```

Validated as a top-level boolean against `https://docs.renovatebot.com/renovate-schema.json`.

Everything beyond one line is filed as **#370**: enabling Dependabot alerts (a repo setting, cannot ship in a PR), confirming OSV remediation actually reaches purely transitive deps like this one rather than assuming it, and a deliberate yes/no on `lockFileMaintenance` (disabled by default, which is why nothing ever refreshes transitive lockfile entries between direct-dependency bumps).

## Verification

All run locally on this branch.

```
$ npm audit                     # 0 vulnerabilities
$ npm ci                        # added 244 packages, audited 245 in 8s, found 0 vulnerabilities
$ npm run typecheck             # tsc -b --force, clean
$ npm test                      # Test Files 9 passed (9) | Tests 121 passed (121)
$ npm run build                 # see below
$ go build ./...                # clean
$ go test ./...                 # all ok
```

`npm run build` is the one that actually exercises vite/postcss, i.e. the only real risk of a transitive build-tool bump:

```
> build
> tsc -b && vite build

vite v8.2.1 building client environment for production...
transforming...✓ 2167 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                       2.71 kB │ gzip:   0.82 kB
dist/assets/index-DdJ1HNoW.css       99.30 kB │ gzip:  15.80 kB
...
dist/assets/index-BI19BdIp.js       308.20 kB │ gzip:  94.37 kB
dist/assets/i18n-n6eyeiCr.js        382.49 kB │ gzip: 129.91 kB

✓ built in 1.04s
```

`go test ./...`:

```
ok  	schautrack/cmd/server	0.014s
ok  	schautrack/internal/clientip	0.006s
ok  	schautrack/internal/database	0.008s
ok  	schautrack/internal/handler	1.693s
ok  	schautrack/internal/middleware	0.070s
ok  	schautrack/internal/openapi	0.025s
ok  	schautrack/internal/release	0.004s
ok  	schautrack/internal/service	0.223s
ok  	schautrack/internal/session	0.007s
ok  	schautrack/internal/sse	0.014s
```

`npm run test:e2e` was deliberately not run (shared-runner budget); this change cannot affect runtime behaviour, only the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
