### PR TITLE
test: cover the untested half of internal/middleware (CSP, RequireLinkAuth, body limit, auth gates)

### DIFF
--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -42,7 +42,23 @@ func GetUserByID(ctx context.Context, pool *pgxpool.Pool, id int) (*model.User, 
 }
 
 // IsAdmin checks if a user is the admin.
+//
+// The empty check happens FIRST (and after trimming): an unset or
+// whitespace-only ADMIN_EMAIL must make nobody an admin, never everybody. The
+// admin panel can rewrite live configuration, so this function failing open on
+// a missing environment variable would be the worst bug in the codebase.
+//
+// The comparison is case-insensitive. adminEmail is trimmed because it comes
+// straight from os.Getenv("ADMIN_EMAIL") with no cleaning in config.go, and a
+// stray trailing newline from a .env file or a Kubernetes secret would
+// otherwise lock the real admin out of their own panel with a bare 403.
+//
+// user.Email is deliberately NOT trimmed. Addresses are normalized to
+// lowercase-and-trimmed on every write path (registration, login, OIDC, email
+// change), so there is nothing to clean; trimming here would instead let an
+// account somehow stored as "admin@example.com " match ADMIN_EMAIL.
 func IsAdmin(user *model.User, adminEmail string) bool {
+	adminEmail = strings.TrimSpace(adminEmail)
 	if adminEmail == "" || user == nil {
 		return false
 	}

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -1,0 +1,384 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"schautrack/internal/model"
+	"schautrack/internal/session"
+)
+
+// probe returns a handler that records whether it ran.
+func probe() (http.Handler, *bool) {
+	ran := false
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ran = true
+		w.WriteHeader(http.StatusOK)
+	}), &ran
+}
+
+func decodeErrorBody(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response body is not JSON (%q): %v", rec.Body.String(), err)
+	}
+	return body
+}
+
+// --- IsAdmin --------------------------------------------------------------
+
+// TestIsAdmin is the table behind the admin panel, which can rewrite live
+// configuration. Every row here is a way an admin check can go wrong; the
+// empty-ADMIN_EMAIL rows are the ones that would turn every logged-in user
+// into an administrator on a deployment that simply forgot the variable.
+func TestIsAdmin(t *testing.T) {
+	user := func(email string) *model.User { return &model.User{ID: 1, Email: email} }
+
+	tests := []struct {
+		name       string
+		user       *model.User
+		adminEmail string
+		want       bool
+		why        string
+	}{
+		{"exact match", user("admin@example.com"), "admin@example.com", true, ""},
+		{"different user", user("someone@example.com"), "admin@example.com", false, ""},
+
+		// The match is case-insensitive: addresses are stored lowercased, but
+		// ADMIN_EMAIL is typed by a human into an env file.
+		{"admin email upper-cased", user("admin@example.com"), "ADMIN@EXAMPLE.COM", true, ""},
+		{"stored email upper-cased", user("Admin@Example.COM"), "admin@example.com", true, ""},
+
+		// ADMIN_EMAIL is read raw from the environment; a trailing newline out
+		// of a .env file or a Kubernetes secret must not lock the admin out.
+		{"admin email with trailing newline", user("admin@example.com"), "admin@example.com\n", true, ""},
+		{"admin email padded with spaces", user("admin@example.com"), "  admin@example.com  ", true, ""},
+
+		// …but the stored address is never trimmed, so a padded account cannot
+		// impersonate the admin.
+		{"padded stored email does not match", user("admin@example.com "), "admin@example.com", false,
+			"an account whose stored address has trailing whitespace must not match ADMIN_EMAIL"},
+
+		// The rows that matter most.
+		{"ADMIN_EMAIL unset", user("anyone@example.com"), "", false,
+			"an unset ADMIN_EMAIL must make NOBODY an admin"},
+		{"ADMIN_EMAIL unset, user email also empty", user(""), "", false,
+			"two empty strings must not compare equal into admin rights"},
+		{"ADMIN_EMAIL whitespace only", user("anyone@example.com"), "   ", false,
+			"a whitespace-only ADMIN_EMAIL is an unset one"},
+		{"ADMIN_EMAIL whitespace only, user email whitespace", user(" "), " ", false,
+			"whitespace must never authenticate an admin"},
+		{"empty stored email against a real ADMIN_EMAIL", user(""), "admin@example.com", false, ""},
+
+		{"nil user", nil, "admin@example.com", false, "an unauthenticated request has no admin rights"},
+		{"nil user and unset ADMIN_EMAIL", nil, "", false, ""},
+
+		// Not a substring/prefix match.
+		{"prefix of the admin address", user("admin@example.co"), "admin@example.com", false, ""},
+		{"admin address as a substring", user("notadmin@example.com"), "admin@example.com", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAdmin(tt.user, tt.adminEmail); got != tt.want {
+				msg := tt.why
+				if msg == "" {
+					msg = "wrong admin decision"
+				}
+				t.Errorf("IsAdmin(%v, %q) = %v, want %v — %s", tt.user, tt.adminEmail, got, tt.want, msg)
+			}
+		})
+	}
+}
+
+// --- RequireAdmin ---------------------------------------------------------
+
+func TestRequireAdmin(t *testing.T) {
+	admin := &model.User{ID: 1, Email: "admin@example.com"}
+	other := &model.User{ID: 2, Email: "user@example.com"}
+
+	tests := []struct {
+		name       string
+		user       *model.User // nil ⇒ unauthenticated request
+		adminEmail string
+		wantStatus int
+		wantRun    bool
+	}{
+		{"no session at all", nil, "admin@example.com", http.StatusForbidden, false},
+		{"logged in but not the admin", other, "admin@example.com", http.StatusForbidden, false},
+		{"the admin", admin, "admin@example.com", http.StatusOK, true},
+		{"the admin, ADMIN_EMAIL cased differently", admin, "Admin@Example.com", http.StatusOK, true},
+		{"ADMIN_EMAIL unset, ordinary user", other, "", http.StatusForbidden, false},
+		{"ADMIN_EMAIL unset, the would-be admin", admin, "", http.StatusForbidden, false},
+		{"ADMIN_EMAIL unset, no session", nil, "", http.StatusForbidden, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			next, ran := probe()
+			req := httptest.NewRequest(http.MethodGet, "/api/admin", nil)
+			if tt.user != nil {
+				req = req.WithContext(WithTestUser(req.Context(), tt.user))
+			}
+			rec := httptest.NewRecorder()
+
+			RequireAdmin(tt.adminEmail)(next).ServeHTTP(rec, req)
+
+			if *ran != tt.wantRun {
+				t.Errorf("handler ran = %v, want %v — the admin panel was reachable by the wrong caller", *ran, tt.wantRun)
+			}
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if tt.wantStatus == http.StatusForbidden {
+				if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+					t.Errorf("Content-Type = %q, want application/json", ct)
+				}
+				if body := decodeErrorBody(t, rec); body["error"] != "Forbidden" {
+					t.Errorf("error = %v, want %q", body["error"], "Forbidden")
+				}
+			}
+		})
+	}
+}
+
+// TestRequireAdminDoesNotLeakWhetherAdminExists checks the 403 body is the same
+// whether ADMIN_EMAIL is unset, belongs to somebody else, or the caller simply
+// is not it. A differing message would tell an attacker whether the deployment
+// has an admin account worth attacking.
+func TestRequireAdminDoesNotLeakWhetherAdminExists(t *testing.T) {
+	user := &model.User{ID: 2, Email: "user@example.com"}
+	var bodies []string
+	for _, adminEmail := range []string{"", "admin@example.com", "nobody@example.com"} {
+		next, _ := probe()
+		req := httptest.NewRequest(http.MethodGet, "/api/admin", nil).
+			WithContext(WithTestUser(t.Context(), user))
+		rec := httptest.NewRecorder()
+		RequireAdmin(adminEmail)(next).ServeHTTP(rec, req)
+		bodies = append(bodies, rec.Body.String())
+	}
+	for i := 1; i < len(bodies); i++ {
+		if bodies[i] != bodies[0] {
+			t.Errorf("403 bodies differ by ADMIN_EMAIL configuration:\n%q\n%q", bodies[0], bodies[i])
+		}
+	}
+}
+
+// --- RequireLogin ---------------------------------------------------------
+
+func TestRequireLoginRejectsAnonymous(t *testing.T) {
+	next, ran := probe()
+	rec := httptest.NewRecorder()
+
+	RequireLogin(next).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/settings", nil))
+
+	if *ran {
+		t.Fatal("handler ran for an unauthenticated request")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if body := decodeErrorBody(t, rec); body["error"] != "Authentication required" {
+		t.Errorf("error = %v, want %q", body["error"], "Authentication required")
+	}
+}
+
+func TestRequireLoginAllowsAuthenticated(t *testing.T) {
+	next, ran := probe()
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil).
+		WithContext(WithTestUser(t.Context(), &model.User{ID: 7, Email: "user@example.com"}))
+	rec := httptest.NewRecorder()
+
+	RequireLogin(next).ServeHTTP(rec, req)
+
+	if !*ran {
+		t.Error("handler did not run for an authenticated request")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+// TestRequireLoginIgnoresASessionWithoutAUser guards the boundary between
+// AttachUser and RequireLogin: a session cookie exists for anonymous visitors
+// too (CSRF tokens live in it), so the presence of a session must never be
+// mistaken for authentication.
+func TestRequireLoginIgnoresASessionWithoutAUser(t *testing.T) {
+	next, ran := probe()
+	sess := &session.Session{Data: map[string]any{"csrf": "abc"}}
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil).
+		WithContext(session.WithTestSession(t.Context(), sess))
+	rec := httptest.NewRecorder()
+
+	RequireLogin(next).ServeHTTP(rec, req)
+
+	if *ran {
+		t.Fatal("an anonymous session was treated as a logged-in user")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+// --- RequireLocalAuth -----------------------------------------------------
+
+// TestRequireLocalAuth covers the gate on password / 2FA / passkey / email
+// routes. A federated account has no local password to change, and the IdP —
+// not this app — owns its authentication; letting an OIDC session set a local
+// password would create a second, weaker way into the account.
+func TestRequireLocalAuth(t *testing.T) {
+	tests := []struct {
+		name       string
+		sess       *session.Session
+		wantRun    bool
+		wantStatus int
+	}{
+		{"password session", &session.Session{Data: map[string]any{"auth_method": "password"}}, true, http.StatusOK},
+		{"passkey session", &session.Session{Data: map[string]any{"auth_method": "passkey"}}, true, http.StatusOK},
+		{"oidc session", &session.Session{Data: map[string]any{"auth_method": "oidc"}}, false, http.StatusForbidden},
+		{"session with no auth_method", &session.Session{Data: map[string]any{}}, true, http.StatusOK},
+
+		// Documented, deliberate: the middleware is always mounted BELOW
+		// RequireLogin, which has already rejected a request with no session.
+		// It is recorded here so that anyone who mounts it on its own knows it
+		// does not authenticate.
+		{"no session at all (RequireLogin's job)", nil, true, http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			next, ran := probe()
+			req := httptest.NewRequest(http.MethodPost, "/settings/password", nil)
+			if tt.sess != nil {
+				req = req.WithContext(session.WithTestSession(req.Context(), tt.sess))
+			}
+			rec := httptest.NewRecorder()
+
+			RequireLocalAuth(next).ServeHTTP(rec, req)
+
+			if *ran != tt.wantRun {
+				t.Errorf("handler ran = %v, want %v", *ran, tt.wantRun)
+			}
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if tt.wantStatus == http.StatusForbidden {
+				if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+					t.Errorf("Content-Type = %q, want application/json", ct)
+				}
+				body := decodeErrorBody(t, rec)
+				if msg, _ := body["error"].(string); msg == "" {
+					t.Error("the 403 must explain why: a federated user needs to be told to manage auth at their IdP")
+				}
+			}
+		})
+	}
+}
+
+// TestRequireLocalAuthBlocksEveryLocalAuthRoute expresses the route list as a
+// table. These are the paths that mount RequireLocalAuth in cmd/server/main.go;
+// an OIDC session must be refused on all of them, not just the password one.
+func TestRequireLocalAuthBlocksEveryLocalAuthRoute(t *testing.T) {
+	routes := []string{
+		"/settings/password",
+		"/settings/email/request",
+		"/settings/email/verify",
+		"/settings/email/cancel",
+		"/2fa/setup",
+		"/2fa/cancel",
+		"/2fa/enable",
+		"/2fa/disable",
+		"/2fa/backup-codes",
+	}
+	for _, path := range routes {
+		t.Run(path, func(t *testing.T) {
+			next, ran := probe()
+			sess := &session.Session{Data: map[string]any{"auth_method": "oidc"}}
+			req := httptest.NewRequest(http.MethodPost, path, nil).
+				WithContext(session.WithTestSession(t.Context(), sess))
+			rec := httptest.NewRecorder()
+
+			RequireLocalAuth(next).ServeHTTP(rec, req)
+
+			if *ran {
+				t.Errorf("an OIDC session reached %s", path)
+			}
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("status = %d, want 403", rec.Code)
+			}
+		})
+	}
+}
+
+// TestAuthMiddlewareMountOrder guards the assumption the two authorization
+// middlewares are written against.
+//
+// RequireLocalAuth only inspects the session's auth_method; with no session at
+// all it passes the request through. That is safe exactly because it is never
+// mounted without RequireLogin above it, which has already rejected an
+// anonymous caller. RequireAdmin does fail closed on its own, but the same
+// ordering is what makes its 403 mean "you are not the admin" rather than "you
+// are not logged in".
+//
+// Neither property is enforced by the type system, so it is enforced here,
+// against the real route table. (RequireScope on /api/v1 solves the same
+// problem in code by returning 401 when no token is present — see apiauth.go.)
+func TestAuthMiddlewareMountOrder(t *testing.T) {
+	const mainGo = "../../cmd/server/main.go"
+
+	routes := parseRoutes(t, mainGo)
+	if len(routes) < 40 {
+		t.Fatalf("only %d routes parsed out of %s; the mount-order guard is not looking at the real "+
+			"route table", len(routes), mainGo)
+	}
+
+	var sawLocalAuth, sawAdmin int
+	for _, rt := range routes {
+		for _, gate := range []string{"RequireLocalAuth", "RequireAdmin"} {
+			if !strings.Contains(rt.chain, gate) {
+				continue
+			}
+			if gate == "RequireLocalAuth" {
+				sawLocalAuth++
+			} else {
+				sawAdmin++
+			}
+			if !strings.Contains(rt.chain, "RequireLogin") {
+				t.Errorf("%s:%d — %s %s mounts %s without RequireLogin above it. %s does not "+
+					"authenticate; an anonymous request would pass straight through it.",
+					mainGo, rt.line, rt.method, rt.path, gate, gate)
+			}
+		}
+	}
+	if sawLocalAuth == 0 {
+		t.Error("no RequireLocalAuth routes found; either they were removed or the guard stopped matching")
+	}
+	if sawAdmin == 0 {
+		t.Error("no RequireAdmin routes found; either they were removed or the guard stopped matching")
+	}
+}
+
+// --- GetCurrentUser -------------------------------------------------------
+
+func TestGetCurrentUserReturnsNilWhenAbsent(t *testing.T) {
+	if u := GetCurrentUser(httptest.NewRequest(http.MethodGet, "/", nil)); u != nil {
+		t.Errorf("GetCurrentUser = %v, want nil on an unauthenticated request", u)
+	}
+}
+
+func TestGetCurrentUserRoundTrips(t *testing.T) {
+	want := &model.User{ID: 42, Email: "user@example.com"}
+	req := httptest.NewRequest(http.MethodGet, "/", nil).
+		WithContext(WithTestUser(t.Context(), want))
+	got := GetCurrentUser(req)
+	if got == nil || got.ID != want.ID || got.Email != want.Email {
+		t.Errorf("GetCurrentUser = %v, want %v", got, want)
+	}
+}

