### PR TITLE
test: pin every Go validation bound to its Postgres CHECK constraint

### DIFF
--- a/internal/handler/bounds_db_test.go
+++ b/internal/handler/bounds_db_test.go
@@ -1,0 +1,605 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"schautrack/internal/database"
+	"schautrack/internal/service"
+)
+
+// The behavioural half of the drift guard (see bounds_test.go for the pure-Go
+// half and for why any of this exists).
+//
+// bounds_test.go compares Go constants to SQL literals it scrapes out of
+// migrations.go. That catches an edit to one side of a pair, but it is still a
+// hand-maintained transcription of the schema: get a row wrong and it pins the
+// wrong thing.
+//
+// This file has no transcription in it. For each pair it BISECTS the real Go
+// validator to find the exact value where it flips, then asks a real Postgres
+// what it does with that value and with the value one step past it:
+//
+//	the value the Go validator accepts   -> the database MUST accept
+//	the value one step past it           -> the database MUST reject
+//
+// The first direction is the 500-instead-of-400 bug. The second is the
+// silently-rejected-legitimate-value bug. Neither needs a literal written down
+// anywhere, so this half stays correct even when someone changes both sides
+// consistently but wrongly.
+//
+// Gated on TEST_DATABASE_URL exactly like internal/database's integration
+// tests. Since PR #325 CI sets it, so this runs on every build.
+
+// boundaryProbe finds where a validator flips, on a grid of 1/scale.
+//
+// The predicate must be true on one contiguous run of the grid (every bound in
+// this app is a plain range), which is what makes a bisection valid.
+type boundaryProbe struct {
+	ok    func(float64) bool
+	scale float64 // 1 for integers, 10 for tenths, 100 for hundredths
+}
+
+// extreme returns the largest (upper) or smallest (lower) value the validator
+// accepts, searching outward from a value it is known to accept.
+func (p boundaryProbe) extreme(t *testing.T, kind limitKind, from float64, span int) float64 {
+	t.Helper()
+	if !p.ok(from) {
+		t.Fatalf("the validator rejects %s, which the search has to start from", fmtNum(from))
+	}
+	dir := 1
+	if kind == lowerLimit {
+		dir = -1
+	}
+	// lo is known-accepted, hi is known-rejected, both in grid units from `from`.
+	lo, hi := 0, span
+	if p.ok(p.at(from, dir*span)) {
+		t.Fatalf("the validator still accepts %s, %d steps out: it has no %s bound at all, "+
+			"so the database is the only thing standing between the user and a 500",
+			fmtNum(p.at(from, dir*span)), span, kind)
+	}
+	for hi-lo > 1 {
+		mid := (lo + hi) / 2
+		if p.ok(p.at(from, dir*mid)) {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	return p.at(from, dir*lo)
+}
+
+// at returns `from` moved by steps grid units, computed in integer units so the
+// result is the double nearest the intended decimal.
+func (p boundaryProbe) at(from float64, steps int) float64 {
+	return (math.Round(from*p.scale) + float64(steps)) / p.scale
+}
+
+func (p boundaryProbe) next(v float64, kind limitKind) float64 {
+	if kind == lowerLimit {
+		return p.at(v, -1)
+	}
+	return p.at(v, 1)
+}
+
+// dbBound is one Go bound and the write that puts a value through it.
+type dbBound struct {
+	what  string
+	kind  limitKind
+	probe boundaryProbe
+	from  float64 // a value the validator accepts, to bisect outward from
+	span  int     // grid units to search
+	write func(ctx context.Context, tx pgx.Tx, userID int, v float64) error
+	// beyondDB is set when the column is deliberately WIDER than the Go bound
+	// (e.g. NUMERIC(6,2) holds 9999.99 while ParseWeight caps at 1500). The
+	// step past the Go bound is then legitimately accepted by the database, so
+	// the reject-side assertion uses this value — past the column's own limit —
+	// instead. Its purpose is to prove the column limit is still where the Go
+	// bound's comment claims it is.
+	beyondDB *float64
+	whyWider string
+}
+
+func f(v float64) *float64 { return &v }
+
+func dbBounds() []dbBound {
+	insertEntry := func(col string) func(context.Context, pgx.Tx, int, float64) error {
+		return func(ctx context.Context, tx pgx.Tx, userID int, v float64) error {
+			_, err := tx.Exec(ctx, fmt.Sprintf(
+				`INSERT INTO calorie_entries (user_id, entry_date, amount, %s) VALUES ($1, CURRENT_DATE, $2, $3)`, col),
+				userID, 100, int(math.Round(v)))
+			return err
+		}
+	}
+	return []dbBound{
+		{
+			what: "handler.MaxEntryCalories -> calorie_entries.amount", kind: upperLimit,
+			probe: boundaryProbe{ok: probeEntryCalories, scale: 1}, from: 0, span: 1 << 20,
+			write: func(ctx context.Context, tx pgx.Tx, userID int, v float64) error {
+				_, err := tx.Exec(ctx,
+					`INSERT INTO calorie_entries (user_id, entry_date, amount) VALUES ($1, CURRENT_DATE, $2)`,
+					userID, int(math.Round(v)))
+				return err
+			},
+		},
+		{
+			what: "-handler.MaxEntryCalories -> calorie_entries.amount", kind: lowerLimit,
+			probe: boundaryProbe{ok: probeEntryCalories, scale: 1}, from: 0, span: 1 << 20,
+			write: func(ctx context.Context, tx pgx.Tx, userID int, v float64) error {
+				_, err := tx.Exec(ctx,
+					`INSERT INTO calorie_entries (user_id, entry_date, amount) VALUES ($1, CURRENT_DATE, $2)`,
+					userID, int(math.Round(v)))
+				return err
+			},
+		},
+		{
+			what: "handler.MaxEntryMacro -> calorie_entries.protein_g", kind: upperLimit,
+			probe: boundaryProbe{ok: probeMacro, scale: 1}, from: 1, span: 1 << 20,
+			write: insertEntry("protein_g"),
+		},
+		{
+			what: "handler macro floor -> calorie_entries.protein_g", kind: lowerLimit,
+			probe: boundaryProbe{ok: probeMacro, scale: 1}, from: 1, span: 1 << 20,
+			write: insertEntry("protein_g"),
+		},
+		{
+			what: "handler.MaxEntryCalories -> saved_foods.amount", kind: upperLimit,
+			probe: boundaryProbe{ok: probeSavedAmount, scale: 1}, from: 0, span: 1 << 20,
+			write: func(ctx context.Context, tx pgx.Tx, userID int, v float64) error {
+				_, err := tx.Exec(ctx,
+					`INSERT INTO saved_foods (user_id, name, amount) VALUES ($1, 'bounds-drift-probe', $2)`,
+					userID, int(math.Round(v)))
+				return err
+			},
+		},
+		{
+			what: "handler.MaxEntryMacro -> saved_foods.protein_g", kind: upperLimit,
+			probe: boundaryProbe{ok: probeMacro, scale: 1}, from: 1, span: 1 << 20,
+			write: func(ctx context.Context, tx pgx.Tx, userID int, v float64) error {
+				_, err := tx.Exec(ctx,
+					`INSERT INTO saved_foods (user_id, name, protein_g) VALUES ($1, 'bounds-drift-probe', $2)`,
+					userID, int(math.Round(v)))
+				return err
+			},
+		},
+		{
+			// The #302 pair: a positive input that rounds to 0 used to be
+			// reported as valid and then hit weight_entries_positive as a 500.
+			what: "service.ParseWeight floor -> weight_entries.weight", kind: lowerLimit,
+			probe: boundaryProbe{ok: probeWeight, scale: 1000}, from: 1, span: 1 << 22,
+			write: insertWeight(""),
+		},
+		{
+			what: "service.MaxWeight -> weight_entries.weight", kind: upperLimit,
+			probe: boundaryProbe{ok: probeWeight, scale: 1000}, from: 1, span: 1 << 22,
+			write: insertWeight(""), beyondDB: f(10000),
+			whyWider: "NUMERIC(6,2) holds 9999.99; MaxWeight is a much lower plausibility cap",
+		},
+		{
+			what: "service.MaxBodyFatPct -> weight_entries.body_fat", kind: upperLimit,
+			probe: boundaryProbe{ok: probeBodyFat, scale: 10}, from: 1, span: 1 << 20,
+			write: insertWeight("body_fat"),
+		},
+		{
+			what: "service.ParseBodyFat floor -> weight_entries.body_fat", kind: lowerLimit,
+			probe: boundaryProbe{ok: probeBodyFat, scale: 100}, from: 1, span: 1 << 20,
+			write: insertWeight("body_fat"),
+		},
+		{
+			what: "validateHeightCm -> users.height_cm", kind: lowerLimit,
+			probe: boundaryProbe{ok: probeHeight, scale: 10}, from: 170, span: 1 << 20,
+			write: updateUser("height_cm"),
+		},
+		{
+			what: "validateHeightCm -> users.height_cm", kind: upperLimit,
+			probe: boundaryProbe{ok: probeHeight, scale: 10}, from: 170, span: 1 << 20,
+			write: updateUser("height_cm"),
+		},
+		{
+			what: "validateBirthYear -> users.birth_year", kind: lowerLimit,
+			probe: boundaryProbe{ok: probeBirth, scale: 1}, from: 1990, span: 1 << 12,
+			write: updateUserInt("birth_year"),
+		},
+		{
+			what: "validateBirthYear -> users.birth_year", kind: upperLimit,
+			probe: boundaryProbe{ok: probeBirth, scale: 1}, from: 1990, span: 1 << 12,
+			write: updateUserInt("birth_year"), beyondDB: f(2201),
+			whyWider: "the CHECK ceiling is a fixed 2200; the Go ceiling is currentYear-10 and moves",
+		},
+		{
+			what: "validateRateKgPerWeek -> weight_goals.rate_kg_per_week", kind: upperLimit,
+			probe: boundaryProbe{ok: probeRate, scale: 100}, from: 1, span: 1 << 20,
+			write: insertGoal("rate_kg_per_week"), beyondDB: f(100),
+			whyWider: "NUMERIC(4,2) holds 99.99; the Go cap is the round 99 below it",
+		},
+		{
+			what: "validateRateKgPerWeek floor -> weight_goals.rate_kg_per_week", kind: lowerLimit,
+			probe: boundaryProbe{ok: probeRate, scale: 100}, from: 1, span: 1 << 20,
+			write: insertGoal("rate_kg_per_week"), beyondDB: f(-100),
+			whyWider: "there is no CHECK on the sign of rate_kg_per_week at all — only the Go " +
+				"validator stops a negative rate, so the column accepts anything down to -99.99",
+		},
+		{
+			// The #305 pair: validateTargetWeight was unbounded, so a target
+			// weight past NUMERIC(6,2) 500'd on INSERT.
+			what: "validateTargetWeight -> weight_goals.target_weight", kind: upperLimit,
+			probe: boundaryProbe{ok: probeTargetWeight, scale: 1000}, from: 1, span: 1 << 22,
+			write: insertGoal("target_weight"), beyondDB: f(10000),
+			whyWider: "NUMERIC(6,2) holds 9999.99; the Go cap is service.MaxWeight",
+		},
+		{
+			what: "validateTargetWeight floor -> weight_goals.target_weight", kind: lowerLimit,
+			probe: boundaryProbe{ok: probeTargetWeight, scale: 1000}, from: 1, span: 1 << 22,
+			write: insertGoal("target_weight"),
+		},
+	}
+}
+
+func insertWeight(extraCol string) func(context.Context, pgx.Tx, int, float64) error {
+	return func(ctx context.Context, tx pgx.Tx, userID int, v float64) error {
+		if extraCol == "" {
+			_, err := tx.Exec(ctx,
+				`INSERT INTO weight_entries (user_id, entry_date, weight) VALUES ($1, CURRENT_DATE, $2)`,
+				userID, v)
+			return err
+		}
+		_, err := tx.Exec(ctx, fmt.Sprintf(
+			`INSERT INTO weight_entries (user_id, entry_date, weight, %s) VALUES ($1, CURRENT_DATE, 80, $2)`, extraCol),
+			userID, v)
+		return err
+	}
+}
+
+func updateUser(col string) func(context.Context, pgx.Tx, int, float64) error {
+	return func(ctx context.Context, tx pgx.Tx, userID int, v float64) error {
+		return exactlyOneRow(tx.Exec(ctx,
+			fmt.Sprintf(`UPDATE users SET %s = $2 WHERE id = $1`, col), userID, v))
+	}
+}
+
+func updateUserInt(col string) func(context.Context, pgx.Tx, int, float64) error {
+	return func(ctx context.Context, tx pgx.Tx, userID int, v float64) error {
+		return exactlyOneRow(tx.Exec(ctx,
+			fmt.Sprintf(`UPDATE users SET %s = $2 WHERE id = $1`, col), userID, int(math.Round(v))))
+	}
+}
+
+func insertGoal(col string) func(context.Context, pgx.Tx, int, float64) error {
+	return func(ctx context.Context, tx pgx.Tx, userID int, v float64) error {
+		if col == "target_weight" {
+			_, err := tx.Exec(ctx,
+				`INSERT INTO weight_goals (user_id, start_weight, start_date, target_weight, pace_mode)
+				 VALUES ($1, 100, CURRENT_DATE, $2, 'rate')`, userID, v)
+			return err
+		}
+		_, err := tx.Exec(ctx,
+			`INSERT INTO weight_goals (user_id, start_weight, start_date, target_weight, pace_mode, rate_kg_per_week)
+			 VALUES ($1, 100, CURRENT_DATE, 90, 'rate', $2)`, userID, v)
+		return err
+	}
+}
+
+// exactlyOneRow turns a no-op UPDATE into an error. Without it an UPDATE that
+// matched nothing would look exactly like a value the database happily
+// accepted, and every reject-side assertion would pass for the wrong reason.
+func exactlyOneRow(tag pgconn.CommandTag, err error) error {
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() != 1 {
+		return fmt.Errorf("updated %d rows, want 1", tag.RowsAffected())
+	}
+	return nil
+}
+
+// TestBoundsAgreeWithLiveDatabase drives every Go validator to its edge and
+// checks a real Postgres agrees on both sides of that edge.
+func TestBoundsAgreeWithLiveDatabase(t *testing.T) {
+	ctx, pool, userID := boundsTestDB(t)
+
+	for _, b := range dbBounds() {
+		t.Run(b.what+" ("+b.kind.String()+")", func(t *testing.T) {
+			// 1. Where does the Go validator actually flip? No literal from
+			//    the schema, and none from bounds_test.go, is used here.
+			edge := b.probe.extreme(t, b.kind, b.from, b.span)
+			past := b.probe.next(edge, b.kind)
+
+			// 2. Everything Go accepts, the database must accept. This is the
+			//    direction that turns a 400 into a 500 in production.
+			if err := attempt(ctx, t, pool, userID, b.write, edge); err != nil {
+				t.Fatalf("the validator accepts %s but the database refuses it: %v\n"+
+					"  A request carrying that value passes validation and then 500s on INSERT.",
+					fmtNum(edge), err)
+			}
+
+			// 3. Everything Go rejects, the database must also reject —
+			//    otherwise the Go bound is silently refusing values the schema
+			//    was perfectly happy to store, and nothing says why.
+			reject, why := past, ""
+			if b.beyondDB != nil {
+				reject, why = *b.beyondDB, b.whyWider
+				// The column really is wider here, so first prove the Go bound
+				// is the stricter one rather than an accidental match.
+				if err := attempt(ctx, t, pool, userID, b.write, past); err != nil {
+					t.Fatalf("this pair is marked as deliberately wider on the database side (%s), "+
+						"but the database rejects %s, one step past the Go bound: %v\n"+
+						"  The two are actually the same bound; drop beyondDB and assert them as an exact pair.",
+						why, fmtNum(past), err)
+				}
+			}
+			if err := attempt(ctx, t, pool, userID, b.write, reject); err == nil {
+				msg := fmt.Sprintf("the validator rejects %s but the database stores it happily",
+					fmtNum(reject))
+				if why != "" {
+					msg = fmt.Sprintf("the database accepted %s, past the column limit this bound exists to stay inside (%s)",
+						fmtNum(reject), why)
+				}
+				t.Fatalf("%s\n  Either the Go bound is needlessly strict, or the schema lost a constraint.", msg)
+			}
+		})
+	}
+}
+
+// attempt runs one write inside a transaction that is always rolled back, so
+// the probes leave nothing behind and cannot collide with each other's unique
+// indexes (one weight entry per user per day, one active goal per user).
+func attempt(ctx context.Context, t *testing.T, pool *pgxpool.Pool, userID int,
+	write func(context.Context, pgx.Tx, int, float64) error, v float64) error {
+	t.Helper()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback(ctx)
+	return write(ctx, tx, userID, v)
+}
+
+// ---------------------------------------------------------------------------
+// Enum sets, read back out of the live catalog
+// ---------------------------------------------------------------------------
+
+var pgTextLiteral = regexp.MustCompile(`'([^']*)'::text`)
+
+// TestEnumSetsAgreeWithLiveDatabase compares each Go set against the CHECK as
+// Postgres itself reports it, rather than against the migration source. Set
+// EQUALITY is the assertion: a value in the Go set but not the CHECK is a 500,
+// and a value in the CHECK but not the Go set can never be stored by anything.
+func TestEnumSetsAgreeWithLiveDatabase(t *testing.T) {
+	ctx, pool, userID := boundsTestDB(t)
+
+	cases := []struct {
+		what          string
+		table, column string
+		goValues      []string
+		write         func(ctx context.Context, tx pgx.Tx, userID int, v string) error
+	}{
+		{
+			what: "handler.validSexes", table: "users", column: "sex",
+			goValues: sortedKeys(validSexes),
+			write: func(ctx context.Context, tx pgx.Tx, userID int, v string) error {
+				return exactlyOneRow(tx.Exec(ctx, `UPDATE users SET sex = $2 WHERE id = $1`, userID, v))
+			},
+		},
+		{
+			what: "handler.validActivityLevels", table: "users", column: "activity_level",
+			goValues: sortedKeys(validActivityLevels),
+			write: func(ctx context.Context, tx pgx.Tx, userID int, v string) error {
+				return exactlyOneRow(tx.Exec(ctx, `UPDATE users SET activity_level = $2 WHERE id = $1`, userID, v))
+			},
+		},
+		{
+			what: "handler.validatePaceMode", table: "weight_goals", column: "pace_mode",
+			goValues: []string{"date", "rate"},
+			write: func(ctx context.Context, tx pgx.Tx, userID int, v string) error {
+				_, err := tx.Exec(ctx,
+					`INSERT INTO weight_goals (user_id, start_weight, start_date, target_weight, pace_mode)
+					 VALUES ($1, 100, CURRENT_DATE, 90, $2)`, userID, v)
+				return err
+			},
+		},
+		{
+			what:  "weight_goals.status written by service/weightgoal.go",
+			table: "weight_goals", column: "status",
+			goValues: []string{"abandoned", "achieved", "active"},
+			write: func(ctx context.Context, tx pgx.Tx, userID int, v string) error {
+				_, err := tx.Exec(ctx,
+					`INSERT INTO weight_goals (user_id, start_weight, start_date, target_weight, pace_mode, status)
+					 VALUES ($1, 100, CURRENT_DATE, 90, 'rate', $2)`, userID, v)
+				return err
+			},
+		},
+		{
+			what:  "account_links.status written by handler/settings.go",
+			table: "account_links", column: "status",
+			goValues: []string{"accepted", "pending"},
+			write: func(ctx context.Context, tx pgx.Tx, userID int, v string) error {
+				var otherID int
+				if err := tx.QueryRow(ctx,
+					`INSERT INTO users (email, password_hash) VALUES ($1, 'x') RETURNING id`,
+					fmt.Sprintf("bounds-drift-link-%d@handler.test", userID)).Scan(&otherID); err != nil {
+					return err
+				}
+				_, err := tx.Exec(ctx,
+					`INSERT INTO account_links (requester_id, target_id, status) VALUES ($1, $2, $3)`,
+					userID, otherID, v)
+				return err
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.what, func(t *testing.T) {
+			sqlValues := checkLiterals(ctx, t, pool, c.table, c.column)
+			want := append([]string(nil), c.goValues...)
+			sort.Strings(want)
+
+			if strings.Join(sqlValues, ",") != strings.Join(want, ",") {
+				t.Fatalf("set mismatch — Go uses %v, %s.%s accepts %v.\n"+
+					"  A value in the first set only is a 500 on write; a value in the second only can never be stored.",
+					want, c.table, c.column, sqlValues)
+			}
+
+			// The catalog says what the CHECK is; these prove it behaves that way.
+			for _, v := range want {
+				tx, err := pool.Begin(ctx)
+				if err != nil {
+					t.Fatalf("begin: %v", err)
+				}
+				err = c.write(ctx, tx, userID, v)
+				tx.Rollback(ctx)
+				if err != nil {
+					t.Errorf("%s.%s rejected %q, which Go writes: %v", c.table, c.column, v, err)
+				}
+			}
+			tx, err := pool.Begin(ctx)
+			if err != nil {
+				t.Fatalf("begin: %v", err)
+			}
+			err = c.write(ctx, tx, userID, "bounds-drift-not-a-member")
+			tx.Rollback(ctx)
+			if err == nil {
+				t.Errorf("%s.%s stored a value outside its own CHECK", c.table, c.column)
+			}
+		})
+	}
+}
+
+// TestAPITokenScopesAgreeWithLiveDatabase is the scopes row of the issue's
+// table. api_tokens.scopes carries only api_tokens_scopes_not_empty
+// (cardinality > 0): the closed set of scope NAMES is enforced in Go alone. So
+// the assertions here are (a) the database accepts every scope Go grants,
+// (b) both sides reject the empty set, and (c) if an element-level CHECK is
+// ever added, its list equals service.AllScopes().
+func TestAPITokenScopesAgreeWithLiveDatabase(t *testing.T) {
+	ctx, pool, userID := boundsTestDB(t)
+
+	scopes := service.AllScopes()
+	sort.Strings(scopes)
+
+	if lits := checkLiterals(ctx, t, pool, "api_tokens", "scopes"); len(lits) > 0 {
+		if strings.Join(lits, ",") != strings.Join(scopes, ",") {
+			t.Errorf("api_tokens.scopes now constrains values to %v, but service.AllScopes() is %v",
+				lits, scopes)
+		}
+	}
+
+	insert := func(v []string) error {
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		defer tx.Rollback(ctx)
+		_, err = tx.Exec(ctx,
+			`INSERT INTO api_tokens (user_id, name, token_hash, prefix, scopes)
+			 VALUES ($1, 'bounds-drift-probe', $2, 'st_probe', $3)`,
+			userID, []byte("bounds-drift-probe-hash"), v)
+		return err
+	}
+
+	// Every scope Go will grant has to survive the write.
+	if err := insert(scopes); err != nil {
+		t.Fatalf("api_tokens rejected the full scope set from service.AllScopes(): %v", err)
+	}
+	for _, s := range scopes {
+		if err := insert([]string{s}); err != nil {
+			t.Errorf("api_tokens rejected scope %q, which ValidateScopes grants: %v", s, err)
+		}
+	}
+
+	// Both sides must refuse a scopeless token: Go with ErrNoScopes, the
+	// database with api_tokens_scopes_not_empty.
+	if _, err := service.ValidateScopes(nil); !errors.Is(err, service.ErrNoScopes) {
+		t.Errorf("ValidateScopes(nil) = %v, want ErrNoScopes", err)
+	}
+	if err := insert([]string{}); err == nil {
+		t.Error("api_tokens accepted a token with no scopes; api_tokens_scopes_not_empty is gone")
+	}
+}
+
+// checkLiterals returns, sorted, every string literal appearing in the CHECK
+// constraints on table that mention column — i.e. the enum set as Postgres
+// itself reports it, with no reference to the migration source.
+func checkLiterals(ctx context.Context, t *testing.T, pool *pgxpool.Pool, table, column string) []string {
+	t.Helper()
+	rows, err := pool.Query(ctx, `
+		SELECT pg_get_constraintdef(oid)
+		FROM pg_constraint
+		WHERE conrelid = $1::regclass AND contype = 'c'`, table)
+	if err != nil {
+		t.Fatalf("reading CHECK constraints on %s failed: %v", table, err)
+	}
+	defer rows.Close()
+
+	mentionsColumn := regexp.MustCompile(`\b` + regexp.QuoteMeta(column) + `\b`)
+	var out []string
+	for rows.Next() {
+		var def string
+		if err := rows.Scan(&def); err != nil {
+			t.Fatalf("scanning a constraint definition failed: %v", err)
+		}
+		if !mentionsColumn.MatchString(def) {
+			continue
+		}
+		for _, m := range pgTextLiteral.FindAllStringSubmatch(def, -1) {
+			out = append(out, m[1])
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterating constraint definitions failed: %v", err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// boundsTestDB brings up the schema and a throwaway user to write against.
+// Skipped unless TEST_DATABASE_URL is set, matching internal/database's
+// integration tests. Run locally with, e.g.:
+//
+//	TEST_DATABASE_URL='postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable' go test ./internal/handler/ -run Bounds -v
+func boundsTestDB(t *testing.T) (context.Context, *pgxpool.Pool, int) {
+	t.Helper()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	t.Cleanup(cancel)
+
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	if err := database.InitSchemaWithRetry(ctx, pool, 1); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	email := fmt.Sprintf("bounds-drift-%s@handler.test", strings.ToLower(t.Name()))
+	cleanup := func() {
+		pool.Exec(ctx, `DELETE FROM users WHERE email LIKE 'bounds-drift-%@handler.test'`)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	var userID int
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email, password_hash, email_verified) VALUES ($1, 'x', true) RETURNING id`,
+		email).Scan(&userID); err != nil {
+		t.Fatalf("seeding the user failed: %v", err)
+	}
+	return ctx, pool, userID
+}

--- a/internal/handler/bounds_test.go
+++ b/internal/handler/bounds_test.go
@@ -1,0 +1,663 @@
+package handler
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"schautrack/internal/service"
+)
+
+// Every user-supplied numeric or enum field in this app is bounded twice: once
+// in Go, so the caller gets a 400, and once as a Postgres CHECK (or a column
+// type), so the data cannot be corrupted. The two are kept in sync entirely by
+// hand.
+//
+//   - Go looser than the DB  -> the value passes validation and then blows up on
+//     INSERT: a 500 where the caller should have got a 400.
+//   - Go tighter than the DB -> a legitimate value is refused with no
+//     explanation, and nothing anywhere says why.
+//
+// The invariant was documented in three separate comments (plan.go's
+// validateRateKgPerWeek, service/utils.go's MaxBodyFatPct, migrations.go's
+// ensureBodyFatSchema) and enforced by nothing. This file is the enforcement,
+// in the form the issue asks for:
+//
+//  1. this file — a pure-Go table pinning each Go limit to the literal written
+//     in internal/database/migrations.go. No database, so it runs in CI today.
+//  2. bounds_db_test.go — the same pairs driven behaviourally against a real
+//     Postgres, which needs no hand-maintained literals at all.
+//
+// Both halves are needed. This one fails the moment someone edits one side of a
+// pair; the other one fails even when someone edits both sides consistently but
+// wrongly.
+
+// migrationsSourcePath is read rather than imported: the CHECK expressions live
+// inside Go string literals in that file, so there is nothing to import.
+const migrationsSourcePath = "../database/migrations.go"
+
+var whitespaceRun = regexp.MustCompile(`\s+`)
+
+// migrationSource returns migrations.go with every run of whitespace collapsed
+// to a single space, so the anchors below can be written the way the SQL reads
+// rather than the way it happens to be indented inside a Go raw string.
+func migrationSource(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(migrationsSourcePath)
+	if err != nil {
+		t.Fatalf("reading %s failed: %v", migrationsSourcePath, err)
+	}
+	return strings.TrimSpace(whitespaceRun.ReplaceAllString(string(b), " "))
+}
+
+// sqlSite says where in migrations.go a constraint is written, which decides
+// how its text is extracted.
+type sqlSite int
+
+const (
+	// inlineCheck: `... CHECK (<expr>)` written directly in the DDL.
+	inlineCheck sqlSite = iota
+	// goTableCheck: a {"<constraint name>", "<expr>"} row in a Go slice that a
+	// loop turns into ALTER TABLE ... ADD CONSTRAINT statements.
+	goTableCheck
+	// columnType: no CHECK at all — the limit is the declared column type, e.g.
+	// NUMERIC(6,2) holding at most 9999.99.
+	columnType
+)
+
+// constraintText returns the SQL that anchor identifies: the CHECK expression
+// for a constraint, or the column declaration itself for columnType. anchor
+// must occur exactly once, which is what makes a renamed constraint fail here
+// instead of silently matching nothing.
+func constraintText(t *testing.T, src string, site sqlSite, anchor string) string {
+	t.Helper()
+	if n := strings.Count(src, anchor); n != 1 {
+		t.Fatalf("anchor %q occurs %d times in %s, want exactly 1 — this table is out of date with the schema",
+			anchor, n, migrationsSourcePath)
+	}
+	switch site {
+	case columnType:
+		return anchor
+	case goTableCheck:
+		re := regexp.MustCompile(`\{"` + regexp.QuoteMeta(anchor) + `", "([^"]*)"\}`)
+		m := re.FindStringSubmatch(src)
+		if m == nil {
+			t.Fatalf("constraint %q is not a {\"name\", \"expr\"} row in %s any more", anchor, migrationsSourcePath)
+		}
+		return m[1]
+	default:
+		rest := src[strings.Index(src, anchor):]
+		i := strings.Index(rest, "CHECK (")
+		if i < 0 {
+			t.Fatalf("no CHECK ( follows anchor %q in %s", anchor, migrationsSourcePath)
+		}
+		return balancedExpr(t, rest[i+len("CHECK ("):])
+	}
+}
+
+// balancedExpr returns everything up to the ")" that closes an already-opened
+// "(", so a CHECK whose body contains nested parens is not truncated.
+func balancedExpr(t *testing.T, s string) string {
+	t.Helper()
+	depth := 1
+	for i, r := range s {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return s[:i]
+			}
+		}
+	}
+	t.Fatalf("unbalanced CHECK ( ... ) in %s", migrationsSourcePath)
+	return ""
+}
+
+type limitKind int
+
+const (
+	lowerLimit limitKind = iota
+	upperLimit
+)
+
+func (k limitKind) String() string {
+	if k == lowerLimit {
+		return "lower"
+	}
+	return "upper"
+}
+
+// bound pins ONE end of ONE range: the extreme value the Go validator accepts
+// against the extreme value Postgres accepts for the column that value is
+// written to.
+//
+// goLimit/sqlLimit record the NUMBER at each end; goExclusive records whether
+// the Go comparison includes it. probe is the real validator, driven at the
+// limit and one grid step past it, so this table pins the VALIDATOR and not
+// merely the constant it is supposed to be using.
+type bound struct {
+	what        string    // the Go side, in prose
+	kind        limitKind //
+	goLimit     float64   // the boundary value on the Go side
+	goExclusive bool      // true when the validator rejects goLimit itself
+	sqlLimit    float64   // the most extreme value Postgres accepts
+	exact       bool      // the two are meant to be literally the same number
+	widerWhy    string    // for !exact rows: why the DB is deliberately wider
+	probe       func(float64) bool
+	probeStep   float64 // granularity of the value grid: 1, 0.1 or 0.01
+	site        sqlSite
+	anchor      string // unique substring of migrations.go
+	literal     string // text that must appear in the anchored SQL
+}
+
+// gridStep moves v by dir steps along the 1/step grid, doing the arithmetic in
+// integer units so 1500 + 0.01 is the double nearest 1500.01 rather than
+// 1500.0100000000000477 (which would then be rejected by ParseWeight's length
+// cap instead of by its range check, and pass for the wrong reason).
+func gridStep(v, step float64, dir int) float64 {
+	scale := math.Round(1 / step)
+	return (math.Round(v*scale) + float64(dir)) / scale
+}
+
+// numericDecl matches a NUMERIC(p,s) column declaration, whose maximum value is
+// 10^(p-s) - 10^-s. That arithmetic is the whole reason validateRateKgPerWeek
+// has an upper bound, so the test derives it rather than trusting the table.
+var numericDecl = regexp.MustCompile(`NUMERIC\((\d+), ?(\d+)\)`)
+
+func numericColumnMax(t *testing.T, decl string) float64 {
+	t.Helper()
+	m := numericDecl.FindStringSubmatch(decl)
+	if m == nil {
+		t.Fatalf("column declaration %q is not a NUMERIC(p,s)", decl)
+	}
+	p, _ := strconv.Atoi(m[1])
+	s, _ := strconv.Atoi(m[2])
+	return math.Pow10(p-s) - math.Pow10(-s)
+}
+
+func fmtNum(v float64) string { return strconv.FormatFloat(v, 'f', -1, 64) }
+
+func nearly(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+// The probes below are the real validators, adapted to a float64 signature.
+var (
+	probeEntryCalories = func(v float64) bool { return entryCaloriesInRange(int(math.Round(v))) }
+	probeSavedAmount   = func(v float64) bool {
+		return service.ParseAmount(fmtNum(v), MaxEntryCalories).Ok
+	}
+	probeMacro = func(v float64) bool {
+		n := int(math.Round(v))
+		_, ok := multiplyMacro(&n, 1)
+		return ok
+	}
+	probeWeight  = func(v float64) bool { return service.ParseWeight(fmtNum(v)).Ok }
+	probeBodyFat = func(v float64) bool { _, ok := service.ParseBodyFat(fmtNum(v)); return ok }
+	probeHeight  = func(v float64) bool { return validateHeightCm(&v) }
+	probeBirth   = func(v float64) bool {
+		y := int(math.Round(v))
+		return validateBirthYear(&y, time.Now().Year())
+	}
+	probeDateYear = func(v float64) bool {
+		return isValidDate(fmt.Sprintf("%04d-06-15", int(math.Round(v))))
+	}
+	probeRate         = func(v float64) bool { return validateRateKgPerWeek("rate", &v) }
+	probeTargetWeight = validateTargetWeight
+)
+
+// goBounds is the hand-maintained half of the drift guard. Editing either side
+// of a pair without editing the other fails this test.
+func goBounds(t *testing.T) []bound {
+	t.Helper()
+	return []bound{
+		// ---- calorie_entries.amount -------------------------------------
+		{
+			what: "handler.MaxEntryCalories (entryCaloriesInRange)", kind: upperLimit,
+			goLimit: MaxEntryCalories, sqlLimit: 9999, exact: true,
+			probe: probeEntryCalories, probeStep: 1,
+			site: inlineCheck, anchor: "calorie_entries_amount_range", literal: "amount <= 9999",
+		},
+		{
+			what: "-handler.MaxEntryCalories (entryCaloriesInRange)", kind: lowerLimit,
+			goLimit: -MaxEntryCalories, sqlLimit: -9999, exact: true,
+			probe: probeEntryCalories, probeStep: 1,
+			site: inlineCheck, anchor: "calorie_entries_amount_range", literal: "amount >= -9999",
+		},
+
+		// ---- calorie_entries.<macro>_g (x5) -----------------------------
+		// The five macro CHECKs are generated from one template; the template
+		// is the anchor and TestMacroCheckFamiliesAreUniform pins the names.
+		{
+			what: "handler.MaxEntryMacro (multiplyMacro)", kind: upperLimit,
+			goLimit: MaxEntryMacro, sqlLimit: 999, exact: true,
+			probe: probeMacro, probeStep: 1,
+			site: inlineCheck, anchor: "ALTER TABLE calorie_entries ADD CONSTRAINT %s", literal: "<= 999",
+		},
+		{
+			what: "handler macro floor (multiplyMacro)", kind: lowerLimit,
+			goLimit: 0, sqlLimit: 0, exact: true,
+			probe: probeMacro, probeStep: 1,
+			site: inlineCheck, anchor: "ALTER TABLE calorie_entries ADD CONSTRAINT %s", literal: ">= 0",
+		},
+
+		// ---- saved_foods.amount / saved_foods.<macro> --------------------
+		{
+			what: "handler.MaxEntryCalories (saved foods)", kind: upperLimit,
+			goLimit: MaxEntryCalories, sqlLimit: 9999, exact: true,
+			probe: probeSavedAmount, probeStep: 1,
+			site: goTableCheck, anchor: "saved_foods_amount_range", literal: "amount <= 9999",
+		},
+		{
+			what: "-handler.MaxEntryCalories (saved foods)", kind: lowerLimit,
+			goLimit: -MaxEntryCalories, sqlLimit: -9999, exact: true,
+			probe: probeSavedAmount, probeStep: 1,
+			site: goTableCheck, anchor: "saved_foods_amount_range", literal: "amount >= -9999",
+		},
+		{
+			what: "handler.MaxEntryMacro (saved foods)", kind: upperLimit,
+			goLimit: MaxEntryMacro, sqlLimit: 999, exact: true,
+			probe: probeMacro, probeStep: 1,
+			site: goTableCheck, anchor: "saved_foods_protein_range", literal: "protein_g <= 999",
+		},
+		{
+			what: "handler macro floor (saved foods)", kind: lowerLimit,
+			goLimit: 0, sqlLimit: 0, exact: true,
+			probe: probeMacro, probeStep: 1,
+			site: goTableCheck, anchor: "saved_foods_protein_range", literal: "protein_g >= 0",
+		},
+
+		// ---- weight_entries.weight ---------------------------------------
+		{
+			what: "service.ParseWeight lower bound", kind: lowerLimit,
+			goLimit: 0, goExclusive: true, sqlLimit: 0, exact: true,
+			probe: probeWeight, probeStep: 0.01,
+			site: inlineCheck, anchor: "weight_entries_positive", literal: "weight > 0",
+		},
+		{
+			what: "service.MaxWeight", kind: upperLimit,
+			goLimit: service.MaxWeight, sqlLimit: 9999.99,
+			widerWhy: "MaxWeight is a plausibility cap far below what NUMERIC(6,2) holds; " +
+				"the column only has to be wide enough that the Go bound is reachable",
+			probe: probeWeight, probeStep: 0.01,
+			site: columnType, anchor: "weight NUMERIC(6, 2) NOT NULL", literal: "NUMERIC(6, 2)",
+		},
+
+		// ---- weight_entries.body_fat --------------------------------------
+		{
+			what: "service.MaxBodyFatPct", kind: upperLimit,
+			goLimit: service.MaxBodyFatPct, sqlLimit: 75, exact: true,
+			probe: probeBodyFat, probeStep: 0.1,
+			site: inlineCheck, anchor: "weight_entries_body_fat_range", literal: "body_fat <= 75",
+		},
+		{
+			what: "service.ParseBodyFat lower bound", kind: lowerLimit,
+			goLimit: 0, goExclusive: true, sqlLimit: 0, exact: true,
+			probe: probeBodyFat, probeStep: 0.1,
+			site: inlineCheck, anchor: "weight_entries_body_fat_range", literal: "body_fat > 0",
+		},
+
+		// ---- users.height_cm ----------------------------------------------
+		{
+			what: "validateHeightCm", kind: lowerLimit,
+			goLimit: 50, sqlLimit: 50, exact: true,
+			probe: probeHeight, probeStep: 0.1,
+			site: goTableCheck, anchor: "users_height_cm_range", literal: "height_cm >= 50",
+		},
+		{
+			what: "validateHeightCm", kind: upperLimit,
+			goLimit: 300, sqlLimit: 300, exact: true,
+			probe: probeHeight, probeStep: 0.1,
+			site: goTableCheck, anchor: "users_height_cm_range", literal: "height_cm <= 300",
+		},
+
+		// ---- users.birth_year -----------------------------------------------
+		{
+			what: "validateBirthYear", kind: lowerLimit,
+			goLimit: 1900, sqlLimit: 1900, exact: true,
+			probe: probeBirth, probeStep: 1,
+			site: goTableCheck, anchor: "users_birth_year_range", literal: "birth_year >= 1900",
+		},
+		{
+			what: "validateBirthYear (currentYear-10)", kind: upperLimit,
+			goLimit: float64(time.Now().Year() - 10), sqlLimit: 2200,
+			widerWhy: "the Go bound moves with the calendar (no under-10s); the CHECK is a fixed " +
+				"sanity ceiling, so it must stay above any year the Go side will ever allow",
+			probe: probeBirth, probeStep: 1,
+			site: goTableCheck, anchor: "users_birth_year_range", literal: "birth_year <= 2200",
+		},
+
+		// ---- handler.minDateYear / maxDateYear -------------------------------
+		// isValidDate's year window has no CHECK of its own (the columns are
+		// DATE, which spans 4713 BC..5874897 AD), but it is the same "plausible
+		// calendar year" range as users_birth_year_range and drifting the two
+		// apart would be just as silent.
+		{
+			what: "handler.minDateYear (isValidDate)", kind: lowerLimit,
+			goLimit: minDateYear, sqlLimit: 1900, exact: true,
+			probe: probeDateYear, probeStep: 1,
+			site: goTableCheck, anchor: "users_birth_year_range", literal: "birth_year >= 1900",
+		},
+		{
+			what: "handler.maxDateYear (isValidDate)", kind: upperLimit,
+			goLimit: maxDateYear, sqlLimit: 2200, exact: true,
+			probe: probeDateYear, probeStep: 1,
+			site: goTableCheck, anchor: "users_birth_year_range", literal: "birth_year <= 2200",
+		},
+
+		// ---- weight_goals.rate_kg_per_week ------------------------------------
+		{
+			what: "validateRateKgPerWeek", kind: upperLimit,
+			goLimit: 99, sqlLimit: 99.99,
+			widerWhy: "99 is the round number below the NUMERIC(4,2) ceiling of 99.99; the point " +
+				"of the bound is only that it stays under the column's ceiling",
+			probe: probeRate, probeStep: 0.01,
+			site: columnType, anchor: "rate_kg_per_week NUMERIC(4,2)", literal: "NUMERIC(4,2)",
+		},
+		{
+			what: "validateRateKgPerWeek lower bound", kind: lowerLimit,
+			goLimit: 0, goExclusive: true, sqlLimit: -99.99,
+			widerWhy: "there is NO CHECK on the sign of rate_kg_per_week — the column would happily " +
+				"store a negative rate, and only the Go validator stops it",
+			probe: probeRate, probeStep: 0.01,
+			site: columnType, anchor: "rate_kg_per_week NUMERIC(4,2)", literal: "NUMERIC(4,2)",
+		},
+
+		// ---- weight_goals.target_weight ----------------------------------------
+		{
+			what: "validateTargetWeight lower bound", kind: lowerLimit,
+			goLimit: 0, goExclusive: true, sqlLimit: 0, exact: true,
+			probe: probeTargetWeight, probeStep: 0.01,
+			site: inlineCheck, anchor: "weight_goals_positive", literal: "target_weight > 0",
+		},
+		{
+			what: "validateTargetWeight (service.MaxWeight)", kind: upperLimit,
+			goLimit: service.MaxWeight, sqlLimit: 9999.99,
+			widerWhy: "same plausibility cap as ParseWeight, well inside what NUMERIC(6,2) holds",
+			probe:    probeTargetWeight, probeStep: 0.01,
+			site: columnType, anchor: "target_weight NUMERIC(6,2)", literal: "NUMERIC(6,2)",
+		},
+	}
+}
+
+// TestGoBoundsMatchMigrationLiterals is the no-database half of the drift
+// guard: every Go limit is checked against the literal written next to the
+// matching CHECK constraint (or column type) in internal/database/migrations.go.
+func TestGoBoundsMatchMigrationLiterals(t *testing.T) {
+	src := migrationSource(t)
+
+	for _, b := range goBounds(t) {
+		t.Run(b.what+" ("+b.kind.String()+")", func(t *testing.T) {
+			sql := constraintText(t, src, b.site, b.anchor)
+
+			// 1. The schema still says what this table claims it says.
+			if !strings.Contains(sql, b.literal) {
+				t.Fatalf("the schema no longer contains %q.\n  anchored SQL: %s\n"+
+					"  Either the constraint changed and this table must follow, or the Go bound %s must.",
+					b.literal, sql, b.what)
+			}
+
+			// 2. The table is honest about the number it claims the SQL holds.
+			if b.site == columnType {
+				max := numericColumnMax(t, b.literal)
+				want := max
+				if b.kind == lowerLimit {
+					want = -max
+				}
+				if !nearly(b.sqlLimit, want) {
+					t.Fatalf("%s holds %s..%s, but this table records the %s limit as %s",
+						b.literal, fmtNum(-max), fmtNum(max), b.kind, fmtNum(b.sqlLimit))
+				}
+			} else if !strings.Contains(b.literal, fmtNum(b.sqlLimit)) {
+				t.Fatalf("this table records the SQL %s limit as %s, but the literal it points at is %q",
+					b.kind, fmtNum(b.sqlLimit), b.literal)
+			}
+
+			// 3. Go must never accept what the database rejects. This is the
+			//    direction that turns a 400 into a 500.
+			tooLoose := b.goLimit > b.sqlLimit
+			if b.kind == lowerLimit {
+				tooLoose = b.goLimit < b.sqlLimit
+			}
+			if tooLoose {
+				t.Fatalf("%s accepts down/up to %s but the database %s limit is %s: "+
+					"a value in between passes validation and then 500s on INSERT",
+					b.what, fmtNum(b.goLimit), b.kind, fmtNum(b.sqlLimit))
+			}
+
+			// 4. Where the two are meant to be the same number, they must be.
+			//    Where they are not, the row has to say why.
+			if b.exact {
+				if !nearly(b.goLimit, b.sqlLimit) {
+					t.Fatalf("%s %s limit is %s but %q is %s; they are meant to be the same number",
+						b.what, b.kind, fmtNum(b.goLimit), b.anchor, fmtNum(b.sqlLimit))
+				}
+				// An exact pair must agree on strictness too: `weight > 0` and
+				// `weight >= 0` are the same number and different constraints.
+				if b.site != columnType {
+					sqlInclusive := strings.Contains(b.literal, ">=") || strings.Contains(b.literal, "<=")
+					if sqlInclusive == b.goExclusive {
+						t.Fatalf("%s %s the boundary value %s, but the CHECK says %q",
+							b.what, map[bool]string{true: "excludes", false: "includes"}[b.goExclusive],
+							fmtNum(b.goLimit), b.literal)
+					}
+				}
+			} else if b.widerWhy == "" {
+				t.Fatalf("%s is not an exact match with the database (%s vs %s) and gives no reason",
+					b.what, fmtNum(b.goLimit), fmtNum(b.sqlLimit))
+			}
+
+			// 5. The VALIDATOR, not just the constant. A bound that is only
+			//    ever compared against itself would still pass steps 1-4 after
+			//    someone stopped applying it (exactly the #305 defect: the
+			//    constant existed, validateTargetWeight ignored it).
+			if b.probe == nil {
+				return
+			}
+			inward := 1
+			if b.kind == upperLimit {
+				inward = -1
+			}
+			in, out := b.goLimit, gridStep(b.goLimit, b.probeStep, -inward)
+			if b.goExclusive {
+				// The boundary itself is rejected; the first accepted value is
+				// one step inside it.
+				in, out = gridStep(b.goLimit, b.probeStep, inward), b.goLimit
+			}
+			if !b.probe(in) {
+				t.Errorf("the validator rejects %s, which this table records as inside its %s bound of %s",
+					fmtNum(in), b.kind, fmtNum(b.goLimit))
+			}
+			if b.probe(out) {
+				t.Errorf("the validator accepts %s, past the %s bound of %s this table records for it: "+
+					"the bound is no longer being applied, and the row above is comparing a constant to itself",
+					fmtNum(out), b.kind, fmtNum(b.goLimit))
+			}
+		})
+	}
+}
+
+// TestMacroCheckFamiliesAreUniform pins the two families of repeated CHECKs.
+// The rows above only anchor one member of each; if a sixth macro is added to
+// calorie_entries, or one saved_foods macro is given a different ceiling, that
+// member would otherwise never be looked at.
+func TestMacroCheckFamiliesAreUniform(t *testing.T) {
+	src := migrationSource(t)
+
+	for _, name := range []string{
+		"calorie_entries_protein_g_range",
+		"calorie_entries_carbs_g_range",
+		"calorie_entries_fat_g_range",
+		"calorie_entries_fiber_g_range",
+		"calorie_entries_sugar_g_range",
+	} {
+		if !strings.Contains(src, `"`+name+`"`) {
+			t.Errorf("macro CHECK %s is gone from %s; the 0..%d bound is no longer enforced for it",
+				name, migrationsSourcePath, MaxEntryMacro)
+		}
+	}
+
+	for _, col := range []string{"protein", "carbs", "fat", "fiber", "sugar"} {
+		expr := constraintText(t, src, goTableCheck, "saved_foods_"+col+"_range")
+		for _, want := range []string{
+			col + "_g >= " + fmtNum(0),
+			col + "_g <= " + fmtNum(MaxEntryMacro),
+		} {
+			if !strings.Contains(expr, want) {
+				t.Errorf("saved_foods_%s_range is %q, want it to contain %q (handler.MaxEntryMacro = %d)",
+					col, expr, want, MaxEntryMacro)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Enum sets
+// ---------------------------------------------------------------------------
+
+var sqlStringLiteral = regexp.MustCompile(`'([^']*)'`)
+
+// enumPair pins a Go set of accepted strings against the IN (...) list of the
+// CHECK that backs it. Set EQUALITY is the assertion, not overlap: adding a
+// value to the Go map without adding it to the CHECK is a 500, and adding it to
+// the CHECK without adding it to the map is a value nothing can ever store.
+type enumPair struct {
+	what     string
+	goValues []string
+	accepts  func(string) bool // the Go validator, when there is one
+	site     sqlSite
+	anchor   string
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestEnumSetsMatchMigrationCHECKs(t *testing.T) {
+	src := migrationSource(t)
+
+	pairs := []enumPair{
+		{
+			what: "handler.validSexes", goValues: sortedKeys(validSexes),
+			accepts: func(s string) bool { return validateSex(&s) },
+			site:    goTableCheck, anchor: "users_sex_valid",
+		},
+		{
+			what: "handler.validActivityLevels", goValues: sortedKeys(validActivityLevels),
+			accepts: func(s string) bool { return validateActivityLevel(&s) },
+			site:    goTableCheck, anchor: "users_activity_valid",
+		},
+		{
+			what: "handler.validatePaceMode", goValues: []string{"date", "rate"},
+			accepts: validatePaceMode,
+			site:    inlineCheck, anchor: "pace_mode TEXT NOT NULL",
+		},
+		{
+			// No Go validator: these are the three literals
+			// internal/service/weightgoal.go writes to weight_goals.status
+			// (the 'active' default, MarkGoalAchieved, AbandonActiveGoal).
+			what:     "weight_goals.status values written by service/weightgoal.go",
+			goValues: []string{"abandoned", "achieved", "active"},
+			site:     inlineCheck, anchor: "status TEXT NOT NULL DEFAULT 'active'",
+		},
+		{
+			// No Go validator: the two literals internal/handler/settings.go
+			// writes to account_links.status.
+			what:     "account_links.status values written by handler/settings.go",
+			goValues: []string{"accepted", "pending"},
+			site:     inlineCheck, anchor: "status TEXT NOT NULL CHECK",
+		},
+	}
+
+	for _, p := range pairs {
+		t.Run(p.what, func(t *testing.T) {
+			expr := constraintText(t, src, p.site, p.anchor)
+
+			var sqlValues []string
+			for _, m := range sqlStringLiteral.FindAllStringSubmatch(expr, -1) {
+				sqlValues = append(sqlValues, m[1])
+			}
+			sort.Strings(sqlValues)
+
+			want := append([]string(nil), p.goValues...)
+			sort.Strings(want)
+
+			if strings.Join(sqlValues, ",") != strings.Join(want, ",") {
+				t.Fatalf("set mismatch — Go accepts %v, the CHECK accepts %v.\n  CHECK: %s\n"+
+					"  A value in one set but not the other is either a 500 on INSERT or a value nothing can store.",
+					want, sqlValues, expr)
+			}
+
+			if p.accepts == nil {
+				return
+			}
+			for _, v := range want {
+				if !p.accepts(v) {
+					t.Errorf("the validator rejects %q even though the CHECK accepts it", v)
+				}
+			}
+			if p.accepts("definitely-not-a-member") {
+				t.Error("the validator accepts a value outside its own set; the CHECK would reject it as a 500")
+			}
+		})
+	}
+}
+
+// TestAPITokenScopesConstraint covers the last row of the issue's table.
+//
+// api_tokens.scopes is TEXT[] with only api_tokens_scopes_not_empty
+// (cardinality > 0) — there is no element-level CHECK, so the closed scope set
+// is enforced in Go alone. That asymmetry is deliberate today but must not
+// drift: if an element CHECK is ever added, its list has to equal
+// service.AllScopes(), which this test pins automatically.
+func TestAPITokenScopesConstraint(t *testing.T) {
+	src := migrationSource(t)
+	expr := constraintText(t, src, inlineCheck, "api_tokens_scopes_not_empty")
+
+	var sqlValues []string
+	for _, m := range sqlStringLiteral.FindAllStringSubmatch(expr, -1) {
+		sqlValues = append(sqlValues, m[1])
+	}
+
+	if len(sqlValues) > 0 {
+		sort.Strings(sqlValues)
+		want := service.AllScopes()
+		sort.Strings(want)
+		if strings.Join(sqlValues, ",") != strings.Join(want, ",") {
+			t.Errorf("api_tokens now constrains scope values to %v, but service.AllScopes() is %v",
+				sqlValues, want)
+		}
+	} else if !strings.Contains(expr, "cardinality(scopes) > 0") {
+		t.Errorf("api_tokens_scopes_not_empty is now %q; it no longer mirrors service.ErrNoScopes", expr)
+	}
+
+	// The Go side of the same pair: the closed set is the only element-level
+	// gate there is, so it has to actually be closed.
+	if _, err := service.ValidateScopes([]string{"entries:definitely-not-a-scope"}); err == nil {
+		t.Error("ValidateScopes accepted an unknown scope; nothing else would stop it reaching the column")
+	}
+	if _, err := service.ValidateScopes(nil); err == nil {
+		t.Error("ValidateScopes accepted an empty scope set; api_tokens_scopes_not_empty would 500 on INSERT")
+	}
+	seen := map[string]bool{}
+	for _, s := range service.AllScopes() {
+		if seen[s] {
+			t.Errorf("scope %q is listed twice in service.ScopeDescriptions", s)
+		}
+		seen[s] = true
+		if _, err := service.ValidateScopes([]string{s}); err != nil {
+			t.Errorf("ValidateScopes rejects %q, which is in its own ScopeDescriptions: %v", s, err)
+		}
+	}
+}

--- a/internal/handler/plan.go
+++ b/internal/handler/plan.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"log/slog"
+	"math"
 	"net/http"
 	"time"
 
@@ -50,8 +51,14 @@ func validateActivityLevel(a *string) bool {
 // passes validation and then 500s on INSERT with a numeric overflow instead of
 // a clean 400. NaN and ±Inf are rejected as a side effect: NaN fails every
 // comparison, and +Inf exceeds the cap.
+//
+// The lower bound is re-checked AFTER coercion to the column's scale, for the
+// same reason ParseWeight does it (#302): NUMERIC(6,2) stores 0.001 as 0.00,
+// which then fails weight_goals_positive — a 500 where the caller should have
+// got a 400. TargetWeight never passes through ParseWeight, so that fix does
+// not reach it.
 func validateTargetWeight(w float64) bool {
-	return w > 0 && w <= service.MaxWeight
+	return w > 0 && w <= service.MaxWeight && math.Round(w*100)/100 > 0
 }
 
 func validatePaceMode(m string) bool {

--- a/internal/handler/plan_test.go
+++ b/internal/handler/plan_test.go
@@ -103,11 +103,16 @@ const targetWeightColumnMax = 9999.99
 // fitsTargetWeightColumn reports whether w survives an INSERT into
 // NUMERIC(6,2). Postgres rounds to two decimals on store, so the check is
 // against the rounded value; NaN and ±Inf never fit.
+//
+// "Survives" includes weight_goals_positive CHECK (target_weight > 0), which is
+// evaluated on the ROUNDED value: 0.001 fits the column's width but is stored
+// as 0.00 and rejected (#374).
 func fitsTargetWeightColumn(w float64) bool {
 	if math.IsNaN(w) || math.IsInf(w, 0) {
 		return false
 	}
-	return math.Abs(math.Round(w*100)/100) <= targetWeightColumnMax
+	stored := math.Round(w*100) / 100
+	return stored > 0 && stored <= targetWeightColumnMax
 }
 
 func TestValidateTargetWeight(t *testing.T) {
@@ -121,7 +126,13 @@ func TestValidateTargetWeight(t *testing.T) {
 		{"NaN", math.NaN(), false},
 		{"positive infinity", math.Inf(1), false},
 		{"negative infinity", math.Inf(-1), false},
-		{"tiny but positive", 0.001, true},
+		// Positive, but NUMERIC(6,2) stores it as 0.00 and
+		// weight_goals_positive then rejects the row — a 500 where the caller
+		// should have got a 400 (#374, the same defect #302 fixed in
+		// ParseWeight).
+		{"tiny but positive, rounds to 0.00", 0.001, false},
+		{"rounds up to the smallest storable value", 0.005, true},
+		{"smallest storable value", 0.01, true},
 		{"one", 1, true},
 		{"typical", 70, true},
 		{"ParseWeight cap", service.MaxWeight, true},


### PR DESCRIPTION
Closes #310

Every user-supplied numeric or enum field is bounded twice — once in Go so the caller gets a 400, once as a Postgres `CHECK` so the data cannot be corrupted — and the two were kept in sync entirely by hand. The invariant was documented in three separate comments (`plan.go`'s `validateRateKgPerWeek`, `service/utils.go`'s `MaxBodyFatPct`, `migrations.go`'s `ensureBodyFatSchema`) and enforced in zero tests.

Both approaches the issue describes are implemented.

## 1. `internal/handler/bounds_test.go` — pure Go, no database

A table of one row per **end** of each range: `{Go limit, SQL limit, constraint anchor, literal}`. 22 rows covering `MaxEntryCalories`, `MaxEntryMacro` (×5 + ×6 saved-food families), `MaxBodyFatPct`, `ParseWeight`, `validateHeightCm`, `validateBirthYear`, `minDateYear`/`maxDateYear`, `validateRateKgPerWeek` and `validateTargetWeight`.

Per row it asserts:

1. the anchor occurs **exactly once** in `migrations.go` (a renamed constraint fails rather than silently matching nothing), and the literal is still there;
2. the table is honest about the number it claims the SQL holds — for column-typed rows the ceiling is **derived** from `NUMERIC(p,s)` as `10^(p-s) - 10^-s` rather than trusted;
3. Go never accepts what the database rejects (the 400→500 direction);
4. rows marked exact agree on the **number and the strictness** (`> 0` and `>= 0` are the same number and different constraints); rows that are not exact must state why the column is deliberately wider;
5. the **validator**, not just the constant: each row drives the real function at its limit and one grid step past it. Without this, a bound that stops being applied still passes — which is exactly the #305 defect (the constant existed, `validateTargetWeight` ignored it).

Enum sets are asserted **equal, not overlapping**: `validSexes` ↔ `users_sex_valid`, `validActivityLevels` ↔ `users_activity_valid`, pace modes ↔ the `pace_mode` CHECK, goal status ↔ the `weight_goals.status` CHECK, link status ↔ the `account_links.status` CHECK, and `service.ScopeDescriptions` ↔ `api_tokens`.

## 2. `internal/handler/bounds_db_test.go` — behavioural, against a real Postgres

No transcription of the schema at all. For each pair it **bisects the real Go validator** to find the value where it flips, then asks a live Postgres what it does on both sides:

- the value the validator accepts → the database **must** accept (otherwise: 500 instead of 400);
- the value one step past it → the database **must** reject (otherwise: a legitimate value silently refused).

Where the column is genuinely wider than the Go bound (`NUMERIC(6,2)` holds 9999.99 while `MaxWeight` caps at 1500) the row says so and the reject side is asserted against the **column's own** limit — plus a check that the widening is real, so a pair cannot be excused as "wider" when it is actually an exact match.

Enum sets are read back out of `pg_get_constraintdef` and compared to the Go sets, so no literal from `migrations.go` is involved. Every write runs in a rolled-back transaction, so the probes leave nothing behind and cannot collide with the one-weight-per-day / one-active-goal unique indexes.

Since #313 / PR #325 merged, CI runs the `test` job against a real `postgres:18` with `TEST_DATABASE_URL` set — **this half actually executes on every build**, it is not aspirational.

## Relationship to #302 / #305

Both are **merged** (PR #316, PR #317), so this branch is rebased on top of them and carries **no duplicate fix**. The `validateTargetWeight` ↔ `target_weight NUMERIC(6,2)` and `ParseWeight`/`ParseBodyFat` ↔ `CHECK (> 0)` pairs are asserted as ordinary rows and pass against upstream code with no local change. The pure-Go table references `service.MaxWeight` (the constant #316 introduced) rather than a literal `1500`.

## A real bug this found: #374

While tuning the behavioural probe grid finer than the column's own scale, the test went red on a pair nobody had flagged:

```
--- FAIL: TestBoundsAgreeWithLiveDatabase/validateTargetWeight_floor_->_weight_goals.target_weight_(lower)
    bounds_db_test.go:322: the validator accepts 0.001 but the database refuses it:
      ERROR: new row for relation "weight_goals" violates check constraint "weight_goals_positive" (SQLSTATE 23514)
```

`validateTargetWeight(0.001)` is true, `NUMERIC(6,2)` stores it as `0.00`, and `weight_goals_positive CHECK (target_weight > 0)` then rejects the row — `PUT /plan/goal` returns a 500 where it should return a 400. Same defect #302 fixed in `ParseWeight`; `TargetWeight` is decoded straight off the JSON body and never passes through it, so that fix did not reach it.

Filed as **#374** and fixed here in one line (`math.Round(w*100)/100 > 0`), because a drift test that deliberately looks away from a drift it can see is the failure mode this issue is about. `plan_test.go`'s `{"tiny but positive", 0.001, true}` row is corrected accordingly, and `fitsTargetWeightColumn` now accounts for `weight_goals_positive` rather than column width alone.

## Verification

Mutation-tested — each historical defect re-introduced, then confirmed the right assertion fails:

| mutation | caught by |
|---|---|
| `validateTargetWeight` back to `w > 0` (#305) | pure-Go probe **and** DB bisection (`it has no upper bound at all`) |
| `ParseWeight`/`ParseBodyFat` validating before rounding (#302) | DB bisection on both floors |
| `MaxEntryMacro` 999 → 998 (one side only) | pure-Go table, 3 rows + the family check |
| a value added to `validSexes`, CHECK untouched | enum set-equality |

### Without Postgres — the behavioural half skips cleanly

```
$ export GOFLAGS=-p=2 GOMAXPROCS=2
$ go build ./... && go vet ./...
(clean)

$ go test ./...
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	0.009s
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	0.005s
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	0.005s
ok  	schautrack/internal/handler	0.513s
ok  	schautrack/internal/middleware	0.065s
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	0.025s
ok  	schautrack/internal/release	0.002s
ok  	schautrack/internal/service	0.213s
ok  	schautrack/internal/session	0.004s
ok  	schautrack/internal/sse	0.010s

$ go test ./internal/handler/ -run 'Bounds|EnumSets|APITokenScopes|MacroCheck' -v
--- SKIP: TestBoundsAgreeWithLiveDatabase (0.00s)
--- SKIP: TestEnumSetsAgreeWithLiveDatabase (0.00s)
--- SKIP: TestAPITokenScopesAgreeWithLiveDatabase (0.00s)
--- PASS: TestGoBoundsMatchMigrationLiterals (0.01s)
--- PASS: TestMacroCheckFamiliesAreUniform (0.01s)
--- PASS: TestEnumSetsMatchMigrationCHECKs (0.01s)
--- PASS: TestAPITokenScopesConstraint (0.01s)
```

### With Postgres 18 — the DB-backed half runs

```
$ docker run -d --rm --name pg-310 -e POSTGRES_PASSWORD=postgres -p 55310:5432 postgres:18
$ TEST_DATABASE_URL='postgres://postgres:postgres@localhost:55310/postgres?sslmode=disable' go test -count=1 ./...
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	0.009s
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	0.004s
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	0.285s
ok  	schautrack/internal/handler	1.200s
ok  	schautrack/internal/middleware	0.068s
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	0.039s
ok  	schautrack/internal/release	0.005s
ok  	schautrack/internal/service	0.325s
ok  	schautrack/internal/session	0.008s
ok  	schautrack/internal/sse	0.021s
```

Every drift subtest, verbose:

```
--- PASS: TestBoundsAgreeWithLiveDatabase (0.07s)
    --- PASS: TestBoundsAgreeWithLiveDatabase/handler.MaxEntryCalories_->_calorie_entries.amount_(upper)
    --- PASS: TestBoundsAgreeWithLiveDatabase/-handler.MaxEntryCalories_->_calorie_entries.amount_(lower)
    --- PASS: TestBoundsAgreeWithLiveDatabase/handler.MaxEntryMacro_->_calorie_entries.protein_g_(upper)
    --- PASS: TestBoundsAgreeWithLiveDatabase/handler_macro_floor_->_calorie_entries.protein_g_(lower)
    --- PASS: TestBoundsAgreeWithLiveDatabase/handler.MaxEntryCalories_->_saved_foods.amount_(upper)
    --- PASS: TestBoundsAgreeWithLiveDatabase/handler.MaxEntryMacro_->_saved_foods.protein_g_(upper)
    --- PASS: TestBoundsAgreeWithLiveDatabase/service.ParseWeight_floor_->_weight_entries.weight_(lower)
    --- PASS: TestBoundsAgreeWithLiveDatabase/service.MaxWeight_->_weight_entries.weight_(upper)
    --- PASS: TestBoundsAgreeWithLiveDatabase/service.MaxBodyFatPct_->_weight_entries.body_fat_(upper)
    --- PASS: TestBoundsAgreeWithLiveDatabase/service.ParseBodyFat_floor_->_weight_entries.body_fat_(lower)
    --- PASS: TestBoundsAgreeWithLiveDatabase/validateHeightCm_->_users.height_cm_(lower)
    --- PASS: TestBoundsAgreeWithLiveDatabase/validateHeightCm_->_users.height_cm_(upper)
    --- PASS: TestBoundsAgreeWithLiveDatabase/validateBirthYear_->_users.birth_year_(lower)
    --- PASS: TestBoundsAgreeWithLiveDatabase/validateBirthYear_->_users.birth_year_(upper)
    --- PASS: TestBoundsAgreeWithLiveDatabase/validateRateKgPerWeek_->_weight_goals.rate_kg_per_week_(upper)
    --- PASS: TestBoundsAgreeWithLiveDatabase/validateRateKgPerWeek_floor_->_weight_goals.rate_kg_per_week_(lower)
    --- PASS: TestBoundsAgreeWithLiveDatabase/validateTargetWeight_->_weight_goals.target_weight_(upper)
    --- PASS: TestBoundsAgreeWithLiveDatabase/validateTargetWeight_floor_->_weight_goals.target_weight_(lower)
--- PASS: TestEnumSetsAgreeWithLiveDatabase (0.06s)
    --- PASS: TestEnumSetsAgreeWithLiveDatabase/handler.validSexes
    --- PASS: TestEnumSetsAgreeWithLiveDatabase/handler.validActivityLevels
    --- PASS: TestEnumSetsAgreeWithLiveDatabase/handler.validatePaceMode
    --- PASS: TestEnumSetsAgreeWithLiveDatabase/weight_goals.status_written_by_service/weightgoal.go
    --- PASS: TestEnumSetsAgreeWithLiveDatabase/account_links.status_written_by_handler/settings.go
--- PASS: TestAPITokenScopesAgreeWithLiveDatabase (0.05s)
--- PASS: TestGoBoundsMatchMigrationLiterals (0.00s)   [22 subtests, all PASS]
--- PASS: TestMacroCheckFamiliesAreUniform (0.00s)
--- PASS: TestEnumSetsMatchMigrationCHECKs (0.01s)     [5 subtests, all PASS]
--- PASS: TestAPITokenScopesConstraint (0.00s)
PASS
ok  	schautrack/internal/handler	0.213s
```

## Note on `api_tokens.scopes`

The only constraint there is `api_tokens_scopes_not_empty CHECK (cardinality(scopes) > 0)` — there is **no element-level CHECK**, so the closed scope set is enforced in Go alone. That asymmetry is left as-is, but it can no longer drift silently: if an element list is ever added, both tests automatically require it to equal `service.AllScopes()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
