### PR TITLE
fix: create a saved food named <nil> on {"name": null}, and drop the "<nil>" sentinel

### DIFF
--- a/internal/handler/saved_foods.go
+++ b/internal/handler/saved_foods.go
@@ -101,12 +101,31 @@ type savedFoodInput struct {
 	macros     map[string]*int // only keys present in body are populated
 }
 
+// Every field below reads through optionalString (entries_helpers.go), which
+// separates "key absent" from "key holding a JSON null" by inspecting the
+// interface before coercing it. This function used to coerce first, with
+// fmt.Sprintf("%v", v), which renders a null as the four characters <nil>, and
+// then compare against that string to recover the null it had just destroyed.
+//
+// The name path did not even do that, which is #341's live bug: POST
+// /api/saved-foods with {"name": null} produced the name "<nil>", and because
+// those four characters are a non-empty string it sailed past the "Name is
+// required" check and created a saved food literally called <nil>. The same
+// shape as #303 on the entries handler, fixed the same way.
+//
+// saved_foods.name is NOT NULL, so there is no "clear the name" state to route
+// a null into: null joins "" and "   " as a 400. The nullable fields keep the
+// clearing behaviour they had. A literal "<nil>" is now taken at face value —
+// stored verbatim as a name or emoji, rejected as an unparseable amount or
+// macro, matching what #338 settled on for the entry amount and macros.
 func parseSavedFoodPayload(body map[string]any, forCreate bool) (*savedFoodInput, int, string) {
 	out := &savedFoodInput{macros: map[string]*int{}}
 
-	if v, ok := body["name"]; ok {
+	if name, present := optionalString(body, "name"); present {
 		out.hasName = true
-		out.name = truncateUTF8(strings.TrimSpace(fmt.Sprintf("%v", v)), MaxSavedFoodName)
+		if name != nil {
+			out.name = truncateUTF8(*name, MaxSavedFoodName)
+		}
 		if out.name == "" {
 			return nil, http.StatusBadRequest, "Name is required"
 		}
@@ -114,24 +133,21 @@ func parseSavedFoodPayload(body map[string]any, forCreate bool) (*savedFoodInput
 		return nil, http.StatusBadRequest, "Name is required"
 	}
 
-	if v, ok := body["emoji"]; ok {
+	if emoji, present := optionalString(body, "emoji"); present {
 		out.hasEmoji = true
-		raw := strings.TrimSpace(fmt.Sprintf("%v", v))
-		if raw == "" || raw == "<nil>" {
-			out.emoji = nil
-		} else {
-			raw = truncateUTF8(raw, MaxSavedFoodEmoji)
+		if emoji != nil && *emoji != "" {
+			raw := truncateUTF8(*emoji, MaxSavedFoodEmoji)
 			out.emoji = &raw
 		}
 	}
 
-	if v, ok := body["amount"]; ok && v != nil {
+	// An explicit null amount is deliberately *not* a clear: it leaves
+	// hasAmount false, so Update omits the column entirely. Only an empty
+	// string clears it. Preserved from before the refactor.
+	if amount, present := optionalString(body, "amount"); present && amount != nil {
 		out.hasAmount = true
-		raw := strings.TrimSpace(fmt.Sprintf("%v", v))
-		if raw == "" || raw == "<nil>" {
-			out.amount = nil
-		} else {
-			parsed := service.ParseAmount(raw, MaxEntryCalories)
+		if *amount != "" {
+			parsed := service.ParseAmount(*amount, MaxEntryCalories)
 			if !parsed.Ok {
 				return nil, http.StatusBadRequest, fmt.Sprintf("Calories must be between -%d and %d", MaxEntryCalories, MaxEntryCalories)
 			}
@@ -141,21 +157,15 @@ func parseSavedFoodPayload(body map[string]any, forCreate bool) (*savedFoodInput
 	}
 
 	for _, key := range service.MacroKeys {
-		field := key + "_g"
-		v, ok := body[field]
-		if !ok {
+		raw, present := optionalString(body, key+"_g")
+		if !present {
 			continue
 		}
-		if v == nil {
+		if raw == nil || *raw == "" {
 			out.macros[key] = nil
 			continue
 		}
-		raw := strings.TrimSpace(fmt.Sprintf("%v", v))
-		if raw == "" || raw == "<nil>" {
-			out.macros[key] = nil
-			continue
-		}
-		n, err := strconv.Atoi(raw)
+		n, err := strconv.Atoi(*raw)
 		if err != nil || n < 0 || n > MaxEntryMacro {
 			return nil, http.StatusBadRequest, fmt.Sprintf("Macro values must be between 0 and %d", MaxEntryMacro)
 		}

--- a/internal/handler/saved_foods_test.go
+++ b/internal/handler/saved_foods_test.go
@@ -318,3 +318,273 @@ func TestParseSavedFoodPayload(t *testing.T) {
 		})
 	}
 }
+
+// --- #341: the "<nil>" sentinel in parseSavedFoodPayload -------------------
+//
+// parseSavedFoodPayload decoded request bodies into map[string]any and coerced
+// every value with fmt.Sprintf("%v", …) before inspecting it, which renders a
+// JSON null as the four-character string "<nil>". The emoji, amount and macro
+// paths then compared against that sentinel to recover the null they had just
+// destroyed; the name path did not compare at all.
+//
+// So POST /api/saved-foods with {"name": null} produced the name "<nil>",
+// which — being a non-empty string — passed the "Name is required" check and
+// created a saved food literally called <nil>. Same bug as #303 on the entries
+// handler, and the reason it shipped is that parseSavedFoodPayload is pure but
+// this matrix was never table-tested.
+//
+// Everything now reads through optionalString (entries_helpers.go), which
+// separates absent / null / present before any coercion happens.
+
+// sfBody decodes a JSON literal the way ReadJSON does, so these tests exercise
+// the same value types the handler really sees (numbers as float64, an explicit
+// null as a present key holding a nil interface). The older tests in this file
+// build map[string]any by hand, which cannot express "key absent" versus
+// "key present holding null" as unambiguously.
+func sfBody(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	return decodeBody(t, raw)
+}
+
+// TestParseSavedFoodPayloadName is the #341 regression proper. saved_foods.name
+// is NOT NULL, so there is no "clear the name" state: an explicit null joins ""
+// and whitespace as a 400, rather than becoming the string <nil>.
+func TestParseSavedFoodPayloadName(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		forCreate bool
+		wantOK    bool
+		wantName  string
+	}{
+		{"absent on create is rejected", `{}`, true, false, ""},
+		{"absent on update leaves the column alone", `{"amount":"500"}`, false, true, ""},
+		// The bug. This used to return a saved food named "<nil>".
+		{"null on create is rejected", `{"name":null}`, true, false, ""},
+		{"null on update is rejected", `{"name":null}`, false, false, ""},
+		{"empty string is rejected", `{"name":""}`, true, false, ""},
+		{"whitespace is rejected", `{"name":"   "}`, true, false, ""},
+		{"tabs and newlines are rejected", `{"name":"\t\n "}`, true, false, ""},
+		{"a normal string is kept", `{"name":"Porridge"}`, true, true, "Porridge"},
+		{"a padded string is trimmed", `{"name":"  Porridge  "}`, true, true, "Porridge"},
+		// The bug's mirror image: a user may legitimately call a food <nil>,
+		// and must get those four characters stored rather than a rejection.
+		{"the literal <nil> is a real name", `{"name":"<nil>"}`, true, true, "<nil>"},
+		{"a number becomes its text", `{"name":42}`, true, true, "42"},
+		{"a zero becomes its text", `{"name":0}`, true, true, "0"},
+		{"true becomes its text", `{"name":true}`, true, true, "true"},
+		{"false becomes its text", `{"name":false}`, true, true, "false"},
+		{"an object becomes its text", `{"name":{"a":1}}`, true, true, "map[a:1]"},
+		{"an empty object becomes its text", `{"name":{}}`, true, true, "map[]"},
+		{"an array becomes its text", `{"name":[1,2]}`, true, true, "[1 2]"},
+		{"an empty array becomes its text", `{"name":[]}`, true, true, "[]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in, status, msg := parseSavedFoodPayload(sfBody(t, tt.body), tt.forCreate)
+			if !tt.wantOK {
+				if status == 0 {
+					t.Fatalf("accepted %s with name %q, want 400", tt.body, in.name)
+				}
+				if msg != "Name is required" {
+					t.Errorf("message = %q, want %q", msg, "Name is required")
+				}
+				return
+			}
+			if status != 0 {
+				t.Fatalf("rejected %s: %d %q", tt.body, status, msg)
+			}
+			if in.hasName != (tt.wantName != "") {
+				t.Fatalf("hasName = %v for %s", in.hasName, tt.body)
+			}
+			if in.name != tt.wantName {
+				t.Errorf("name = %q, want %q", in.name, tt.wantName)
+			}
+		})
+	}
+}
+
+// TestParseSavedFoodPayloadNameIsCapped keeps the UTF-8-safe truncation the
+// refactor moved from inside the coercion to after it.
+func TestParseSavedFoodPayloadNameIsCapped(t *testing.T) {
+	// 78 ASCII bytes + a 4-byte avocado = 82 bytes, so an 80-byte cap lands
+	// two bytes inside the emoji and must walk back off it.
+	utf8Boundary := strings.Repeat("a", 78) + "🥑"
+	for _, tc := range []struct{ in, want string }{
+		{strings.Repeat("b", 130), strings.Repeat("b", MaxSavedFoodName)},
+		{utf8Boundary, strings.Repeat("a", 78)},
+	} {
+		in, status, msg := parseSavedFoodPayload(map[string]any{"name": tc.in}, true)
+		if status != 0 {
+			t.Fatalf("rejected a long name: %d %q", status, msg)
+		}
+		if in.name != tc.want {
+			t.Errorf("name = %q (%d bytes), want %q (%d bytes)", in.name, len(in.name), tc.want, len(tc.want))
+		}
+		if len(in.name) > MaxSavedFoodName {
+			t.Errorf("name is %d bytes, over the %d-byte cap", len(in.name), MaxSavedFoodName)
+		}
+		if !utf8.ValidString(in.name) {
+			t.Errorf("name %q is not valid UTF-8; Postgres would reject it (22021)", in.name)
+		}
+	}
+}
+
+// TestParseSavedFoodPayloadEmoji pins the emoji column, which is nullable and
+// therefore really does have a clear state. Only the literal "<nil>" changes
+// behaviour: it used to clear the column and is now stored.
+func TestParseSavedFoodPayloadEmoji(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantPresent bool
+		wantNil     bool
+		wantValue   string
+	}{
+		{"key absent leaves the column alone", `{"name":"x"}`, false, true, ""},
+		{"null clears it", `{"name":"x","emoji":null}`, true, true, ""},
+		{"empty string clears it", `{"name":"x","emoji":""}`, true, true, ""},
+		{"whitespace clears it", `{"name":"x","emoji":"   "}`, true, true, ""},
+		{"an emoji is stored", `{"name":"x","emoji":"🍕"}`, true, false, "🍕"},
+		{"a normal string is stored", `{"name":"x","emoji":"pz"}`, true, false, "pz"},
+		{"a padded value is trimmed", `{"name":"x","emoji":"  🍕  "}`, true, false, "🍕"},
+		// Was silently cleared by the sentinel. Nonsense as an emoji either
+		// way, but the point is that the four characters are no longer magic.
+		{"the literal <nil> is stored verbatim", `{"name":"x","emoji":"<nil>"}`, true, false, "<nil>"},
+		{"a number becomes its text", `{"name":"x","emoji":42}`, true, false, "42"},
+		{"true becomes its text", `{"name":"x","emoji":true}`, true, false, "true"},
+		{"an object becomes its text", `{"name":"x","emoji":{"a":1}}`, true, false, "map[a:1]"},
+		{"an array becomes its text", `{"name":"x","emoji":[1,2]}`, true, false, "[1 2]"},
+		{"an empty array becomes its text", `{"name":"x","emoji":[]}`, true, false, "[]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in, status, msg := parseSavedFoodPayload(sfBody(t, tt.body), true)
+			if status != 0 {
+				t.Fatalf("rejected %s: %d %q", tt.body, status, msg)
+			}
+			if in.hasEmoji != tt.wantPresent {
+				t.Fatalf("hasEmoji = %v, want %v", in.hasEmoji, tt.wantPresent)
+			}
+			if (in.emoji == nil) != tt.wantNil {
+				t.Fatalf("emoji nil = %v, want %v (got %v)", in.emoji == nil, tt.wantNil, in.emoji)
+			}
+			if in.emoji != nil && *in.emoji != tt.wantValue {
+				t.Errorf("emoji = %q, want %q", *in.emoji, tt.wantValue)
+			}
+			if in.emoji != nil && len(*in.emoji) > MaxSavedFoodEmoji {
+				t.Errorf("emoji is %d bytes, over the %d-byte cap", len(*in.emoji), MaxSavedFoodEmoji)
+			}
+		})
+	}
+}
+
+// TestParseSavedFoodPayloadAmount pins the amount column. Note the asymmetry
+// preserved from before the refactor: an explicit null leaves hasAmount false
+// (Update omits the column entirely), while an empty string clears it. Only the
+// literal "<nil>" changes: it used to clear, and is now a 400 — the same call
+// #338 made for the entry amount.
+func TestParseSavedFoodPayloadAmount(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantSet   bool // hasAmount
+		wantNil   bool
+		wantValue int
+		wantMsg   bool
+	}{
+		{"key absent leaves the column alone", `{"name":"x"}`, false, true, 0, false},
+		{"null leaves hasAmount false", `{"name":"x","amount":null}`, false, true, 0, false},
+		{"empty string clears it", `{"name":"x","amount":""}`, true, true, 0, false},
+		{"whitespace clears it", `{"name":"x","amount":"   "}`, true, true, 0, false},
+		{"a numeric string sets it", `{"name":"x","amount":"500"}`, true, false, 500, false},
+		{"a JSON number sets it", `{"name":"x","amount":500}`, true, false, 500, false},
+		{"an expression is evaluated", `{"name":"x","amount":"2*3"}`, true, false, 6, false},
+		{"literal <nil> is rejected, not silently cleared", `{"name":"x","amount":"<nil>"}`, false, false, 0, true},
+		{"a word is rejected", `{"name":"x","amount":"abc"}`, false, false, 0, true},
+		{"true is rejected", `{"name":"x","amount":true}`, false, false, 0, true},
+		{"an object is rejected", `{"name":"x","amount":{"a":1}}`, false, false, 0, true},
+		{"an array is rejected", `{"name":"x","amount":[1,2]}`, false, false, 0, true},
+		{"over the cap is rejected", `{"name":"x","amount":"99999"}`, false, false, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in, status, msg := parseSavedFoodPayload(sfBody(t, tt.body), true)
+			if (status != 0) != tt.wantMsg {
+				t.Fatalf("status = %d (%q), wantMsg = %v", status, msg, tt.wantMsg)
+			}
+			if tt.wantMsg {
+				return
+			}
+			if in.hasAmount != tt.wantSet {
+				t.Fatalf("hasAmount = %v, want %v", in.hasAmount, tt.wantSet)
+			}
+			if (in.amount == nil) != tt.wantNil {
+				t.Fatalf("amount nil = %v, want %v (got %v)", in.amount == nil, tt.wantNil, in.amount)
+			}
+			if in.amount != nil && *in.amount != tt.wantValue {
+				t.Errorf("amount = %d, want %d", *in.amount, tt.wantValue)
+			}
+		})
+	}
+}
+
+// TestParseSavedFoodPayloadMacros pins the macro columns. They are nullable, so
+// null and "" both clear — but unlike the entries handler an explicit "0" here
+// is a real zero, not a clear. Only the literal "<nil>" changes behaviour.
+func TestParseSavedFoodPayloadMacros(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantPresent bool
+		wantNil     bool
+		wantValue   int
+		wantMsg     bool
+	}{
+		{"key absent leaves the column alone", `{"name":"x"}`, false, true, 0, false},
+		{"null clears it", `{"name":"x","protein_g":null}`, true, true, 0, false},
+		{"empty string clears it", `{"name":"x","protein_g":""}`, true, true, 0, false},
+		{"whitespace clears it", `{"name":"x","protein_g":"   "}`, true, true, 0, false},
+		{"a numeric string sets it", `{"name":"x","protein_g":"50"}`, true, false, 50, false},
+		{"a JSON number sets it", `{"name":"x","protein_g":50}`, true, false, 50, false},
+		// Unlike buildEntryUpdates, where "0" means clear. Pinned so the two
+		// surfaces are not "harmonised" by accident.
+		{"zero is a real zero here, not a clear", `{"name":"x","protein_g":0}`, true, false, 0, false},
+		{"literal <nil> is rejected, not silently cleared", `{"name":"x","protein_g":"<nil>"}`, false, false, 0, true},
+		{"a word is rejected", `{"name":"x","protein_g":"abc"}`, false, false, 0, true},
+		{"true is rejected", `{"name":"x","protein_g":true}`, false, false, 0, true},
+		{"an object is rejected", `{"name":"x","protein_g":{"a":1}}`, false, false, 0, true},
+		{"an array is rejected", `{"name":"x","protein_g":[1,2]}`, false, false, 0, true},
+		{"a fraction is rejected", `{"name":"x","protein_g":30.5}`, false, false, 0, true},
+		{"a negative value is rejected", `{"name":"x","protein_g":-5}`, false, false, 0, true},
+		{"over the cap is rejected", `{"name":"x","protein_g":1500}`, false, false, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in, status, msg := parseSavedFoodPayload(sfBody(t, tt.body), true)
+			if (status != 0) != tt.wantMsg {
+				t.Fatalf("status = %d (%q), wantMsg = %v", status, msg, tt.wantMsg)
+			}
+			if tt.wantMsg {
+				return
+			}
+			v, present := in.macros["protein"]
+			if present != tt.wantPresent {
+				t.Fatalf("protein present = %v, want %v", present, tt.wantPresent)
+			}
+			if !present {
+				return
+			}
+			if (v == nil) != tt.wantNil {
+				t.Fatalf("protein nil = %v, want %v (got %v)", v == nil, tt.wantNil, v)
+			}
+			if v != nil && *v != tt.wantValue {
+				t.Errorf("protein = %d, want %d", *v, tt.wantValue)
+			}
+		})
+	}
+}

--- a/internal/handler/weight.go
+++ b/internal/handler/weight.go
@@ -45,23 +45,49 @@ func (h *WeightHandler) ToggleBodyFatEnabled(w http.ResponseWriter, r *http.Requ
 // stored reading alone, an explicit null or empty string clears it, and a
 // number sets it. The bool is false only when a value was supplied but is
 // unusable, so the caller can answer 400 instead of silently dropping it.
+//
+// optionalString (entries_helpers.go) is what keeps those states apart: it
+// checks the interface for nil *before* coercing, so a JSON null never becomes
+// the four-character string "<nil>" that this function used to have to
+// recognise. That sentinel comparison was defensive rather than wrong here —
+// the explicit nil check above it already caught the null — but it also meant
+// a caller sending the literal characters <nil> silently cleared the column.
+// Now it is simply an unparseable body fat and earns a 400, the same call
+// #338 made for the entry amount and macros.
 func parseBodyFatUpdate(body map[string]any) (service.BodyFatUpdate, bool) {
-	raw, exists := body["body_fat"]
-	if !exists {
+	raw, present := optionalString(body, "body_fat")
+	if !present {
 		return service.KeepBodyFat, true
 	}
-	if raw == nil {
+	if raw == nil || *raw == "" {
 		return service.BodyFatUpdate{Set: true}, true
 	}
-	s := strings.TrimSpace(fmt.Sprintf("%v", raw))
-	if s == "" || s == "<nil>" {
-		return service.BodyFatUpdate{Set: true}, true
-	}
-	pct, ok := service.ParseBodyFat(s)
+	pct, ok := service.ParseBodyFat(*raw)
 	if !ok {
 		return service.BodyFatUpdate{}, false
 	}
 	return service.BodyFatUpdate{Set: true, Value: &pct}, true
+}
+
+// weightUpsertDate resolves the date a weight upsert applies to. The SPA sends
+// entry_date, older clients and the CSV importer send date, and a body with
+// neither means "today" in the account's zone — not the server's.
+//
+// Both keys go through optionalString for the same reason parseBodyFatUpdate
+// does: the fallback chain used to coerce with %v first and then test the
+// result against "<nil>" to work out that the key had held a JSON null. A
+// caller who sent the literal characters <nil> therefore had the reading
+// quietly filed under today. It now fails isValidDate in the caller and gets
+// a 400, which is what an unparseable date has always got.
+//
+// now is a parameter so the fallback is testable without a clock.
+func weightUpsertDate(body map[string]any, now time.Time, tz string) string {
+	for _, key := range []string{"entry_date", "date"} {
+		if v, present := optionalString(body, key); present && v != nil && *v != "" {
+			return *v
+		}
+	}
+	return service.FormatDateInTz(now, tz)
 }
 
 // WeightDay handles GET /weight/day
@@ -118,13 +144,7 @@ func (h *WeightHandler) WeightUpsert(w http.ResponseWriter, r *http.Request) {
 	user := middleware.GetCurrentUser(r)
 	userTz := getUserTimezone(r, user)
 
-	dateStr := strings.TrimSpace(fmt.Sprintf("%v", body["entry_date"]))
-	if dateStr == "" || dateStr == "<nil>" {
-		dateStr = strings.TrimSpace(fmt.Sprintf("%v", body["date"]))
-	}
-	if dateStr == "" || dateStr == "<nil>" {
-		dateStr = service.FormatDateInTz(time.Now(), userTz)
-	}
+	dateStr := weightUpsertDate(body, time.Now(), userTz)
 	if !isValidDate(dateStr) {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid date")
 		return

--- a/internal/handler/weight_test.go
+++ b/internal/handler/weight_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 // decodeBody mirrors how the weight and entries handlers receive a request:
@@ -79,4 +80,169 @@ func TestParseBodyFatUpdate(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestParseBodyFatUpdateCoercionMatrix walks every JSON shape the body_fat key
+// can arrive as, which is the #341 half of the #303 story: parseBodyFatUpdate
+// used to coerce with fmt.Sprintf("%v", …) and then compare the result against
+// the literal string "<nil>" to recover a null it had already destroyed.
+//
+// The sentinel was defensive rather than wrong here — the nil check above it
+// caught the null first — so almost every row below asserts *unchanged*
+// behaviour. The one that changes is the literal "<nil>": it used to clear the
+// column and is now just an unparseable body fat, the same call #338 made for
+// the entry amount and macros.
+func TestParseBodyFatUpdateCoercionMatrix(t *testing.T) {
+	const (
+		keep  = "keep"  // absent key: leave any stored reading alone
+		clear = "clear" // Set with no value: NULL the column
+		set   = "set"   // Set with a value
+		bad   = "bad"   // unusable: the caller answers 400
+	)
+
+	tests := []struct {
+		name string
+		body string
+		want string
+		val  float64
+	}{
+		{"key absent", `{"weight":"75.5"}`, keep, 0},
+		{"empty body", `{}`, keep, 0},
+		{"explicit null", `{"body_fat":null}`, clear, 0},
+		{"empty string", `{"body_fat":""}`, clear, 0},
+		{"whitespace only", `{"body_fat":"   "}`, clear, 0},
+		{"tabs and newlines", `{"body_fat":"\t\n "}`, clear, 0},
+		{"a normal numeric string", `{"body_fat":"24.3"}`, set, 24.3},
+		{"a comma decimal", `{"body_fat":"24,3"}`, set, 24.3},
+		{"a JSON number", `{"body_fat":24.3}`, set, 24.3},
+		{"a whole JSON number", `{"body_fat":24}`, set, 24},
+		{"a padded string is trimmed", `{"body_fat":"  24.3  "}`, set, 24.3},
+		// The behaviour change. Under the sentinel these four characters
+		// silently cleared the reading; now they are what they look like.
+		{"literal <nil> is rejected, not silently cleared", `{"body_fat":"<nil>"}`, bad, 0},
+		{"a word", `{"body_fat":"abc"}`, bad, 0},
+		{"boolean true", `{"body_fat":true}`, bad, 0},
+		{"boolean false", `{"body_fat":false}`, bad, 0},
+		{"an object", `{"body_fat":{"a":1}}`, bad, 0},
+		{"an array", `{"body_fat":[1,2]}`, bad, 0},
+		{"an empty array", `{"body_fat":[]}`, bad, 0},
+		{"zero is out of range", `{"body_fat":0}`, bad, 0},
+		{"a negative reading", `{"body_fat":-5}`, bad, 0},
+		{"an impossible reading", `{"body_fat":99}`, bad, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseBodyFatUpdate(decodeBody(t, tt.body))
+			if tt.want == bad {
+				if ok {
+					t.Fatalf("accepted %s as {Set:%v Value:%v}, want a 400", tt.body, got.Set, got.Value)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("rejected %s, want %s", tt.body, tt.want)
+			}
+			switch tt.want {
+			case keep:
+				if got.Set {
+					t.Errorf("Set = true, want false — an absent key must not touch the column")
+				}
+			case clear:
+				if !got.Set || got.Value != nil {
+					t.Errorf("got {Set:%v Value:%v}, want a clear", got.Set, got.Value)
+				}
+			case set:
+				if !got.Set || got.Value == nil {
+					t.Fatalf("got {Set:%v Value:%v}, want a set", got.Set, got.Value)
+				}
+				if *got.Value != tt.val {
+					t.Errorf("Value = %v, want %v", *got.Value, tt.val)
+				}
+			}
+		})
+	}
+}
+
+// TestWeightUpsertDate pins the entry_date / date / today fallback chain that
+// POST /weight/upsert runs a body through.
+//
+// It used to coerce each key with %v before testing the result for emptiness,
+// so a JSON null arrived as "<nil>" and had to be compared against that
+// sentinel to be recognised as absent. A caller sending the literal four
+// characters therefore had the reading quietly filed under today; now the
+// string survives, fails isValidDate in the handler, and earns a 400.
+func TestWeightUpsertDate(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	const today = "2026-08-08"
+
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"entry_date wins", `{"entry_date":"2026-01-02","date":"2026-03-04"}`, "2026-01-02"},
+		{"date is the fallback key", `{"date":"2026-03-04"}`, "2026-03-04"},
+		{"both keys absent means today", `{"weight":"82"}`, today},
+		{"empty body means today", `{}`, today},
+		{"a null entry_date falls through to date", `{"entry_date":null,"date":"2026-03-04"}`, "2026-03-04"},
+		{"a null entry_date with no date means today", `{"entry_date":null}`, today},
+		{"an empty entry_date falls through to date", `{"entry_date":"","date":"2026-03-04"}`, "2026-03-04"},
+		{"a whitespace entry_date falls through", `{"entry_date":"   ","date":"2026-03-04"}`, "2026-03-04"},
+		{"both null means today", `{"entry_date":null,"date":null}`, today},
+		{"a padded date is trimmed", `{"entry_date":"  2026-01-02  "}`, "2026-01-02"},
+		// The behaviour change: these used to be swallowed by the sentinel and
+		// silently become today. They now reach isValidDate and are rejected.
+		{"literal <nil> is kept so the handler can reject it", `{"entry_date":"<nil>"}`, "<nil>"},
+		// json.Unmarshal into any gives float64, so %v renders a large integer
+		// in scientific notation. Unchanged from the pre-refactor coercion —
+		// pinned here so nobody "fixes" it into something isValidDate accepts.
+		{"a number is kept so the handler can reject it", `{"entry_date":20260102}`, "2.0260102e+07"},
+		{"a small number is kept so the handler can reject it", `{"entry_date":5}`, "5"},
+		{"a boolean is kept so the handler can reject it", `{"entry_date":true}`, "true"},
+		{"an object is kept so the handler can reject it", `{"entry_date":{"a":1}}`, "map[a:1]"},
+		{"an array is kept so the handler can reject it", `{"entry_date":[1,2]}`, "[1 2]"},
+		{"a garbage string is kept so the handler can reject it", `{"entry_date":"not-a-date"}`, "not-a-date"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := weightUpsertDate(decodeBody(t, tt.body), now, "UTC"); got != tt.want {
+				t.Errorf("weightUpsertDate(%s) = %q, want %q", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWeightUpsertDateRejectsWhatItPassesThrough is the other half of the
+// change above: a value the sentinel used to swallow must not merely survive
+// weightUpsertDate, it must actually fail the handler's date check, or all the
+// refactor did is move a silent "today" one line later.
+func TestWeightUpsertDateRejectsWhatItPassesThrough(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	for _, body := range []string{
+		`{"entry_date":"<nil>"}`,
+		`{"date":"<nil>"}`,
+		`{"entry_date":true}`,
+		`{"entry_date":{"a":1}}`,
+		`{"entry_date":"not-a-date"}`,
+	} {
+		got := weightUpsertDate(decodeBody(t, body), now, "UTC")
+		if isValidDate(got) {
+			t.Errorf("%s resolved to %q, which isValidDate accepts — the reading would be filed under a bogus date", body, got)
+		}
+	}
+}
+
+// TestWeightUpsertDateUsesTheAccountTimezone guards the reason `now` is a
+// parameter: "today" is today for the account, not for the server.
+func TestWeightUpsertDateUsesTheAccountTimezone(t *testing.T) {
+	// 23:30 UTC on the 8th is already the 9th in Auckland.
+	now := time.Date(2026, 8, 8, 23, 30, 0, 0, time.UTC)
+	if got := weightUpsertDate(decodeBody(t, `{}`), now, "UTC"); got != "2026-08-08" {
+		t.Errorf("UTC: got %q, want 2026-08-08", got)
+	}
+	if got := weightUpsertDate(decodeBody(t, `{}`), now, "Pacific/Auckland"); got != "2026-08-09" {
+		t.Errorf("Pacific/Auckland: got %q, want 2026-08-09", got)
+	}
 }


### PR DESCRIPTION
Closes #341.

Follow-up to #303 / #338, which removed the `"<nil>"` sentinel from
`internal/handler/entries_crud.go` only. Six sites survived in `weight.go` and
`saved_foods.go`. One of them was a live bug.

## The bug

`parseSavedFoodPayload`'s name path did `truncateUTF8(strings.TrimSpace(fmt.Sprintf("%v", v)), …)`
with **no nil check at all**. `fmt.Sprintf("%v", nil)` is the four characters
`<nil>`, which is a non-empty string, so it passed the "Name is required" check
and a saved food was created literally called `<nil>`.

### Before — on the pre-fix code, through the real handler against `postgres:18`

```
POST /api/saved-foods {"name": null}
  HTTP 200
  body: {"ok":true,"savedFood":{"id":1,"name":"<nil>","emoji":null,"amount":null,
         "macros":{"carbs":null,"fat":null,"fiber":null,"protein":null,"sugar":null},
         "use_count":0,"last_used_at":null}}
  rows in saved_foods for this user: ["<nil>"]
  BUG REPRODUCED: saved_foods row created with name = "<nil>"
```

### After — same request, same harness

```
POST /api/saved-foods {"name": null}
  HTTP 400
  body: {"error":"Name is required","ok":false}
  rows in saved_foods for this user: []
```

`saved_foods.name` is `NOT NULL` (confirmed against the live schema), so there is
no "clear the name" state to route a null into. It joins `""` and `"   "` as a
400, which is what the endpoint already answered for those.

## The cleanup

All six sites now read through `optionalString` from #338, which checks the
interface for nil **before** coercing, so absent / null / present stay apart and
no sentinel is needed.

| site | before | after |
| --- | --- | --- |
| `weight.go` `parseBodyFatUpdate` | `s == "" \|\| s == "<nil>"` | `optionalString` |
| `weight.go` `WeightUpsert` date (×2) | `dateStr == "<nil>"` chain | `weightUpsertDate` helper |
| `saved_foods.go` emoji | `raw == "<nil>"` | `optionalString` |
| `saved_foods.go` amount | `raw == "<nil>"` | `optionalString` |
| `saved_foods.go` macros | `raw == "<nil>"` | `optionalString` |
| `saved_foods.go` **name** | *no nil check — the bug* | `optionalString` |

`weightUpsertDate(body, now, tz)` extracts the `entry_date` → `date` → today
chain, `now` as a parameter, so the fallback is testable without a clock —
mirroring how #338 extracted `buildEntryUpdates`.

### Behaviour preserved

Everywhere the sentinel was merely defensive. Notably the asymmetry that a null
saved-food `amount` leaves `hasAmount` false (Update omits the column) while an
empty string clears it, and that an explicit `0` macro here is a real zero
rather than a clear — both pinned by new tests so a later "harmonisation" with
the entries handler cannot drop them silently.

### Behaviour deliberately changed

A user who types the literal `<nil>` is no longer indistinguishable from a null:

- **Text fields** (`name`, `emoji`) store the four characters verbatim.
- **Numeric fields** (`amount`, macros, `body_fat`) reject them with a 400
  instead of silently clearing. This is exactly the call #338 made for the entry
  amount and macros; these files now agree with it.
- `{"entry_date": "<nil>"}` used to be swallowed and silently filed under today.
  It now reaches `isValidDate` and earns a 400 `Invalid date`.
  `TestWeightUpsertDateRejectsWhatItPassesThrough` asserts the rejection really
  happens, so the refactor did not just move a silent "today" one line later.

## Tests

Table tests on every extracted path covering the full matrix the issue asked
for — key absent, `null`, `""`, whitespace, a normal string, a number, `true`,
an object, an array, and the literal `"<nil>"`:

- `TestParseSavedFoodPayloadName` (the #341 regression proper), `…NameIsCapped`,
  `…Emoji`, `…Amount`, `…Macros`
- `TestParseBodyFatUpdateCoercionMatrix`, `TestWeightUpsertDate`,
  `TestWeightUpsertDateRejectsWhatItPassesThrough`,
  `TestWeightUpsertDateUsesTheAccountTimezone`

All pure, no database — needing one is exactly why the name bug shipped
untested. The existing `TestParseSavedFoodPayload` and `TestParseBodyFatUpdate`
are untouched and still pass.

```
$ go build ./... && go vet ./... && go test ./...
ok  	schautrack/cmd/server
ok  	schautrack/internal/clientip
ok  	schautrack/internal/database        # incl. TEST_DATABASE_URL integration tests
ok  	schautrack/internal/handler
ok  	schautrack/internal/middleware
ok  	schautrack/internal/openapi
ok  	schautrack/internal/release
ok  	schautrack/internal/service
ok  	schautrack/internal/session
ok  	schautrack/internal/sse

$ go test ./internal/handler/ -run 'SavedFood|Weight|Optional|BodyFat' -v
ok  	schautrack/internal/handler        # 150 subtests pass

$ grep -rn '"<nil>"' internal/handler/weight.go internal/handler/saved_foods.go
# 4 hits, all in explanatory comments — no comparison remains.
# (#338 left the same kind of comment reference in entries_crud.go.)
```

The full suite was run with a `postgres:18` container on a unique port so the
`TEST_DATABASE_URL`-gated integration tests actually executed rather than
skipping; the container has been removed.

## Stacked on #338

This branch is stacked on `entries-update-null-name` (#338), because it needs
the `optionalString` / `optionalEntryName` helpers that PR adds in
`internal/handler/entries_helpers.go`. It is therefore opened with
`--base entries-update-null-name`; **GitHub will retarget it to `staging`
automatically once #338 merges.** Review #338 first.

## Notes for the merge into `staging`

Two things found while doing this, filed separately rather than smuggled in:

- **#326 (already on `staging`) added a seventh sentinel.** Its new
  `parseWeightUpdate` carries a fresh `s == "" || s == "<nil>"`, and it replaced
  the `weightStr := fmt.Sprintf("%v", body["weight"])` line this branch
  deliberately leaves alone. Touching that line here would only manufacture a
  conflict with code `staging` has already rewritten, so it is left for the
  follow-up issue.
- Clearing a saved food's calories in the UI is broken independently of this
  change — also filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)