--- a/internal/middleware/bodylimit_test.go
+++ b/internal/middleware/bodylimit_test.go
@@ -1,0 +1,253 @@
+package middleware
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// readBodyHandler drains the request body and records what happened, so a test
+// can distinguish "the cap fired" from "the handler read a truncated body and
+// carried on regardless" — the second is the dangerous outcome, because a
+// handler that ignores the error parses half a JSON document.
+func readBodyHandler(read *int, gotErr *error) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		*read = len(b)
+		*gotErr = err
+		if err != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				w.WriteHeader(http.StatusRequestEntityTooLarge)
+				return
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func TestMaxBodySizeAllowsBodyUnderLimit(t *testing.T) {
+	const limit = 1024
+	body := bytes.Repeat([]byte("a"), limit-1)
+
+	var read int
+	var readErr error
+	req := httptest.NewRequest(http.MethodPost, "/entries", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	MaxBodySize(limit)(readBodyHandler(&read, &readErr)).ServeHTTP(rec, req)
+
+	if readErr != nil {
+		t.Fatalf("reading a body under the limit failed: %v", readErr)
+	}
+	if read != len(body) {
+		t.Errorf("handler read %d bytes, want %d — the body was truncated below the limit", read, len(body))
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+// TestMaxBodySizeAllowsBodyExactlyAtLimit pins the boundary. MaxBytesReader
+// permits exactly n bytes and errors on the (n+1)th, so a payload of exactly
+// the limit must pass.
+func TestMaxBodySizeAllowsBodyExactlyAtLimit(t *testing.T) {
+	const limit = 1024
+	var read int
+	var readErr error
+	req := httptest.NewRequest(http.MethodPost, "/entries", bytes.NewReader(bytes.Repeat([]byte("a"), limit)))
+	rec := httptest.NewRecorder()
+	MaxBodySize(limit)(readBodyHandler(&read, &readErr)).ServeHTTP(rec, req)
+
+	if readErr != nil {
+		t.Fatalf("a body of exactly the limit was rejected: %v", readErr)
+	}
+	if read != limit {
+		t.Errorf("handler read %d bytes, want %d", read, limit)
+	}
+}
+
+func TestMaxBodySizeRejectsBodyOverLimit(t *testing.T) {
+	const limit = 1024
+	var read int
+	var readErr error
+	req := httptest.NewRequest(http.MethodPost, "/entries", bytes.NewReader(bytes.Repeat([]byte("a"), limit*4)))
+	rec := httptest.NewRecorder()
+	MaxBodySize(limit)(readBodyHandler(&read, &readErr)).ServeHTTP(rec, req)
+
+	var maxErr *http.MaxBytesError
+	if !errors.As(readErr, &maxErr) {
+		t.Fatalf("reading an oversized body returned %v, want *http.MaxBytesError — "+
+			"without that error the handler cannot tell a truncated body from a complete one", readErr)
+	}
+	if maxErr.Limit != limit {
+		t.Errorf("MaxBytesError.Limit = %d, want %d", maxErr.Limit, limit)
+	}
+	if read > limit {
+		t.Errorf("handler read %d bytes past a %d-byte cap", read, limit)
+	}
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", rec.Code)
+	}
+}
+
+// TestMaxBodySizeIgnoresLyingContentLength is the reason the cap is worth
+// having at all. A hostile client can claim any Content-Length it likes;
+// MaxBytesReader counts the bytes actually read off the wire, so the header is
+// irrelevant to the limit.
+func TestMaxBodySizeIgnoresLyingContentLength(t *testing.T) {
+	const limit = 1024
+	body := bytes.Repeat([]byte("a"), limit*4)
+
+	var read int
+	var readErr error
+	req := httptest.NewRequest(http.MethodPost, "/entries", bytes.NewReader(body))
+	// Claim a tiny body while sending a large one.
+	req.ContentLength = 10
+	req.Header.Set("Content-Length", "10")
+
+	rec := httptest.NewRecorder()
+	MaxBodySize(limit)(readBodyHandler(&read, &readErr)).ServeHTTP(rec, req)
+
+	var maxErr *http.MaxBytesError
+	if !errors.As(readErr, &maxErr) {
+		t.Fatalf("a request lying about Content-Length was not capped: err = %v, bytes read = %d", readErr, read)
+	}
+	if read > limit {
+		t.Errorf("read %d bytes despite a %d-byte cap", read, limit)
+	}
+}
+
+// TestMaxBodySizeChunkedWithNoContentLength covers the other half of the same
+// point: a chunked upload announces no length at all, and must still be capped.
+func TestMaxBodySizeChunkedWithNoContentLength(t *testing.T) {
+	const limit = 1024
+	var read int
+	var readErr error
+	req := httptest.NewRequest(http.MethodPost, "/entries", bytes.NewReader(bytes.Repeat([]byte("a"), limit*4)))
+	req.ContentLength = -1 // what net/http sets for a chunked request
+	req.Header.Del("Content-Length")
+	req.TransferEncoding = []string{"chunked"}
+
+	rec := httptest.NewRecorder()
+	MaxBodySize(limit)(readBodyHandler(&read, &readErr)).ServeHTTP(rec, req)
+
+	var maxErr *http.MaxBytesError
+	if !errors.As(readErr, &maxErr) {
+		t.Fatalf("a chunked request with no Content-Length was not capped: err = %v, bytes read = %d", readErr, read)
+	}
+}
+
+func TestMaxBodySizeHandlesBodylessRequest(t *testing.T) {
+	var read int
+	var readErr error
+	req := httptest.NewRequest(http.MethodGet, "/api/dashboard", nil)
+	rec := httptest.NewRecorder()
+	MaxBodySize(15<<20)(readBodyHandler(&read, &readErr)).ServeHTTP(rec, req)
+
+	if readErr != nil {
+		t.Errorf("a GET with no body errored: %v", readErr)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+// TestMaxBodySizeAllowsFiveMBUnderTheGlobalCap is the control for the v1 limit
+// test in v1_bodylimit_test.go. 5 MB sits between the two caps this app has:
+// the global 15 MB one lets it through, and the 1 MB one inside decodeV1 must
+// not. This half of the contrast needs no database.
+func TestMaxBodySizeAllowsFiveMBUnderTheGlobalCap(t *testing.T) {
+	var read int
+	var readErr error
+	req := httptest.NewRequest(http.MethodPost, "/settings/import",
+		bytes.NewReader(bytes.Repeat([]byte("a"), 5<<20)))
+	rec := httptest.NewRecorder()
+	MaxBodySize(15<<20)(readBodyHandler(&read, &readErr)).ServeHTTP(rec, req)
+
+	if readErr != nil {
+		t.Fatalf("a 5 MB body was rejected by the 15 MB global cap: %v", readErr)
+	}
+	if read != 5<<20 {
+		t.Errorf("read %d bytes, want %d", read, 5<<20)
+	}
+}
+
+// TestMaxBodySizeOverRealConnection exercises the cap through an actual TCP
+// connection rather than httptest.NewRecorder.
+//
+// The recorder cannot show the failure mode that matters operationally: whether
+// an oversized upload ends in a clean status the client can read, or in a hung
+// connection / reset that surfaces as an inscrutable network error. net/http's
+// MaxBytesReader marks the request "too large" on the real ResponseWriter and
+// closes the connection after the response, so the client must still receive
+// the 413 before the close.
+func TestMaxBodySizeOverRealConnection(t *testing.T) {
+	const limit = 64 << 10
+
+	var read int
+	var readErr error
+	srv := httptest.NewServer(MaxBodySize(limit)(readBodyHandler(&read, &readErr)))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Post(srv.URL+"/entries", "application/json",
+		bytes.NewReader(bytes.Repeat([]byte("a"), limit*8)))
+	if err != nil {
+		t.Fatalf("the oversized POST produced a transport error instead of an HTTP response: %v", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", resp.StatusCode)
+	}
+	if resp.StatusCode < 400 || resp.StatusCode >= 500 {
+		t.Errorf("status = %d, want a 4xx — an oversized body is a client error, not a server fault", resp.StatusCode)
+	}
+	if read > limit {
+		t.Errorf("server read %d bytes off the wire despite a %d-byte cap", read, limit)
+	}
+}
+
+// TestMaxBodySizePassesThroughOtherRequestState checks the middleware only
+// swaps the body and leaves the rest of the request alone.
+func TestMaxBodySizePassesThroughOtherRequestState(t *testing.T) {
+	var gotMethod, gotPath, gotHeader string
+	h := MaxBodySize(1024)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotHeader = r.Method, r.URL.Path, r.Header.Get("X-Probe")
+	}))
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/entries/7", strings.NewReader("{}"))
+	req.Header.Set("X-Probe", "kept")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if gotMethod != http.MethodPatch || gotPath != "/api/v1/entries/7" || gotHeader != "kept" {
+		t.Errorf("request mutated: method=%q path=%q X-Probe=%q", gotMethod, gotPath, gotHeader)
+	}
+}
+
+// TestGlobalBodyLimitIsMountedAt15MB pins the number in cmd/server/main.go.
+//
+// The middleware is generic; the deployed limit is a literal at the mount site,
+// and nothing else in the tree would notice if it were widened. 15 MB is sized
+// for photo uploads and account imports on the legacy surface — see the
+// maxV1Body comment in internal/handler/v1_common.go for why /api/v1 is tighter.
+func TestGlobalBodyLimitIsMountedAt15MB(t *testing.T) {
+	src, err := os.ReadFile("../../cmd/server/main.go")
+	if err != nil {
+		t.Fatalf("reading the router source failed: %v", err)
+	}
+	const want = "middleware.MaxBodySize(15 << 20)"
+	if !strings.Contains(string(src), want) {
+		t.Errorf("cmd/server/main.go no longer mounts %s. If the global request cap was changed on "+
+			"purpose, update this test in the same commit so the new number is reviewed.", want)
+	}
+}

--- a/internal/middleware/links_test.go
+++ b/internal/middleware/links_test.go
@@ -1,0 +1,653 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"schautrack/internal/database"
+	"schautrack/internal/model"
+	"schautrack/internal/service"
+)
+
+// RequireLinkAuth is the only place in the application where one account may
+// read another's data, so it is the only place a bug becomes a cross-account
+// data leak. These tests need a real database: the entire decision is a single
+// SQL statement over account_links, and a fake would only assert that the
+// statement we wrote is the statement we wrote.
+//
+// Skipped unless TEST_DATABASE_URL is set, matching the other integration tests
+// in this repo (CI has no database; e2e covers the full stack). Run locally
+// with, e.g.:
+//
+//	TEST_DATABASE_URL='postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable' go test ./internal/middleware/ -run TestRequireLinkAuth -v
+
+// linkTestDB opens a pool and applies the schema, or skips.
+func linkTestDB(t *testing.T) (context.Context, *pgxpool.Pool) {
+	t.Helper()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	t.Cleanup(cancel)
+
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	if err := database.InitSchemaWithRetry(ctx, pool, 3); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+	return ctx, pool
+}
+
+// mkUser inserts a user and returns it as the middleware would load it.
+func mkUser(t *testing.T, ctx context.Context, pool *pgxpool.Pool, label string) *model.User {
+	t.Helper()
+	email := fmt.Sprintf("linkauth-%s-%d@middleware.test", label, time.Now().UnixNano())
+	var id int
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email, password_hash, email_verified) VALUES ($1, 'x', true) RETURNING id`,
+		email).Scan(&id); err != nil {
+		t.Fatalf("seeding user %s failed: %v", label, err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, id)
+	})
+
+	u, err := GetUserByID(ctx, pool, id)
+	if err != nil {
+		t.Fatalf("loading seeded user %s failed: %v", label, err)
+	}
+	return u
+}
+
+// setLink replaces whatever link exists between the two accounts.
+// requesterShares is what the requester exposes to the target, and vice versa.
+func setLink(t *testing.T, ctx context.Context, pool *pgxpool.Pool,
+	requesterID, targetID int, status string, requesterShares, targetShares map[string]bool) {
+	t.Helper()
+	clearLink(t, ctx, pool, requesterID, targetID)
+
+	enc := func(m map[string]bool) string {
+		if m == nil {
+			m = map[string]bool{}
+		}
+		b, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("encoding share map: %v", err)
+		}
+		return string(b)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO account_links (requester_id, target_id, status, requester_shares, target_shares)
+		VALUES ($1, $2, $3, $4::jsonb, $5::jsonb)`,
+		requesterID, targetID, status, enc(requesterShares), enc(targetShares)); err != nil {
+		t.Fatalf("seeding %s link %d→%d failed: %v", status, requesterID, targetID, err)
+	}
+}
+
+func clearLink(t *testing.T, ctx context.Context, pool *pgxpool.Pool, a, b int) {
+	t.Helper()
+	if _, err := pool.Exec(ctx,
+		`DELETE FROM account_links WHERE (requester_id = $1 AND target_id = $2) OR (requester_id = $2 AND target_id = $1)`,
+		a, b); err != nil {
+		t.Fatalf("clearing link %d↔%d failed: %v", a, b, err)
+	}
+}
+
+// linkResult is what a run of the middleware produced.
+type linkResult struct {
+	status       int
+	contentType  string
+	body         string
+	reached      bool
+	targetUserID int
+	targetUser   *model.User
+}
+
+// runLinkAuth drives RequireLinkAuth for one viewer, category and ?user= value.
+// A nil viewer models an unauthenticated request.
+func runLinkAuth(t *testing.T, ctx context.Context, pool *pgxpool.Pool,
+	category string, viewer *model.User, rawQuery string) linkResult {
+	t.Helper()
+
+	res := linkResult{}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res.reached = true
+		res.targetUserID = GetTargetUserID(r)
+		res.targetUser = GetTargetUser(r)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	url := "/entries/day?date=2026-08-08"
+	if rawQuery != "" {
+		url += "&" + rawQuery
+	}
+	req := httptest.NewRequest(http.MethodGet, url, nil).WithContext(ctx)
+	if viewer != nil {
+		req = req.WithContext(WithTestUser(req.Context(), viewer))
+	}
+
+	rec := httptest.NewRecorder()
+	RequireLinkAuth(pool, category)(next).ServeHTTP(rec, req)
+
+	res.status = rec.Code
+	res.contentType = rec.Header().Get("Content-Type")
+	res.body = strings.TrimSpace(rec.Body.String())
+	return res
+}
+
+func (r linkResult) assertDenied(t *testing.T, why string) {
+	t.Helper()
+	if r.reached {
+		t.Fatalf("%s: the handler ran — another account's data would have been served", why)
+	}
+	if r.status != http.StatusForbidden {
+		t.Errorf("%s: status = %d, want 403", why, r.status)
+	}
+	if r.contentType != "application/json" {
+		t.Errorf("%s: Content-Type = %q, want application/json", why, r.contentType)
+	}
+	var body map[string]any
+	if err := json.Unmarshal([]byte(r.body), &body); err != nil {
+		t.Fatalf("%s: 403 body is not JSON (%q): %v", why, r.body, err)
+	}
+	if body["ok"] != false || body["error"] != "Not authorized" {
+		t.Errorf("%s: body = %v, want {ok:false, error:\"Not authorized\"}", why, body)
+	}
+}
+
+func (r linkResult) assertAllowed(t *testing.T, wantTargetID int, why string) {
+	t.Helper()
+	if !r.reached {
+		t.Fatalf("%s: denied with %d (%s), want the handler to run", why, r.status, r.body)
+	}
+	if r.targetUserID != wantTargetID {
+		t.Errorf("%s: target user id in context = %d, want %d", why, r.targetUserID, wantTargetID)
+	}
+	if r.targetUser == nil {
+		t.Fatalf("%s: no target user in context; handlers fall back to the viewer and would read the wrong rows", why)
+	}
+	if r.targetUser.ID != wantTargetID {
+		t.Errorf("%s: target user in context is %d, want %d", why, r.targetUser.ID, wantTargetID)
+	}
+}
+
+func TestRequireLinkAuth(t *testing.T) {
+	ctx, pool := linkTestDB(t)
+
+	alice := mkUser(t, ctx, pool, "alice")
+	bob := mkUser(t, ctx, pool, "bob")
+	carol := mkUser(t, ctx, pool, "carol")
+
+	all := map[string]bool{
+		service.ShareNutrition: true,
+		service.ShareWeight:    true,
+		service.ShareTodos:     true,
+		service.ShareNotes:     true,
+	}
+
+	t.Run("unauthenticated request is 401, not 403", func(t *testing.T) {
+		res := runLinkAuth(t, ctx, pool, service.ShareNutrition, nil, "")
+		if res.reached {
+			t.Fatal("the handler ran without a logged-in user")
+		}
+		if res.status != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", res.status)
+		}
+	})
+
+	t.Run("no ?user= reads your own data", func(t *testing.T) {
+		res := runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, "")
+		res.assertAllowed(t, alice.ID, "own data with no ?user=")
+	})
+
+	t.Run("?user= pointing at yourself needs no link", func(t *testing.T) {
+		clearLink(t, ctx, pool, alice.ID, bob.ID)
+		res := runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, fmt.Sprintf("user=%d", alice.ID))
+		res.assertAllowed(t, alice.ID, "self-reference")
+	})
+
+	t.Run("no link at all is denied", func(t *testing.T) {
+		clearLink(t, ctx, pool, alice.ID, bob.ID)
+		res := runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, fmt.Sprintf("user=%d", bob.ID))
+		res.assertDenied(t, "unlinked account")
+	})
+
+	// A pending request is an invitation, not consent. Reading on the strength
+	// of one would mean sending a link request were enough to see someone's
+	// data before they ever answered.
+	t.Run("pending link is denied even with every share flag on", func(t *testing.T) {
+		setLink(t, ctx, pool, alice.ID, bob.ID, "pending", all, all)
+		res := runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, fmt.Sprintf("user=%d", bob.ID))
+		res.assertDenied(t, "pending link")
+
+		res = runLinkAuth(t, ctx, pool, service.ShareNutrition, bob, fmt.Sprintf("user=%d", alice.ID))
+		res.assertDenied(t, "pending link, other direction")
+	})
+
+	t.Run("accepted link grants only the categories it names", func(t *testing.T) {
+		// Bob (the target) shares nutrition and weight with Alice. Todos and
+		// notes stay private; "notes" is absent from the JSON entirely, which
+		// must read as false rather than as NULL/true.
+		setLink(t, ctx, pool, alice.ID, bob.ID, "accepted",
+			map[string]bool{},
+			map[string]bool{service.ShareNutrition: true, service.ShareWeight: true, service.ShareTodos: false})
+
+		for _, category := range []string{service.ShareNutrition, service.ShareWeight} {
+			res := runLinkAuth(t, ctx, pool, category, alice, fmt.Sprintf("user=%d", bob.ID))
+			res.assertAllowed(t, bob.ID, "granted category "+category)
+		}
+		for _, category := range []string{service.ShareTodos, service.ShareNotes} {
+			res := runLinkAuth(t, ctx, pool, category, alice, fmt.Sprintf("user=%d", bob.ID))
+			res.assertDenied(t, "ungranted category "+category)
+		}
+	})
+
+	// The share flags are per direction. Bob letting Alice see his nutrition
+	// must not let Bob see Alice's — this is the row of the table that would
+	// turn "I shared with you" into "we shared with each other".
+	t.Run("sharing is directional", func(t *testing.T) {
+		setLink(t, ctx, pool, alice.ID, bob.ID, "accepted",
+			map[string]bool{}, // Alice → Bob: nothing
+			map[string]bool{service.ShareNutrition: true}) // Bob → Alice: nutrition
+
+		runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, fmt.Sprintf("user=%d", bob.ID)).
+			assertAllowed(t, bob.ID, "Alice reading Bob, who shares with her")
+		runLinkAuth(t, ctx, pool, service.ShareNutrition, bob, fmt.Sprintf("user=%d", alice.ID)).
+			assertDenied(t, "Bob reading Alice, who shares nothing")
+
+		// Now Alice opts in too; the reverse direction opens and nothing else does.
+		setLink(t, ctx, pool, alice.ID, bob.ID, "accepted",
+			map[string]bool{service.ShareNutrition: true},
+			map[string]bool{service.ShareNutrition: true})
+		runLinkAuth(t, ctx, pool, service.ShareNutrition, bob, fmt.Sprintf("user=%d", alice.ID)).
+			assertAllowed(t, alice.ID, "Bob reading Alice after she opted in")
+		runLinkAuth(t, ctx, pool, service.ShareWeight, bob, fmt.Sprintf("user=%d", alice.ID)).
+			assertDenied(t, "weight was never shared")
+	})
+
+	// Declining a request and removing a link both DELETE the row (there is no
+	// 'declined' status — the CHECK constraint permits only pending/accepted),
+	// so revocation has to take effect on the very next request.
+	t.Run("deleting the link revokes access immediately", func(t *testing.T) {
+		setLink(t, ctx, pool, alice.ID, bob.ID, "accepted", map[string]bool{}, all)
+		runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, fmt.Sprintf("user=%d", bob.ID)).
+			assertAllowed(t, bob.ID, "before revocation")
+
+		clearLink(t, ctx, pool, alice.ID, bob.ID)
+		runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, fmt.Sprintf("user=%d", bob.ID)).
+			assertDenied(t, "after the link was removed")
+	})
+
+	t.Run("a third party's link grants nothing", func(t *testing.T) {
+		// Bob and Carol share everything with each other. Alice is linked to
+		// neither and must not ride along.
+		setLink(t, ctx, pool, bob.ID, carol.ID, "accepted", all, all)
+		clearLink(t, ctx, pool, alice.ID, bob.ID)
+		clearLink(t, ctx, pool, alice.ID, carol.ID)
+
+		runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, fmt.Sprintf("user=%d", bob.ID)).
+			assertDenied(t, "Alice reading Bob via Bob↔Carol")
+		runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, fmt.Sprintf("user=%d", carol.ID)).
+			assertDenied(t, "Alice reading Carol via Bob↔Carol")
+
+		clearLink(t, ctx, pool, bob.ID, carol.ID)
+	})
+
+	t.Run("malformed and hostile ?user= values", func(t *testing.T) {
+		clearLink(t, ctx, pool, alice.ID, bob.ID)
+
+		// Values that do not parse as an integer fall back to the caller's own
+		// id. That is fail-closed — you see your own data, never someone
+		// else's — and is pinned here so the fallback cannot quietly become
+		// "ignore the check". (/api/v1 answers 400 for the same input; the two
+		// surfaces differ on purpose, the legacy one predates the problem+json
+		// contract.)
+		for _, raw := range []string{"abc", "1.5", "", "%20", "null", "1;2", "1+OR+1=1"} {
+			res := runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, "user="+raw)
+			res.assertAllowed(t, alice.ID, fmt.Sprintf("unparseable ?user=%q falls back to self", raw))
+		}
+
+		// Values that DO parse but name no reachable account are denied, and
+		// denied identically — a different status or body would let a caller
+		// enumerate which user ids exist.
+		for _, raw := range []string{"0", "-1", "2147483647", "99999999999999999"} {
+			res := runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, "user="+raw)
+			res.assertDenied(t, fmt.Sprintf("?user=%s", raw))
+		}
+	})
+
+	t.Run("denial is indistinguishable across causes", func(t *testing.T) {
+		// no link / accepted-but-not-shared / nonexistent user must produce
+		// byte-identical responses.
+		clearLink(t, ctx, pool, alice.ID, bob.ID)
+		noLink := runLinkAuth(t, ctx, pool, service.ShareNotes, alice, fmt.Sprintf("user=%d", bob.ID))
+
+		setLink(t, ctx, pool, alice.ID, bob.ID, "accepted", map[string]bool{}, map[string]bool{service.ShareNotes: false})
+		notShared := runLinkAuth(t, ctx, pool, service.ShareNotes, alice, fmt.Sprintf("user=%d", bob.ID))
+
+		noSuchUser := runLinkAuth(t, ctx, pool, service.ShareNotes, alice, "user=2147483646")
+
+		for _, r := range []linkResult{noLink, notShared, noSuchUser} {
+			r.assertDenied(t, "enumeration probe")
+		}
+		if noLink.status != notShared.status || noLink.body != notShared.body {
+			t.Errorf("an unlinked account and a non-sharing one are distinguishable:\n%d %q\n%d %q",
+				noLink.status, noLink.body, notShared.status, notShared.body)
+		}
+		if noLink.status != noSuchUser.status || noLink.body != noSuchUser.body {
+			t.Errorf("a nonexistent user id is distinguishable from an unshared one:\n%d %q\n%d %q",
+				noLink.status, noLink.body, noSuchUser.status, noSuchUser.body)
+		}
+	})
+
+	t.Run("context carries the target so handlers read the right rows", func(t *testing.T) {
+		setLink(t, ctx, pool, alice.ID, bob.ID, "accepted", map[string]bool{}, all)
+		res := runLinkAuth(t, ctx, pool, service.ShareWeight, alice, fmt.Sprintf("user=%d", bob.ID))
+		res.assertAllowed(t, bob.ID, "linked read")
+		if res.targetUser.Email != bob.Email {
+			t.Errorf("target user email = %q, want %q — the wrong account was loaded", res.targetUser.Email, bob.Email)
+		}
+	})
+}
+
+// TestGetTargetUserWithoutMiddleware pins the fallback every handler relies on:
+// a route that does NOT mount RequireLinkAuth leaves no target in the context,
+// so GetTargetUser returns nil and the handlers fall back to the current user.
+// That is exactly what makes ?user= inert on a mutating route.
+func TestGetTargetUserWithoutMiddleware(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/entries?user=999", nil).
+		WithContext(WithTestUser(t.Context(), &model.User{ID: 1, Email: "a@example.com"}))
+
+	if u := GetTargetUser(req); u != nil {
+		t.Errorf("GetTargetUser = %v, want nil when RequireLinkAuth is not mounted", u)
+	}
+	if id := GetTargetUserID(req); id != 0 {
+		t.Errorf("GetTargetUserID = %d, want 0 when RequireLinkAuth is not mounted", id)
+	}
+}
+
+// --- The read-only invariant, as a table over the router -------------------
+//
+// CLAUDE.md: "Shared data is read-only (no editing other users' entries)."
+//
+// Nothing in the type system enforces that. It holds only because every route
+// that honours ?user= is a GET, and every handler that reads the target user is
+// mounted behind RequireLinkAuth. Both halves are one-line edits away from
+// being false, so both are asserted here directly against the route table in
+// cmd/server/main.go and the handler sources.
+
+var routeRe = regexp.MustCompile(
+	`\.(Get|Post|Put|Patch|Delete|Head|Options)\(\s*"([^"]*)"\s*,\s*([A-Za-z_][A-Za-z0-9_.]*)\)`)
+
+type route struct {
+	line    int
+	method  string
+	path    string
+	handler string // e.g. "entriesHandler.Overview"
+	chain   string // the text before the registration: the .With(...) middleware list
+}
+
+// parseRoutes extracts the route table from a Go source file. Registrations
+// whose handler is a call expression or a func literal are skipped; only the
+// `var.Method` form is of interest here.
+func parseRoutes(t *testing.T, path string) []route {
+	t.Helper()
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var out []route
+	for i, line := range strings.Split(string(src), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "r.") || strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		loc := routeRe.FindStringSubmatchIndex(trimmed)
+		if loc == nil {
+			continue
+		}
+		m := routeRe.FindStringSubmatch(trimmed)
+		out = append(out, route{
+			line:    i + 1,
+			method:  m[1],
+			path:    m[2],
+			handler: m[3],
+			chain:   trimmed[:loc[0]],
+		})
+	}
+	return out
+}
+
+type methodKey struct{ recv, name string }
+
+func (k methodKey) String() string { return k.recv + "." + k.name }
+
+// methodsCalling returns the methods in a package directory whose bodies
+// mention any of the given selectors ("middleware.GetTargetUser", or a bare
+// "resolveTarget" for calls on the receiver).
+func methodsCalling(t *testing.T, dir string, wanted map[string]bool) map[methodKey]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", dir, err)
+	}
+
+	found := map[methodKey]bool{}
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Recv == nil || len(fn.Recv.List) == 0 || fn.Body == nil {
+					continue
+				}
+				recv := ""
+				switch rt := fn.Recv.List[0].Type.(type) {
+				case *ast.StarExpr:
+					if id, ok := rt.X.(*ast.Ident); ok {
+						recv = id.Name
+					}
+				case *ast.Ident:
+					recv = rt.Name
+				}
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					sel, ok := n.(*ast.SelectorExpr)
+					if !ok {
+						return true
+					}
+					if wanted[sel.Sel.Name] {
+						found[methodKey{recv, fn.Name.Name}] = true
+						return true
+					}
+					if x, ok := sel.X.(*ast.Ident); ok && wanted[x.Name+"."+sel.Sel.Name] {
+						found[methodKey{recv, fn.Name.Name}] = true
+					}
+					return true
+				})
+			}
+		}
+	}
+	return found
+}
+
+// handlerVarTypes maps the local variables in main.go to their handler types,
+// so `notesHandler.Get` can be resolved to `NotesHandler.Get` (there is more
+// than one handler with a method called Get).
+func handlerVarTypes(t *testing.T, path string) map[string]string {
+	t.Helper()
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	re := regexp.MustCompile(`(\w+)\s*:?=\s*&handler\.(\w+)\{`)
+	out := map[string]string{}
+	for _, m := range re.FindAllStringSubmatch(string(src), -1) {
+		out[m[1]] = m[2]
+	}
+	return out
+}
+
+func TestSharedDataIsReadOnlyAcrossTheRouter(t *testing.T) {
+	const mainGo = "../../cmd/server/main.go"
+
+	routes := parseRoutes(t, mainGo)
+	if len(routes) < 40 {
+		t.Fatalf("only %d routes parsed out of %s; the route-table guard is not actually looking at "+
+			"anything. Fix parseRoutes before trusting this test.", len(routes), mainGo)
+	}
+
+	varTypes := handlerVarTypes(t, mainGo)
+	targetReaders := methodsCalling(t, "../handler", map[string]bool{
+		"middleware.GetTargetUser":   true,
+		"middleware.GetTargetUserID": true,
+	})
+	if len(targetReaders) == 0 {
+		t.Fatal("no handler methods were found reading the target user; the AST scan is broken")
+	}
+
+	linkAuthed := map[methodKey]bool{}
+	for _, rt := range routes {
+		hasLinkAuth := strings.Contains(rt.chain, "RequireLinkAuth")
+
+		// 1. ?user= may only be honoured on a read.
+		if hasLinkAuth && rt.method != "Get" {
+			t.Errorf("%s:%d — %s %s mounts RequireLinkAuth on a mutating method. "+
+				"Shared data is read-only; a linked account must never be able to write.",
+				mainGo, rt.line, rt.method, rt.path)
+		}
+
+		key, known := resolveHandler(rt.handler, varTypes)
+		if !known {
+			continue
+		}
+		if hasLinkAuth {
+			linkAuthed[key] = true
+		}
+
+		// 2. A handler that reads the target user must be gated by the
+		//    middleware that validates it — otherwise ?user= would be honoured
+		//    with no authorization check at all.
+		if targetReaders[key] {
+			if !hasLinkAuth {
+				t.Errorf("%s:%d — %s %s serves %s, which reads middleware.GetTargetUser, but the route "+
+					"does not mount RequireLinkAuth. ?user= would be honoured unchecked.",
+					mainGo, rt.line, rt.method, rt.path, key)
+			}
+			if rt.method != "Get" {
+				t.Errorf("%s:%d — %s %s serves %s, which reads the target user, on a mutating method.",
+					mainGo, rt.line, rt.method, rt.path, key)
+			}
+		}
+	}
+
+	// 3. The two sets must match exactly: no handler reads a target it was not
+	//    given, and no route validates a target nobody uses.
+	if got, want := keys(linkAuthed), keys(targetReaders); !equalStrings(got, want) {
+		t.Errorf("the set of RequireLinkAuth-gated handlers and the set of handlers reading the target "+
+			"user disagree.\n  gated by RequireLinkAuth: %v\n  reading the target user:  %v", got, want)
+	}
+	if len(linkAuthed) < 4 {
+		t.Errorf("only %d link-authorized routes found; expected the nutrition, weight, todos and notes "+
+			"read routes at minimum", len(linkAuthed))
+	}
+}
+
+// TestV1SharedDataIsReadOnly is the same invariant on the public API. There,
+// ?user= is resolved by V1Handler.resolveTarget rather than by middleware, and
+// its doc comment claims "no write endpoint calls this". This asserts it.
+func TestV1SharedDataIsReadOnly(t *testing.T) {
+	const v1Router = "../handler/v1_router.go"
+
+	routes := parseRoutes(t, v1Router)
+	if len(routes) < 15 {
+		t.Fatalf("only %d routes parsed out of %s; the guard is not looking at the real route table",
+			len(routes), v1Router)
+	}
+
+	resolvers := methodsCalling(t, "../handler", map[string]bool{"resolveTarget": true})
+	// resolveTarget itself is in the set; drop it, it is the definition.
+	delete(resolvers, methodKey{"V1Handler", "resolveTarget"})
+	if len(resolvers) == 0 {
+		t.Fatal("no v1 handlers were found calling resolveTarget; the AST scan is broken")
+	}
+
+	mounted := map[methodKey]bool{}
+	for _, rt := range routes {
+		name := rt.handler
+		if i := strings.LastIndex(name, "."); i >= 0 {
+			name = name[i+1:]
+		}
+		key := methodKey{"V1Handler", name}
+		if !resolvers[key] {
+			continue
+		}
+		mounted[key] = true
+		if rt.method != "Get" {
+			t.Errorf("%s:%d — %s %s serves %s, which honours ?user=, on a mutating method. "+
+				"A token would be able to write to a linked account.", v1Router, rt.line, rt.method, rt.path, key)
+		}
+	}
+	if len(mounted) != len(resolvers) {
+		t.Errorf("handlers calling resolveTarget that no parsed route mounts: gated %v, callers %v",
+			keys(mounted), keys(resolvers))
+	}
+}
+
+// resolveHandler turns a route's handler expression into a Type.Method key.
+func resolveHandler(expr string, varTypes map[string]string) (methodKey, bool) {
+	i := strings.LastIndex(expr, ".")
+	if i < 0 {
+		return methodKey{}, false
+	}
+	recvVar, method := expr[:i], expr[i+1:]
+	typ, ok := varTypes[recvVar]
+	if !ok {
+		return methodKey{}, false
+	}
+	return methodKey{typ, method}, true
+}
+
+func keys(m map[methodKey]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k.String())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -1,0 +1,257 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// wantCSP is the Content-Security-Policy this application serves, pinned
+// byte-for-byte.
+//
+// The point of an exact-match assertion (rather than a set of "contains"
+// checks) is that the CSP is the last line of defence against an injected
+// script, and it is the kind of header that gets quietly widened to make a
+// third-party library work. With this test in place, widening it is a visible
+// diff in a security test that a reviewer has to approve on purpose, instead of
+// a one-word edit in a middleware nobody reads.
+const wantCSP = "default-src 'self'; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"font-src 'self'; " +
+	"img-src 'self' data: blob:; " +
+	"script-src 'self'"
+
+// wantSecurityHeaders is the full header set, name → exact value.
+var wantSecurityHeaders = map[string]string{
+	"Content-Security-Policy":           wantCSP,
+	"Cross-Origin-Opener-Policy":        "same-origin",
+	"Cross-Origin-Resource-Policy":      "same-origin",
+	"Origin-Agent-Cluster":              "?1",
+	"Referrer-Policy":                   "no-referrer",
+	"Strict-Transport-Security":         "max-age=15552000; includeSubDomains",
+	"X-Content-Type-Options":            "nosniff",
+	"X-DNS-Prefetch-Control":            "off",
+	"X-Download-Options":                "noopen",
+	"X-Frame-Options":                   "SAMEORIGIN",
+	"X-Permitted-Cross-Domain-Policies": "none",
+	"X-XSS-Protection":                  "0",
+}
+
+// serveThrough runs one request through SecurityHeaders and returns the
+// recorder, so each test can pick its own downstream behaviour.
+func serveThrough(next http.Handler, r *http.Request) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	SecurityHeaders(next).ServeHTTP(rec, r)
+	return rec
+}
+
+// cspDirectives splits a policy into directive name → source list.
+func cspDirectives(policy string) map[string][]string {
+	out := make(map[string][]string)
+	for _, d := range strings.Split(policy, ";") {
+		fields := strings.Fields(d)
+		if len(fields) == 0 {
+			continue
+		}
+		out[fields[0]] = fields[1:]
+	}
+	return out
+}
+
+func TestSecurityHeadersCSPIsExact(t *testing.T) {
+	rec := serveThrough(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	got := rec.Header().Get("Content-Security-Policy")
+	if got != wantCSP {
+		t.Errorf("Content-Security-Policy changed.\n got: %s\nwant: %s\n\n"+
+			"If this change is deliberate, update wantCSP in this test in the same commit — "+
+			"and read the unsafe-eval assertions below before you do.", got, wantCSP)
+	}
+}
+
+// TestSecurityHeadersScriptSrcHasNoUnsafeDirectives is the assertion CLAUDE.md's
+// "never use eval() or Function() in client-side code" rule depends on.
+//
+// client/src/lib/mathParser.ts exists precisely because 'unsafe-eval' is absent
+// here. Until this test existed, the rule was a comment: relaxing the CSP to
+// make some library work would have broken nothing and failed nothing, and the
+// hand-written parser would have become dead weight guarding a door that was
+// already open.
+func TestSecurityHeadersScriptSrcHasNoUnsafeDirectives(t *testing.T) {
+	rec := serveThrough(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+		httptest.NewRequest(http.MethodGet, "/", nil))
+	dirs := cspDirectives(rec.Header().Get("Content-Security-Policy"))
+
+	scriptSrc, ok := dirs["script-src"]
+	if !ok {
+		t.Fatal("the policy has no script-src directive; scripts would fall back to default-src")
+	}
+	for _, src := range scriptSrc {
+		switch src {
+		case "'unsafe-eval'":
+			t.Errorf("script-src contains 'unsafe-eval'. This re-enables eval()/Function() in the "+
+				"browser and makes client/src/lib/mathParser.ts pointless. script-src = %v", scriptSrc)
+		case "'unsafe-inline'":
+			t.Errorf("script-src contains 'unsafe-inline'. Inline <script> becomes executable and the "+
+				"CSP stops being an XSS mitigation. script-src = %v", scriptSrc)
+		case "'unsafe-hashes'", "*", "data:", "blob:":
+			t.Errorf("script-src contains %q, which widens the script origin set. script-src = %v", src, scriptSrc)
+		}
+	}
+
+	// 'unsafe-inline' is legitimate for styles (Svelte emits inline style
+	// attributes) and nowhere else. 'unsafe-eval' is legitimate nowhere.
+	for name, sources := range dirs {
+		for _, src := range sources {
+			if src == "'unsafe-eval'" {
+				t.Errorf("%s contains 'unsafe-eval'; no directive in this policy may", name)
+			}
+			if src == "'unsafe-inline'" && name != "style-src" {
+				t.Errorf("%s contains 'unsafe-inline'; only style-src may", name)
+			}
+		}
+	}
+
+	// default-src is the fallback for every directive that is not listed
+	// (connect-src, frame-src, object-src, …), so it must stay at 'self'.
+	if want := []string{"'self'"}; len(dirs["default-src"]) != 1 || dirs["default-src"][0] != want[0] {
+		t.Errorf("default-src = %v, want %v — it is the fallback for every unlisted directive",
+			dirs["default-src"], want)
+	}
+}
+
+func TestSecurityHeadersTable(t *testing.T) {
+	rec := serveThrough(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), httptest.NewRequest(http.MethodGet, "/api/dashboard", nil))
+
+	for name, want := range wantSecurityHeaders {
+		t.Run(name, func(t *testing.T) {
+			if got := rec.Header().Get(name); got != want {
+				t.Errorf("%s = %q, want %q", name, got, want)
+			}
+		})
+	}
+}
+
+// TestSecurityHeadersHSTSIsAtLeastSixMonths guards the one header whose value
+// is a number that means something: browsers only accept a site into the HSTS
+// preload list at max-age >= 31536000, and anything under a few months makes
+// the header close to decorative.
+func TestSecurityHeadersHSTSIsAtLeastSixMonths(t *testing.T) {
+	rec := serveThrough(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+		httptest.NewRequest(http.MethodGet, "/", nil))
+
+	hsts := rec.Header().Get("Strict-Transport-Security")
+	if !strings.HasPrefix(hsts, "max-age=15552000") {
+		t.Errorf("Strict-Transport-Security = %q; the max-age was changed from 15552000 (180 days). "+
+			"Lowering it shortens the window in which a browser refuses plaintext.", hsts)
+	}
+	if !strings.Contains(hsts, "includeSubDomains") {
+		t.Errorf("Strict-Transport-Security = %q, want includeSubDomains", hsts)
+	}
+}
+
+// TestSecurityHeadersOnEveryResponseKind covers the failure mode where headers
+// are set only on the happy path. A 500 rendered into an HTML page, a 404, a
+// redirect and a static asset are all places an injected script could land, so
+// they need the same policy as a 200.
+func TestSecurityHeadersOnEveryResponseKind(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		handler http.HandlerFunc
+	}{
+		{"200 with body", "/api/dashboard", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"ok":true}`))
+		}},
+		{"500 error response", "/api/dashboard", func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+		}},
+		{"404 not found", "/nope", func(w http.ResponseWriter, r *http.Request) {
+			http.NotFound(w, r)
+		}},
+		{"401 unauthorized", "/api/tokens", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}},
+		{"302 redirect", "/login", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/", http.StatusFound)
+		}},
+		{"static JS asset", "/assets/index-DOugxfrc.js", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/javascript")
+			w.Write([]byte("console.log(1)"))
+		}},
+		{"index.html", "/index.html", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			w.Write([]byte("<!doctype html>"))
+		}},
+		{"handler that writes nothing at all", "/", func(w http.ResponseWriter, r *http.Request) {}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := serveThrough(tc.handler, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			for name, want := range wantSecurityHeaders {
+				if got := rec.Header().Get(name); got != want {
+					t.Errorf("%s = %q, want %q", name, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestSecurityHeadersSurviveStaticAssetShortcut pins the interaction with the
+// middleware order in cmd/server/main.go: SecurityHeaders is mounted ABOVE
+// SkipStaticAssets, so the session/user shortcut for asset requests must not
+// also skip the policy. Swapping those two lines is an easy mistake and would
+// silently ship unprotected assets.
+func TestSecurityHeadersSurviveStaticAssetShortcut(t *testing.T) {
+	skipped := false
+	authLike := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			skipped = false
+			next.ServeHTTP(w, r)
+		})
+	}
+	final := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("asset"))
+	})
+
+	// Same order as main.go: SecurityHeaders → SkipStaticAssets(auth).
+	h := SecurityHeaders(SkipStaticAssets(authLike)(final))
+
+	skipped = true
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/assets/index-DOugxfrc.js", nil))
+
+	if !skipped {
+		t.Fatal("test setup: the asset request did not take the SkipStaticAssets shortcut")
+	}
+	if got := rec.Header().Get("Content-Security-Policy"); got != wantCSP {
+		t.Errorf("static asset served without the CSP: got %q", got)
+	}
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("static asset served without X-Content-Type-Options: got %q", got)
+	}
+}
+
+// TestSecurityHeadersCallsNext is the trivial-but-necessary check that the
+// middleware is not a dead end.
+func TestSecurityHeadersCallsNext(t *testing.T) {
+	called := false
+	rec := serveThrough(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	}), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if !called {
+		t.Error("downstream handler was not called")
+	}
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("status = %d, want %d — the middleware must not write a status of its own",
+			rec.Code, http.StatusTeapot)
+	}
+}

--- a/internal/middleware/v1_bodylimit_test.go
+++ b/internal/middleware/v1_bodylimit_test.go
@@ -1,0 +1,174 @@
+// This file is in the external test package because it imports
+// internal/handler to mount the real /api/v1 router, and internal/handler
+// imports internal/middleware — an in-package test file would be an import
+// cycle.
+package middleware_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"schautrack/internal/apierr"
+	"schautrack/internal/database"
+	"schautrack/internal/handler"
+	"schautrack/internal/middleware"
+	"schautrack/internal/service"
+)
+
+// TestV1BodyLimitBeatsTheGlobalLimit covers the interaction between the two
+// request caps this application has.
+//
+// cmd/server/main.go mounts middleware.MaxBodySize(15 << 20) globally, sized
+// for photo uploads and account imports on the legacy surface. handler's
+// decodeV1 wraps the body a second time at maxV1Body (1 MB), because nothing
+// on the public API takes a payload anywhere near 15 MB.
+//
+// A 5 MB request to a v1 route therefore sits between the two limits, and the
+// tighter one has to win — with the v1 surface's error contract (RFC 9457
+// problem+json, 413), not a bare net/http rejection. Getting this wrong in
+// either direction is invisible from a unit test of either middleware alone:
+// the global cap would silently accept 5 MB, and the v1 cap can only be
+// reached through the real router.
+//
+// Needs a database: /api/v1 authenticates with a real personal access token,
+// and RequireAPIToken runs before any body is read.
+func TestV1BodyLimitBeatsTheGlobalLimit(t *testing.T) {
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+	if err := database.InitSchemaWithRetry(ctx, pool, 3); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	email := fmt.Sprintf("v1-bodylimit-%d@middleware.test", time.Now().UnixNano())
+	var userID int
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email, password_hash, email_verified) VALUES ($1, 'x', true) RETURNING id`,
+		email).Scan(&userID); err != nil {
+		t.Fatalf("seeding the user failed: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID)
+	})
+
+	_, rawToken, err := service.CreateAPIToken(ctx, pool, userID, "body limit test",
+		[]string{service.ScopeEntriesWrite}, nil)
+	if err != nil {
+		t.Fatalf("minting an API token failed: %v", err)
+	}
+
+	// The same two layers as production: the global cap outside, the real v1
+	// router (which applies maxV1Body inside decodeV1) within.
+	v1 := &handler.V1Handler{Pool: pool}
+	root := chi.NewRouter()
+	root.Use(middleware.MaxBodySize(15 << 20))
+	root.Mount("/api/v1", v1.MountAPIV1(pool))
+
+	srv := httptest.NewServer(root)
+	defer srv.Close()
+
+	post := func(t *testing.T, body []byte) *http.Response {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/entries", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("building the request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+rawToken)
+
+		resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+		if err != nil {
+			t.Fatalf("the request produced a transport error instead of an HTTP response: %v", err)
+		}
+		t.Cleanup(func() { resp.Body.Close() })
+		return resp
+	}
+
+	decodeProblem := func(t *testing.T, resp *http.Response) apierr.Problem {
+		t.Helper()
+		var p apierr.Problem
+		if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
+			t.Fatalf("response body is not a problem document: %v", err)
+		}
+		return p
+	}
+
+	// Control: a well-formed but rejected small body proves the route is
+	// reachable with this token, so a 413 below is really the size check and
+	// not a mis-wired test.
+	t.Run("control: a small body reaches the handler", func(t *testing.T) {
+		resp := post(t, []byte(`{"totally_unknown_field": 1}`))
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400 for an unknown field (the route must be reachable)", resp.StatusCode)
+		}
+		if ct := resp.Header.Get("Content-Type"); ct != apierr.ContentType {
+			t.Errorf("Content-Type = %q, want %q", ct, apierr.ContentType)
+		}
+	})
+
+	// 5 MB: under the 15 MB global cap, far over the 1 MB v1 cap.
+	t.Run("5 MB hits the v1 limit, not the global one", func(t *testing.T) {
+		body := append([]byte(`{"description":"`), bytes.Repeat([]byte("a"), 5<<20)...)
+		body = append(body, []byte(`","calories":100}`)...)
+
+		resp := post(t, body)
+		if resp.StatusCode != http.StatusRequestEntityTooLarge {
+			t.Fatalf("status = %d, want 413 — a 5 MB body slipped past the 1 MB v1 cap", resp.StatusCode)
+		}
+		if ct := resp.Header.Get("Content-Type"); ct != apierr.ContentType {
+			t.Errorf("Content-Type = %q, want %q — the v1 surface must answer in problem+json even here",
+				ct, apierr.ContentType)
+		}
+
+		p := decodeProblem(t, resp)
+		if !strings.HasSuffix(p.Type, "/body-too-large") {
+			t.Errorf("problem type = %q, want the body-too-large type", p.Type)
+		}
+		if p.Status != http.StatusRequestEntityTooLarge {
+			t.Errorf("problem status field = %d, want 413", p.Status)
+		}
+		if !strings.Contains(p.Detail, "1048576") {
+			t.Errorf("detail = %q; it should name the 1 MB v1 limit so a caller knows which cap it hit "+
+				"(quoting the 15 MB global limit here would be actively misleading)", p.Detail)
+		}
+	})
+
+	// Over the global cap too. The v1 reader is the inner one, so it still
+	// trips first and the caller still gets a problem document rather than
+	// net/http's bare "request body too large".
+	t.Run("20 MB still produces a v1 problem document", func(t *testing.T) {
+		body := append([]byte(`{"description":"`), bytes.Repeat([]byte("a"), 20<<20)...)
+		body = append(body, []byte(`","calories":100}`)...)
+
+		resp := post(t, body)
+		if resp.StatusCode != http.StatusRequestEntityTooLarge {
+			t.Fatalf("status = %d, want 413", resp.StatusCode)
+		}
+		if ct := resp.Header.Get("Content-Type"); ct != apierr.ContentType {
+			t.Errorf("Content-Type = %q, want %q", ct, apierr.ContentType)
+		}
+	})
+}


### PR DESCRIPTION
Closes #314

`internal/middleware` sat at **44.5%** statement coverage. The tested half was the half that was hard to get right (`apiauth`, `ratelimit`, `stepup`, `timezone`, `static`, `accesslog`); the untested half was the half that is easy to get right and catastrophic to get wrong. This covers four of the five files named in the issue. `recovery.go` / `recovery_test.go` are **untouched** — they belong to #307, which is in flight on `recovery-problem-json-v1` in the same package.

## What is now pinned

### 1. `SecurityHeaders` — `internal/middleware/security_test.go`

- The **exact** `Content-Security-Policy` string, so any change to it is a deliberate diff a reviewer has to approve.
- `script-src` carries neither `'unsafe-eval'` nor `'unsafe-inline'` (nor `'unsafe-hashes'`, `*`, `data:`, `blob:`). More generally: no directive may carry `'unsafe-eval'`, and only `style-src` may carry `'unsafe-inline'`. `default-src` must stay at `'self'`, since it is the fallback for every directive the policy does not list.
  This is the assertion CLAUDE.md's *"Never use `eval()` or `Function()` in client-side code"* rule depends on. `client/src/lib/mathParser.ts` exists **because** `'unsafe-eval'` is absent — until now, relaxing the CSP to make some library work would have broken nothing and failed nothing, and the hand-written parser would have become dead weight guarding an already-open door.
- All eleven remaining headers with their exact values, plus a separate check that HSTS `max-age` was not quietly lowered from 15552000.
- The full header set on a **500, a 404, a 401, a 302, a static JS asset, `index.html`, and a handler that writes nothing at all** — not just on 200s.
- The headers survive the `SkipStaticAssets` shortcut, pinning the middleware order in `main.go` (`SecurityHeaders` above `SkipStaticAssets`). Swapping those two lines would ship unprotected assets.

### 2. `RequireLinkAuth` — `internal/middleware/links_test.go` (needs a DB)

Account linking is the app's only cross-user data path, so it is the only place a bug becomes a cross-account data leak. The whole decision is one SQL statement over `account_links`, so a fake would only assert that the statement we wrote is the statement we wrote — these run against a real Postgres, gated on `TEST_DATABASE_URL` like the other integration tests (they skip cleanly in CI).

| Case | Expected |
|---|---|
| unauthenticated | 401, not 403 |
| no `?user=` | own data |
| `?user=` = your own id | allowed, no link needed |
| no link at all | 403 |
| `pending` link, **every** share flag on | 403 — an invitation is not consent |
| `accepted` link | allowed for the categories it grants, denied for those it does not (including a category absent from the JSONB entirely, which must read as `false`, not NULL/true) |
| direction | A→B accepted does not grant B→A; asserted both before and after B opts in |
| link deleted | denied on the very next request (decline and remove both DELETE the row; there is no `declined` status) |
| a third party's link | grants nothing |
| `?user=` = `abc`, `1.5`, `%20`, `null`, `1;2`, `1+OR+1=1` | falls back to self (fail-closed) — pinned, see #376 |
| `?user=` = `0`, `-1`, `2147483647`, `99999999999999999` | 403, and the out-of-int32 one does **not** 500 |
| enumeration | "not linked", "linked but not sharing" and "no such user" produce byte-identical 403s |

**The read-only invariant as a table over the router.** CLAUDE.md says *"Shared data is read-only (no editing other users' entries)."* Nothing in the type system enforces that — it holds only because every route honouring `?user=` is a GET and every handler reading the target user sits behind `RequireLinkAuth`. `TestSharedDataIsReadOnlyAcrossTheRouter` parses the real route table in `cmd/server/main.go`, resolves each handler expression to its type via the `&handler.XHandler{` declarations, AST-scans `internal/handler` for the methods that call `middleware.GetTargetUser`/`GetTargetUserID`, and asserts:

1. `RequireLinkAuth` never appears on a mutating method;
2. every handler reading the target user is mounted **with** `RequireLinkAuth` and only on a GET;
3. the two sets are **exactly equal** — no handler reads a target it was not given, no route validates a target nobody uses.

`TestV1SharedDataIsReadOnly` applies the same guard to `V1Handler.resolveTarget` on `/api/v1`, whose doc comment claims *"no write endpoint calls this"*. It does now.

Both guards were verified to actually fail by temporarily flipping `/api/notes/day` to `Post` (caught) and by removing `RequireLinkAuth` from it (caught, including the set-mismatch message), then reverting.

### 3. `MaxBodySize` — `internal/middleware/bodylimit_test.go` + `v1_bodylimit_test.go`

- Under the limit passes with the body intact; **exactly** at the limit passes (the `n` vs `n+1` boundary).
- Over the limit surfaces a real `*http.MaxBytesError` with the right `Limit`, not a silently truncated read — a handler that cannot tell those apart parses half a JSON document.
- A request **lying about `Content-Length`** (claims 10 bytes, sends 4 KB) is still capped, and so is a chunked request announcing no length at all. `MaxBytesReader` counts bytes read, not the header.
- Over a **real TCP connection**, not a recorder: an oversized upload ends in a readable `413` rather than a hang or a transport error. That failure mode is invisible to `httptest.NewRecorder`.
- `TestGlobalBodyLimitIsMountedAt15MB` pins the literal at the mount site in `main.go` — the middleware is generic, the deployed number is not.
- **The interaction with `maxV1Body`.** `v1_bodylimit_test.go` (external test package, because it imports `internal/handler` which imports `internal/middleware`) mounts the *real* `/api/v1` router under the *real* 15 MB global cap and drives it with a real personal access token. A 5 MB body sits between the two limits: the tighter one must win, and answer **413 `application/problem+json`** with the `body-too-large` type and a detail naming `1048576` — quoting the 15 MB limit there would be actively misleading. A control request proves the route is reachable with that token first, and a 20 MB body confirms the v1 reader (the inner one) still trips first, so the caller gets a problem document rather than net/http's bare rejection.

### 4. `RequireLogin` / `RequireAdmin` / `RequireLocalAuth` — `internal/middleware/auth_test.go`

A 16-row `IsAdmin` table, and a `RequireAdmin` table over the middleware itself:

- no session → 403; valid session, non-admin email → 403.
- The match **is** case-insensitive, on both sides.
- **An empty `ADMIN_EMAIL` does not make everyone an admin** — asserted for an ordinary user, the would-be admin, a request with no session, and the both-empty-strings case.
- A whitespace-only `ADMIN_EMAIL` is likewise nobody's.
- The 403 body is identical whether `ADMIN_EMAIL` is unset, someone else's, or just not yours — a differing message would tell an attacker whether the deployment has an admin account worth attacking.
- `RequireLocalAuth` refuses an `oidc` session on **all nine** local-auth routes and passes `password` / `passkey` / no-`auth_method`.

## Security findings

**No hole was found in the empty-`ADMIN_EMAIL` case** — `IsAdmin` already guarded it, and it is now locked down by tests from four angles.

**One hardening fix, in `internal/middleware/auth.go`:** `IsAdmin` now trims `adminEmail` *before* the empty check.

```go
adminEmail = strings.TrimSpace(adminEmail)
if adminEmail == "" || user == nil {
	return false
}
return strings.EqualFold(user.Email, adminEmail)
```

`config.go` reads `ADMIN_EMAIL` straight from `os.Getenv` with no cleaning, so a trailing newline out of a `.env` file or a Kubernetes secret used to lock the real admin out of their own panel with a bare 403. This is a lockout footgun rather than a security hole — it failed closed — but the fix is strictly safer in both directions: the empty check happens *after* the trim, so a whitespace-only value still makes nobody an admin. `user.Email` is deliberately **not** trimmed: addresses are normalized to lowercase-and-trimmed on every write path (registration, login, OIDC, email change), so there is nothing to clean, and trimming it here would let an account somehow stored as `"admin@example.com "` match `ADMIN_EMAIL`. Both directions are asserted.

**Two issues filed** for things that are fail-closed today but should not stay as they are:

- #373 — `RequireLocalAuth` fails **open** with no session, relying on an unwritten convention that `RequireLogin` is always mounted above it (`RequireScope` on `/api/v1` fails closed in the same situation, on purpose). Mitigated here by `TestAuthMiddlewareMountOrder`, which parses the route table and fails if any route mounts `RequireLocalAuth` or `RequireAdmin` without `RequireLogin` — verified to fail by temporarily removing it from `/2fa/setup`.
- #376 — the legacy `RequireLinkAuth` silently discards a malformed `?user=` and serves your own data, while `/api/v1`'s `resolveTarget` answers 400 for the same input. `?user=undefined` from a buggy client gets a 200 with the wrong data substituted. Current behaviour is pinned so whichever way it is resolved is a visible diff.

## Coverage

| | before | after |
|---|---|---|
| `go test ./internal/middleware/ -cover` (no DB) | **44.5%** | **60.2%** |
| same, with `TEST_DATABASE_URL` | 44.5% | **79.2%** |

## Verification

Both runs below are real output, `GOFLAGS=-p=2 GOMAXPROCS=2`.

**Without a database** (what CI does — the DB-gated tests must skip cleanly):

```
$ go build ./... && go vet ./... && go test ./...
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	0.013s
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	0.006s
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	0.005s
ok  	schautrack/internal/handler	1.237s
ok  	schautrack/internal/middleware	0.655s
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	0.056s
ok  	schautrack/internal/release	0.005s
ok  	schautrack/internal/service	0.221s
ok  	schautrack/internal/session	0.005s
ok  	schautrack/internal/sse	0.018s

$ go test ./internal/middleware/ -cover
ok  	schautrack/internal/middleware	0.617s	coverage: 60.2% of statements
```

The DB-gated tests skip rather than fail:

```
=== RUN   TestRequireLinkAuth
    links_test.go:197: TEST_DATABASE_URL not set; skipping integration test
--- SKIP: TestRequireLinkAuth (0.00s)
```

**With a database** (`docker run -d --rm --name pg-314 -e POSTGRES_PASSWORD=postgres -p 55314:5432 postgres:18`):

```
$ TEST_DATABASE_URL='postgres://postgres:postgres@localhost:55314/postgres?sslmode=disable' go test ./internal/middleware/... -v
=== RUN   TestRequireLinkAuth
2026/08/08 08:52:11 Schema initialization successful
--- PASS: TestRequireLinkAuth (0.07s)
    --- PASS: TestRequireLinkAuth/unauthenticated_request_is_401,_not_403 (0.00s)
    --- PASS: TestRequireLinkAuth/no_?user=_reads_your_own_data (0.00s)
    --- PASS: TestRequireLinkAuth/?user=_pointing_at_yourself_needs_no_link (0.00s)
    --- PASS: TestRequireLinkAuth/no_link_at_all_is_denied (0.00s)
    --- PASS: TestRequireLinkAuth/pending_link_is_denied_even_with_every_share_flag_on (0.00s)
    --- PASS: TestRequireLinkAuth/accepted_link_grants_only_the_categories_it_names (0.00s)
    --- PASS: TestRequireLinkAuth/sharing_is_directional (0.00s)
    --- PASS: TestRequireLinkAuth/deleting_the_link_revokes_access_immediately (0.00s)
    --- PASS: TestRequireLinkAuth/a_third_party's_link_grants_nothing (0.00s)
    --- PASS: TestRequireLinkAuth/malformed_and_hostile_?user=_values (0.00s)
    --- PASS: TestRequireLinkAuth/denial_is_indistinguishable_across_causes (0.00s)
    --- PASS: TestRequireLinkAuth/context_carries_the_target_so_handlers_read_the_right_rows (0.00s)
--- PASS: TestGetTargetUserWithoutMiddleware (0.00s)
--- PASS: TestSharedDataIsReadOnlyAcrossTheRouter (0.04s)
--- PASS: TestV1SharedDataIsReadOnly (0.03s)
--- PASS: TestIsAdmin (0.00s)   [16 subtests]
--- PASS: TestRequireAdmin (0.00s)   [7 subtests]
--- PASS: TestRequireAdminDoesNotLeakWhetherAdminExists (0.00s)
--- PASS: TestRequireLoginRejectsAnonymous (0.00s)
--- PASS: TestRequireLoginAllowsAuthenticated (0.00s)
--- PASS: TestRequireLoginIgnoresASessionWithoutAUser (0.00s)
--- PASS: TestRequireLocalAuth (0.00s)   [5 subtests]
--- PASS: TestRequireLocalAuthBlocksEveryLocalAuthRoute (0.00s)   [9 subtests]
--- PASS: TestAuthMiddlewareMountOrder (0.00s)
--- PASS: TestMaxBodySizeAllowsBodyUnderLimit (0.00s)
--- PASS: TestMaxBodySizeAllowsBodyExactlyAtLimit (0.00s)
--- PASS: TestMaxBodySizeRejectsBodyOverLimit (0.00s)
--- PASS: TestMaxBodySizeIgnoresLyingContentLength (0.00s)
--- PASS: TestMaxBodySizeChunkedWithNoContentLength (0.00s)
--- PASS: TestMaxBodySizeHandlesBodylessRequest (0.00s)
--- PASS: TestMaxBodySizeAllowsFiveMBUnderTheGlobalCap (0.00s)
--- PASS: TestMaxBodySizeOverRealConnection (0.50s)
--- PASS: TestMaxBodySizePassesThroughOtherRequestState (0.00s)
--- PASS: TestGlobalBodyLimitIsMountedAt15MB (0.00s)
--- PASS: TestSecurityHeadersCSPIsExact (0.00s)
--- PASS: TestSecurityHeadersScriptSrcHasNoUnsafeDirectives (0.00s)
--- PASS: TestSecurityHeadersTable (0.00s)   [12 subtests]
--- PASS: TestSecurityHeadersHSTSIsAtLeastSixMonths (0.00s)
--- PASS: TestSecurityHeadersOnEveryResponseKind (0.00s)   [8 subtests]
--- PASS: TestSecurityHeadersSurviveStaticAssetShortcut (0.00s)
--- PASS: TestSecurityHeadersCallsNext (0.00s)
--- PASS: TestV1BodyLimitBeatsTheGlobalLimit (0.63s)
    --- PASS: TestV1BodyLimitBeatsTheGlobalLimit/control:_a_small_body_reaches_the_handler (0.00s)
    --- PASS: TestV1BodyLimitBeatsTheGlobalLimit/5_MB_hits_the_v1_limit,_not_the_global_one (0.02s)
    --- PASS: TestV1BodyLimitBeatsTheGlobalLimit/20_MB_still_produces_a_v1_problem_document (0.04s)
PASS
ok  	schautrack/internal/middleware	1.368s

$ TEST_DATABASE_URL=... go test ./internal/middleware/ -cover
ok  	schautrack/internal/middleware	1.365s	coverage: 79.2% of statements
```

The full suite also passes with the database attached (`go test ./...`: `internal/database` 0.397s, `internal/handler` 0.815s, `internal/service` 0.292s, all `ok`), confirming the `IsAdmin` change breaks nothing downstream.

## Notes for review

- No production code changed except the four-line `IsAdmin` trim (plus its doc comment). Everything else is new `_test.go` files.
- `internal/middleware/v1_bodylimit_test.go` is `package middleware_test` rather than `package middleware`, because it imports `internal/handler` and an in-package test file would be an import cycle.
- The three router-parsing guards read `cmd/server/main.go` and `internal/handler/v1_router.go` as source. Each one has a sanity floor (route count, non-empty AST result) so it fails loudly if a refactor makes the parser match nothing, rather than passing vacuously. All three were verified against deliberately broken route tables.
- `stepup_test.go` and `timezone_test.go` show up under `gofmt -l`; that predates this branch and was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)