### PR TITLE
test: add native Go fuzz targets for the parsers and validators

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,102 @@
+name: Nightly Fuzz
+
+# Step 3 of issue #315. The fuzz targets themselves are ordinary tests: `go
+# test ./...` replays their recorded seed corpus on every push, which is where
+# the regression value lives and needs no CI change at all. This workflow is
+# the other half — actually *fuzzing*, i.e. generating new inputs, which is
+# too slow to sit in the PR path.
+#
+# The corpus is cached per target and carried forward from run to run, so each
+# night resumes from the coverage the previous nights found rather than
+# restarting from the seeds. Without that, a nightly fuzz job re-explores the
+# same shallow inputs forever.
+#
+# A crasher is uploaded as an artifact rather than auto-committed: pushing to a
+# branch from CI needs `contents: write` on a scheduled job, and a failing
+# nightly with the reproducer attached is enough to act on. Drop the artifact
+# into `internal/<pkg>/testdata/fuzz/<Target>/` in a PR to make it a permanent
+# regression seed.
+
+on:
+  schedule:
+    - cron: '0 4 * * *' # 04:00 UTC daily
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: 'Per-target fuzz duration (any Go duration, e.g. 5m)'
+        required: false
+        default: '5m'
+
+permissions:
+  contents: read
+
+# One nightly at a time. Two overlapping runs would race on the corpus cache
+# and the later save would silently drop the earlier run's findings.
+concurrency:
+  group: nightly-fuzz
+  cancel-in-progress: false
+
+env:
+  # Pin the build cache into the workspace so the fuzz corpus underneath it
+  # (GOCACHE/fuzz) has a stable, cacheable path.
+  GOCACHE: ${{ github.workspace }}/.gocache
+
+jobs:
+  fuzz:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      # Every target runs even when one of them finds something — a crasher in
+      # one parser says nothing about the others.
+      fail-fast: false
+      matrix:
+        include:
+          - { package: ./internal/service/, target: FuzzParseAmount }
+          - { package: ./internal/service/, target: FuzzParseWeight }
+          - { package: ./internal/service/, target: FuzzParseBodyFat }
+          - { package: ./internal/service/, target: FuzzValidateSchedule }
+          - { package: ./internal/handler/, target: FuzzIsValidDate }
+          - { package: ./internal/handler/, target: FuzzTruncateUTF8 }
+          - { package: ./internal/handler/, target: FuzzDecodeCursor }
+          - { package: ./internal/handler/, target: FuzzDecodeV1 }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          # setup-go's cache is keyed on go.sum and would pin a stale copy of
+          # GOCACHE — including the fuzz corpus — for as long as deps do not
+          # change. The corpus is cached explicitly below instead.
+          cache: false
+
+      # Restore the previous night's corpus. The run_id in the key means the
+      # primary key never hits, so every run writes a fresh entry and
+      # restore-keys picks up the most recent one.
+      - name: Restore fuzz corpus
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ github.workspace }}/.gocache/fuzz
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target }}-
+
+      - name: Fuzz ${{ matrix.target }}
+        run: |
+          go test ${{ matrix.package }} \
+            -run '^$' \
+            -fuzz '^${{ matrix.target }}$' \
+            -fuzztime='${{ inputs.fuzztime || '5m' }}'
+
+      # A failing target writes its reproducer to
+      # internal/<pkg>/testdata/fuzz/<Target>/<hash>.
+      - name: Upload crasher
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: crasher-${{ matrix.target }}
+          path: internal/**/testdata/fuzz/**
+          if-no-files-found: ignore

--- a/internal/handler/v1_common_fuzz_test.go
+++ b/internal/handler/v1_common_fuzz_test.go
@@ -1,0 +1,173 @@
+package handler
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"schautrack/internal/apierr"
+)
+
+// FuzzDecodeCursor drives the keyset pagination cursor through both
+// directions.
+//
+// The cursor arrives as a user-supplied query parameter, is base64-decoded,
+// and its two halves are spliced into a keyset WHERE clause. A cursor that
+// decodes to a bogus date or a non-positive id is a malformed query at best.
+//
+// Properties asserted:
+//
+//   - decodeCursor never panics on arbitrary input;
+//   - a failed decode returns the zero cursor, never a half-filled one;
+//   - success implies isValidDate(c.Date) && c.ID > 0;
+//   - success is stable: re-encoding a decoded cursor decodes back to it;
+//   - decodeCursor(encodeCursor(c)) == c for every cursor the encoder can
+//     legitimately be handed (valid date, positive id).
+func FuzzDecodeCursor(f *testing.F) {
+	seeds := []struct {
+		raw  string
+		date string
+		id   int
+	}{
+		{encodeCursor(cursor{Date: "2026-07-03", ID: 42}), "2026-07-03", 42},
+		{encodeCursor(cursor{Date: "1900-01-01", ID: 1}), "1900-01-01", 1},
+		{encodeCursor(cursor{Date: "2200-12-31", ID: 1 << 31}), "2200-12-31", 1 << 31},
+		// Malformed cursors: not base64, base64 of nonsense, missing comma,
+		// bad date, non-positive / non-numeric id, padded base64.
+		{"", "", 0},
+		{"!!!not base64!!!", "2026-02-31", 0},
+		{"MjAyNi0wNy0wMw", "2026-07-03", -1},
+		{"MjAyNi0wMi0zMSw0Mg", "2026-7-3", 1},
+		{"MjAyNi0wNy0wMyww", "2026-07-03", 0},
+		{"MjAyNi0wNy0wMyxhYmM", "not-a-date", 5},
+		{"MjAyNi0wNy0wMyw0Mg==", "2026-07-03", 1<<62 + 1},
+		{",,,", "2026,07,03", 7},
+		{strings.Repeat("A", 400), "2026-07-03", 9223372036854775807},
+	}
+	for _, s := range seeds {
+		f.Add(s.raw, s.date, s.id)
+	}
+
+	f.Fuzz(func(t *testing.T, raw, date string, id int) {
+		// Direction 1: arbitrary bytes off the wire.
+		got, err := decodeCursor(raw)
+		if err != nil {
+			if got != (cursor{}) {
+				t.Fatalf("decodeCursor(%q) failed but returned %+v, want the zero cursor", raw, got)
+			}
+		} else {
+			if !isValidDate(got.Date) {
+				t.Fatalf("decodeCursor(%q) = %+v, but %q is not a valid date", raw, got, got.Date)
+			}
+			if got.ID <= 0 {
+				t.Fatalf("decodeCursor(%q) = %+v, but the id must be positive", raw, got)
+			}
+			// A cursor we handed out must survive being handed back.
+			again, err := decodeCursor(encodeCursor(got))
+			if err != nil || again != got {
+				t.Fatalf("re-encoding %+v does not round-trip: got %+v, err %v", got, again, err)
+			}
+		}
+
+		// Direction 2: cursors the encoder can legitimately be given. Only
+		// these are round-trippable — encodeCursor has no validation of its
+		// own, and a caller that fabricates an invalid one is out of contract.
+		c := cursor{Date: date, ID: id}
+		if !isValidDate(c.Date) || c.ID <= 0 {
+			return
+		}
+		back, err := decodeCursor(encodeCursor(c))
+		if err != nil {
+			t.Fatalf("decodeCursor(encodeCursor(%+v)) failed: %v", c, err)
+		}
+		if back != c {
+			t.Fatalf("decodeCursor(encodeCursor(%+v)) = %+v, want the original", c, back)
+		}
+	})
+}
+
+// FuzzDecodeV1 drives the /api/v1 body decoder with arbitrary bytes.
+//
+// decodeV1 is the first thing every v1 write endpoint runs against a caller's
+// body, and its whole job is to turn malformed input into a precise 4xx. A
+// 5xx from here would be the API blaming itself for the client's typo, and an
+// unhandled panic would take the process down.
+//
+// Properties asserted:
+//
+//   - never panics on any byte sequence, against several real request shapes
+//     (plain pointers, Optional[T] fields, and a bare map);
+//   - the outcome is either a successful decode or a *apierr.Problem;
+//   - a returned Problem always carries a 4xx status — never 5xx, never 0,
+//     never a success code;
+//   - a returned Problem is well-formed: non-empty type and title;
+//   - deterministic for the same bytes.
+func FuzzDecodeV1(f *testing.F) {
+	seeds := []struct {
+		body  string
+		shape uint8
+	}{
+		{`{"calories":500}`, 0},
+		{`{"date":"2026-07-03","calories":500,"name":"pizza"}`, 0},
+		{`{"name":null,"protein_g":12}`, 1},
+		{`{"anything":1}`, 2},
+		// Malformed / hostile bodies.
+		{``, 0},
+		{`   `, 0},
+		{`null`, 0},
+		{`{`, 0},
+		{`{}{}`, 0},
+		{`{} garbage`, 0},
+		{`[1,2,3]`, 0},
+		{`{"calories":"five hundred"}`, 0},   // UnmarshalTypeError -> 422
+		{`{"caloriez":500}`, 0},              // unknown field -> 400
+		{`{"calories":1e309}`, 0},            // number out of float range
+		{`{"name":"\ud800"}`, 0},             // lone surrogate
+		{`{"name":"` + "\xff\xfe" + `"}`, 0}, // invalid UTF-8 in a string
+		{strings.Repeat(`{"a":`, 200) + `1` + strings.Repeat(`}`, 200), 2},
+		{`{"protein_g":{"nested":true}}`, 1},
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s.body), s.shape)
+	}
+
+	f.Fuzz(func(t *testing.T, body []byte, shape uint8) {
+		first := runDecodeV1(t, body, shape)
+		if second := runDecodeV1(t, body, shape); (first == nil) != (second == nil) {
+			t.Fatalf("decodeV1 is not deterministic for %q", body)
+		}
+		if first == nil {
+			return
+		}
+		if first.Status < 400 || first.Status > 499 {
+			t.Fatalf("decodeV1(%q) returned status %d; a malformed body must always be 4xx",
+				body, first.Status)
+		}
+		if first.Type == "" || first.Title == "" {
+			t.Fatalf("decodeV1(%q) returned a malformed problem %+v", body, first)
+		}
+	})
+}
+
+// runDecodeV1 pushes body through decodeV1 against one of the real v1 request
+// shapes. shape selects between plain-pointer fields, Optional[T] fields
+// (whose custom UnmarshalJSON is its own error path), and a bare map.
+func runDecodeV1(t *testing.T, body []byte, shape uint8) *apierr.Problem {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/entries", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	switch shape % 3 {
+	case 0:
+		var dst v1EntryInput
+		return decodeV1(w, r, &dst)
+	case 1:
+		var dst v1EntryPatch
+		return decodeV1(w, r, &dst)
+	default:
+		var dst map[string]any
+		return decodeV1(w, r, &dst)
+	}
+}

--- a/internal/handler/validate_fuzz_test.go
+++ b/internal/handler/validate_fuzz_test.go
@@ -1,0 +1,147 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+// FuzzIsValidDate drives the strict YYYY-MM-DD validator with arbitrary
+// strings.
+//
+// isValidDate guards every date that reaches a SQL query. A shape-only regex
+// accepts 2026-02-31, which Postgres then rejects with a query error — a 500
+// for the caller. The property below is the guarantee that stops that:
+//
+//   - never panics;
+//   - isValidDate(s) implies time.Parse("2006-01-02", s) succeeds AND
+//     Format round-trips to s exactly (so 2026-02-31 and 2026-7-3 are out);
+//   - isValidDate(s) implies the year is within the sane 1900..2200 range;
+//   - deterministic.
+//
+// It also asserts the converse for the only class where it is unambiguous: a
+// string that Parse+Format round-trips and lands in range MUST be accepted,
+// so the validator cannot start rejecting real dates.
+func FuzzIsValidDate(f *testing.F) {
+	seeds := []string{
+		// Accepted rows from TestIsValidDate.
+		"2026-07-03", "2024-02-29", "1900-01-01", "2200-12-31",
+		// Rejected rows.
+		"", "not-a-date", "2026/07/03", "2026-7-3", "20260703",
+		"2026-02-31", "2026-02-30", "2023-02-29", "2026-13-01", "2026-00-10",
+		"2026-01-32", "2026-01-00", "1899-12-31", "2201-01-01",
+		"2026-07-03x", "2026-07-03T00:00:00Z", " 2026-07-03 ",
+		// Extra shapes worth pinning: signed and over-wide years, separators,
+		// and a value time.Parse tolerates but Format does not reproduce.
+		"+2026-07-03", "-2026-07-03", "02026-07-03", "2026-07-03\n",
+		"0000-01-01", "9999-12-31", "2026-07-03 ", "2026-07-3",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		got := isValidDate(s)
+
+		if again := isValidDate(s); again != got {
+			t.Fatalf("isValidDate(%q) is not deterministic: %v then %v", s, got, again)
+		}
+
+		parsed, err := time.Parse("2006-01-02", s)
+		roundTrips := err == nil && parsed.Format("2006-01-02") == s
+		inRange := roundTrips && parsed.Year() >= minDateYear && parsed.Year() <= maxDateYear
+
+		if got && err != nil {
+			t.Fatalf("isValidDate(%q) = true but time.Parse fails: %v", s, err)
+		}
+		if got && !roundTrips {
+			t.Fatalf("isValidDate(%q) = true but it does not round-trip: Format gives %q",
+				s, parsed.Format("2006-01-02"))
+		}
+		if got != inRange {
+			t.Fatalf("isValidDate(%q) = %v, but Parse+Format round-trip in range = %v",
+				s, got, inRange)
+		}
+	})
+}
+
+// FuzzTruncateUTF8 drives the byte-capping helper over arbitrary strings and
+// arbitrary caps.
+//
+// truncateUTF8 exists because byte-index slicing can cut a multi-byte rune in
+// half, and Postgres rejects the result with "invalid byte sequence for
+// encoding UTF8" (22021). TestTruncateUTF8 asserts three invariants per hand
+// written row; those invariants are the fuzz properties, over every input
+// rather than sixteen:
+//
+//   - never panics;
+//   - the result never exceeds the cap (and is empty for a non-positive cap);
+//   - the result is always a prefix of the input;
+//   - a valid-UTF-8 input yields a valid-UTF-8 result;
+//   - the truncation is maximal — the next rune would not have fit;
+//   - a string already within the cap comes back unchanged;
+//   - truncating twice at the same cap changes nothing.
+func FuzzTruncateUTF8(f *testing.F) {
+	seeds := []struct {
+		in       string
+		maxBytes int
+	}{
+		{"", 10}, {"hello", 10}, {"hello", 5}, {"hello world", 5},
+		{"hello", 0}, {"hello", -1},
+		{"🍕🍕", 8}, {"🍕🍕", 7}, {"ab🍕", 4},
+		{"aé", 2}, {"€", 3}, {"€", 2},
+		{"👨‍👩‍👧‍👦", 16}, {"👨‍👩‍👧‍👦", 25},
+		{strings.Repeat("🍕", 5), MaxSavedFoodEmoji},
+		// Real call-site caps.
+		{"a name that a user typed", 120},
+		// Invalid UTF-8 in, and a cap far beyond the input.
+		{"\xff\xfe", 1}, {"a\xc3", 2}, {"hello", 1 << 20},
+	}
+	for _, s := range seeds {
+		f.Add(s.in, s.maxBytes)
+	}
+
+	f.Fuzz(func(t *testing.T, in string, maxBytes int) {
+		got := truncateUTF8(in, maxBytes)
+
+		if !strings.HasPrefix(in, got) {
+			t.Fatalf("truncateUTF8(%q, %d) = %q, not a prefix of the input", in, maxBytes, got)
+		}
+		if maxBytes <= 0 {
+			if got != "" {
+				t.Fatalf("truncateUTF8(%q, %d) = %q, want empty for a non-positive cap",
+					in, maxBytes, got)
+			}
+			return
+		}
+		if len(got) > maxBytes {
+			t.Fatalf("truncateUTF8(%q, %d) = %q, %d bytes, exceeds the cap",
+				in, maxBytes, got, len(got))
+		}
+		if len(in) <= maxBytes && got != in {
+			t.Fatalf("truncateUTF8(%q, %d) = %q, want the input unchanged", in, maxBytes, got)
+		}
+		if twice := truncateUTF8(got, maxBytes); twice != got {
+			t.Fatalf("truncateUTF8 is not idempotent: %q -> %q -> %q", in, got, twice)
+		}
+
+		if !utf8.ValidString(in) {
+			// Garbage in, garbage out is acceptable — the caller's input was
+			// already unstorable. Only the prefix/cap invariants above apply.
+			return
+		}
+		if !utf8.ValidString(got) {
+			t.Fatalf("truncateUTF8(%q, %d) = %q, which is not valid UTF-8", in, maxBytes, got)
+		}
+		if len(got) < len(in) {
+			// Maximal: one more rune would have blown the cap. Without this,
+			// a helper that always returned "" would satisfy everything above.
+			_, size := utf8.DecodeRuneInString(in[len(got):])
+			if len(got)+size <= maxBytes {
+				t.Fatalf("truncateUTF8(%q, %d) = %q but the next %d-byte rune still fits",
+					in, maxBytes, got, size)
+			}
+		}
+	})
+}

--- a/internal/service/mathparser_fuzz_test.go
+++ b/internal/service/mathparser_fuzz_test.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// FuzzParseAmount drives the calorie expression parser with arbitrary strings
+// and arbitrary maxAbs bounds.
+//
+// ParseAmount is reachable from the entries handler with a raw, unvalidated
+// string off the wire (`fmt.Sprintf("%v", body["amount"])` in
+// entries_crud.go), so every byte sequence below is something a client can
+// actually send. The table tests next door cover the inputs a human thought
+// of; this covers the rest.
+//
+// Properties asserted (all hold on the current implementation):
+//
+//   - never panics;
+//   - deterministic — the same (input, maxAbs) always yields the same result;
+//   - !Ok implies Value == 0, so a rejected parse can never leak a value;
+//   - Ok implies abs(Value) <= maxAbs, when maxAbs > 0 (ParseAmount applies
+//     the bound only for a positive maxAbs; 0 means "unbounded").
+//
+// The seed corpus is the union of every table in mathparser_test.go plus the
+// pathological inputs that motivated issue #315.
+func FuzzParseAmount(f *testing.F) {
+	seeds := []struct {
+		input  string
+		maxAbs int
+	}{
+		// Plain numbers and decimal rounding.
+		{"123", 0}, {"0", 0}, {"999", 0},
+		{"123.7", 0}, {"123.2", 0}, {"123.5", 0},
+		// Arithmetic, precedence, parentheses.
+		{"100 + 50", 0}, {"200 - 30", 0}, {"10 * 5", 0}, {"100 / 4", 0},
+		{"(10 + 20) * 3", 0}, {"10 + (20 * 3)", 0}, {"((10 + 5) * 2) - 5", 0},
+		{"100 + 50 * 2 - 10", 0}, {"100 / (2 + 3) * 4", 0},
+		// Unicode operator aliases the normalizer rewrites.
+		{"10 × 5", 0}, {"10 x 5", 0}, {"10 X 5", 0}, {"100 ÷ 4", 0},
+		{"10 – 5", 0}, {"10 — 5", 0}, {"10 − 5", 0},
+		// Thousands separators.
+		{"1,000", 0}, {"1,234 + 500", 0},
+		// Negatives.
+		{"-10", 0}, {"10 + (-5)", 0}, {"-(10 + 5)", 0},
+		// Rejected shapes.
+		{"", 0}, {"abc", 0}, {"10 + abc", 0}, {"10 +", 0}, {"   ", 0},
+		{"eval(1)", 0}, {"10; alert(1)", 0}, {"10 & 20", 0}, {"10 | 20", 0},
+		{"10 ^ 20", 0}, {"10 << 2", 0},
+		{"(10 + 20", 0}, {"10 + 20)", 0}, {"((10 + 20)", 0}, {"(10 + 20))", 0},
+		{"10 / 0", 0}, {"100 / (5 - 5)", 0},
+		{strings.Repeat("1 + ", 100) + "1", 0},
+		// maxAbs boundary rows.
+		{"9999", 9999}, {"-9999", 9999}, {"10000", 9999}, {"-10000", 9999},
+		{"5000 + 5000", 9999},
+		// Curiosities turned up while writing issue #315: silent
+		// concatenation, "x" as a multiplication alias, sub-rounding values,
+		// and the float->int overflow recorded in FuzzParseAmount's exemption
+		// below.
+		{"5 5", 9999}, {"0x10", 9999}, {"0.004", 9999},
+		{".", 0}, {"..", 0}, {"(.)", 0}, {"1e5", 0},
+		{"99999999999999999999", 9999},
+		{strings.Repeat("9", 100), 9999},
+	}
+	for _, s := range seeds {
+		f.Add(s.input, s.maxAbs)
+	}
+
+	f.Fuzz(func(t *testing.T, input string, maxAbs int) {
+		got := ParseAmount(input, maxAbs)
+
+		if again := ParseAmount(input, maxAbs); again != got {
+			t.Fatalf("ParseAmount(%q, %d) is not deterministic: %+v then %+v",
+				input, maxAbs, got, again)
+		}
+
+		if !got.Ok {
+			if got.Value != 0 {
+				t.Fatalf("ParseAmount(%q, %d) rejected but carries Value %d, want 0",
+					input, maxAbs, got.Value)
+			}
+			return
+		}
+
+		// KNOWN DEFECT — see issue #364. ParseAmount converts the float
+		// result to int with no range check. When the expression evaluates
+		// beyond int64, the conversion is implementation-defined and yields
+		// math.MinInt64 on amd64/arm64; abs(math.MinInt64) is itself
+		// negative, so the maxAbs guard below passes and the caller gets a
+		// hugely negative "valid" amount ("99999999999999999999" is enough).
+		// The fix belongs to ParseAmount, which this PR deliberately does not
+		// touch (issue #304 owns its behaviour). Delete this block — not the
+		// assertion under it — when the overflow is fixed.
+		if got.Value == math.MinInt64 {
+			return
+		}
+
+		if maxAbs > 0 && abs(got.Value) > maxAbs {
+			t.Fatalf("ParseAmount(%q, %d) = Ok with Value %d, exceeds the maxAbs bound",
+				input, maxAbs, got.Value)
+		}
+	})
+}

--- a/internal/service/todos_fuzz_test.go
+++ b/internal/service/todos_fuzz_test.go
@@ -1,0 +1,119 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// FuzzValidateSchedule drives the todo schedule validator with arbitrary
+// decoded JSON.
+//
+// ValidateSchedule takes `any` — whatever encoding/json produced from a
+// request body — so the fuzzer feeds it raw bytes through json.Unmarshal into
+// `any`, exactly the way the handler reaches it. Anything that is not valid
+// JSON never gets that far and is skipped.
+//
+// Properties asserted:
+//
+//   - never panics for any decoded JSON value;
+//   - !Ok implies an Error message and no Schedule, so a rejection is never
+//     silently stored;
+//   - Ok implies the emitted Schedule is valid JSON that unmarshals into a
+//     Schedule with a recognised type;
+//   - Ok implies the emitted Schedule re-validates to itself — feeding the
+//     stored form back through ValidateSchedule is a fixed point. This is what
+//     makes an edit round-trip safe: the DB value is always accepted again.
+func FuzzValidateSchedule(f *testing.F) {
+	seeds := []string{
+		// Accepted shapes.
+		`{"type":"daily"}`,
+		`{"type":"weekdays","days":[1,3,5]}`,
+		`{"type":"weekdays","days":[7]}`,
+		`{"type":"weekdays","days":[1,1,2]}`,
+		// Rejected shapes from TestValidateSchedule.
+		`{"type":"weekdays","days":[]}`,
+		`{"type":"monthly"}`,
+		`{}`,
+		`null`,
+		// Values that are not objects at all.
+		`[]`, `"daily"`, `5`, `true`,
+		// Out-of-range, wrong-typed and pathological day values.
+		`{"type":"weekdays","days":[0,8,-1]}`,
+		`{"type":"weekdays","days":["1",null,{},[]]}`,
+		`{"type":"weekdays","days":[1.5,2.9]}`,
+		`{"type":"weekdays","days":[1e309]}`,
+		`{"type":"weekdays","days":[9223372036854775808]}`,
+		`{"type":"weekdays","days":[-1e309]}`,
+		`{"type":null}`,
+		`{"type":"daily","days":[1]}`,
+		`{"TYPE":"daily"}`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		var decoded any
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			t.Skip() // not a JSON body; the handler never reaches the validator
+		}
+
+		got := ValidateSchedule(decoded)
+
+		if !got.Ok {
+			if got.Error == "" {
+				t.Fatalf("ValidateSchedule(%s) rejected with an empty Error message", raw)
+			}
+			if len(got.Schedule) != 0 {
+				t.Fatalf("ValidateSchedule(%s) rejected but emitted Schedule %s", raw, got.Schedule)
+			}
+			return
+		}
+
+		if len(got.Schedule) == 0 {
+			t.Fatalf("ValidateSchedule(%s) = Ok with an empty Schedule", raw)
+		}
+		var s Schedule
+		if err := json.Unmarshal(got.Schedule, &s); err != nil {
+			t.Fatalf("ValidateSchedule(%s) emitted unparseable Schedule %s: %v", raw, got.Schedule, err)
+		}
+		switch s.Type {
+		case "daily":
+			if len(s.Days) != 0 {
+				t.Fatalf("ValidateSchedule(%s) emitted a daily schedule carrying days %v", raw, s.Days)
+			}
+		case "weekdays":
+			if len(s.Days) == 0 {
+				t.Fatalf("ValidateSchedule(%s) emitted a weekdays schedule with no days", raw)
+			}
+			seen := map[int]bool{}
+			for _, d := range s.Days {
+				if d < 1 || d > 7 {
+					t.Fatalf("ValidateSchedule(%s) emitted out-of-range ISO weekday %d", raw, d)
+				}
+				if seen[d] {
+					t.Fatalf("ValidateSchedule(%s) emitted duplicate weekday %d in %v", raw, d, s.Days)
+				}
+				seen[d] = true
+			}
+		default:
+			t.Fatalf("ValidateSchedule(%s) emitted unrecognised schedule type %q", raw, s.Type)
+		}
+
+		// Fixed point: what we store must validate again, byte for byte.
+		var reDecoded any
+		if err := json.Unmarshal(got.Schedule, &reDecoded); err != nil {
+			t.Fatalf("emitted Schedule %s is not valid JSON: %v", got.Schedule, err)
+		}
+		again := ValidateSchedule(reDecoded)
+		if !again.Ok {
+			t.Fatalf("ValidateSchedule(%s) emitted %s, which does not re-validate: %s",
+				raw, got.Schedule, again.Error)
+		}
+		if !bytes.Equal(again.Schedule, got.Schedule) {
+			t.Fatalf("ValidateSchedule is not idempotent: %s -> %s -> %s",
+				raw, got.Schedule, again.Schedule)
+		}
+	})
+}

--- a/internal/service/utils_fuzz_test.go
+++ b/internal/service/utils_fuzz_test.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"math"
+	"strconv"
+	"testing"
+)
+
+// FuzzParseWeight drives the weight parser with arbitrary strings.
+//
+// Properties asserted:
+//
+//   - never panics;
+//   - !Ok implies Value == 0;
+//   - Ok implies Value > 0 — the contract the weight_entries_positive CHECK
+//     depends on. A parse that says "fine" and hands back 0 turns a 400 into
+//     a 500 from Postgres (issue #302: ParseWeight("0.004") did exactly that,
+//     fixed by #317; this target is what keeps it fixed);
+//   - Ok implies Value <= MaxWeight;
+//   - Ok implies Value is neither NaN nor ±Inf;
+//   - Ok implies the accepted value re-parses to itself, so what is stored can
+//     be read back and re-submitted unchanged.
+func FuzzParseWeight(f *testing.F) {
+	seeds := []string{
+		// Accepted rows from TestParseWeight / TestParseWeightValid.
+		"80.5", "80,5", "75.5", "100", "0.1", "1", "999.99", "1500", "  42.5  ",
+		"75,5", "75.555", "75.554",
+		// Rejected rows.
+		"", "   ", "abc", "-5", "-1", "0", "1501", "12.34.56", "NaN", "Inf",
+		"1234567890123",
+		// Sub-rounding positives — the issue #302 class.
+		"0.004", "0.001", "0.0049", "0,004",
+		// Shapes strconv.ParseFloat quietly accepts that a human would not.
+		"1e3", "0x1p-2", "+5", ".5", "5.", " 5",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		got := ParseWeight(input)
+
+		if !got.Ok {
+			if got.Value != 0 {
+				t.Fatalf("ParseWeight(%q) rejected but carries Value %v, want 0", input, got.Value)
+			}
+			return
+		}
+		if math.IsNaN(got.Value) || math.IsInf(got.Value, 0) {
+			t.Fatalf("ParseWeight(%q) = Ok with non-finite Value %v", input, got.Value)
+		}
+		if got.Value <= 0 {
+			t.Fatalf("ParseWeight(%q) = Ok with Value %v; Ok must imply Value > 0 "+
+				"(the weight_entries_positive CHECK rejects it)", input, got.Value)
+		}
+		if got.Value > MaxWeight {
+			t.Fatalf("ParseWeight(%q) = Ok with Value %v, exceeds MaxWeight %v",
+				input, got.Value, MaxWeight)
+		}
+
+		// An accepted value must survive a round-trip through its own
+		// canonical rendering: the API echoes stored weights back to clients,
+		// which resubmit them verbatim on edit.
+		canon := strconv.FormatFloat(got.Value, 'f', -1, 64)
+		if back := ParseWeight(canon); !back.Ok || back.Value != got.Value {
+			t.Fatalf("ParseWeight(%q) = %v, but re-parsing its rendering %q gives %+v",
+				input, got.Value, canon, back)
+		}
+	})
+}
+
+// FuzzParseBodyFat drives the body-fat parser with arbitrary strings.
+//
+// Same shape as FuzzParseWeight, against the tighter NUMERIC(4,1) column and
+// the MaxBodyFatPct ceiling:
+//
+//   - never panics;
+//   - !ok implies the returned percentage is 0;
+//   - ok implies pct > 0 (weight_entries_body_fat_range CHECK);
+//   - ok implies pct <= MaxBodyFatPct;
+//   - ok implies pct is finite and re-parses to itself.
+func FuzzParseBodyFat(f *testing.F) {
+	seeds := []string{
+		// Accepted rows from TestParseBodyFat.
+		"24.3", "18", "  31.5  ", "22,7", "24.36", "24.34", "75", "0.1",
+		// Rejected rows.
+		"", "   ", "abc", "0", "-5", "75.1", "100", "NaN", "Inf",
+		"1234567890123",
+		// Sub-rounding positives — the issue #302 class for one decimal.
+		"0.04", "0.049", "0,04", "0.01",
+		// Shapes strconv.ParseFloat quietly accepts.
+		"1e1", "0x1p-2", "+5", ".5", "5.",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		pct, ok := ParseBodyFat(input)
+
+		if !ok {
+			if pct != 0 {
+				t.Fatalf("ParseBodyFat(%q) rejected but returned %v, want 0", input, pct)
+			}
+			return
+		}
+		if math.IsNaN(pct) || math.IsInf(pct, 0) {
+			t.Fatalf("ParseBodyFat(%q) = ok with non-finite value %v", input, pct)
+		}
+		if pct <= 0 {
+			t.Fatalf("ParseBodyFat(%q) = ok with value %v; ok must imply pct > 0 "+
+				"(the weight_entries_body_fat_range CHECK rejects it)", input, pct)
+		}
+		if pct > MaxBodyFatPct {
+			t.Fatalf("ParseBodyFat(%q) = ok with value %v, exceeds MaxBodyFatPct %v",
+				input, pct, MaxBodyFatPct)
+		}
+
+		canon := strconv.FormatFloat(pct, 'f', -1, 64)
+		if back, backOk := ParseBodyFat(canon); !backOk || back != pct {
+			t.Fatalf("ParseBodyFat(%q) = %v, but re-parsing its rendering %q gives (%v, %v)",
+				input, pct, canon, back, backOk)
+		}
+	})
+}


### PR DESCRIPTION
Closes #315

Every parser in this codebase takes an unvalidated string off the wire and was covered only by table tests, so coverage stopped exactly where a human stopped imagining inputs. Go's native fuzzing needs no dependency and no new CI service, and `go test ./...` replays the recorded seed corpus as an ordinary unit test — **steps 1–2 of the issue's "Wiring" section land the regression value on every push with no CI change at all.**

This is a **test-only PR** — no production source file is modified.

## Targets and properties

Each target lives in its own `*_fuzz_test.go` file, seeded from the corpora the existing table tests already provide.

| Target | File | Properties |
|---|---|---|
| `FuzzParseAmount` | `internal/service/mathparser_fuzz_test.go` | never panics; deterministic; `!Ok` implies `Value == 0`; `Ok` implies `abs(Value) <= maxAbs` when `maxAbs > 0` |
| `FuzzParseWeight` | `internal/service/utils_fuzz_test.go` | never panics; `!Ok` implies `Value == 0`; **`Ok` implies `Value > 0`**; `Ok` implies `Value <= MaxWeight`; never `NaN`/`Inf`; an accepted value re-parses to itself |
| `FuzzParseBodyFat` | `internal/service/utils_fuzz_test.go` | same shape against `MaxBodyFatPct` and the `NUMERIC(4,1)` rounding |
| `FuzzValidateSchedule` | `internal/service/todos_fuzz_test.go` | never panics on arbitrary decoded JSON; `!Ok` implies an error message and no schedule; `Ok` implies the emitted `Schedule` parses, carries only ISO days 1–7 without duplicates, and **re-validates to itself byte-for-byte** |
| `FuzzIsValidDate` | `internal/handler/validate_fuzz_test.go` | never panics; deterministic; `isValidDate(s)` iff `time.Parse` succeeds **and** `Format` round-trips to `s` exactly **and** the year is in `1900..2200` — the guard against the `2026-02-31` class |
| `FuzzTruncateUTF8` | `internal/handler/validate_fuzz_test.go` | never exceeds the cap; empty for a non-positive cap; always a prefix; valid UTF-8 in gives valid UTF-8 out; unchanged when already within the cap; idempotent; and the cut is **maximal** (one more rune would not have fit — without this a helper that always returned `""` would satisfy everything else) |
| `FuzzDecodeCursor` | `internal/handler/v1_common_fuzz_test.go` | never panics; a failed decode returns the zero cursor; success implies `isValidDate(c.Date) && c.ID > 0`; `decodeCursor(encodeCursor(c)) == c`, in both directions |
| `FuzzDecodeV1` | `internal/handler/v1_common_fuzz_test.go` | never panics on arbitrary bytes against three real request shapes (`v1EntryInput` plain pointers, `v1EntryPatch` `Optional[T]` fields, and a bare map); deterministic; the result is either a decode or a `*apierr.Problem` with a **4xx** status — never 5xx, never 0; the problem is well-formed |

## A fuzzer finding: #364

`FuzzParseAmount`'s `Ok implies abs(Value) <= maxAbs` property found a real defect, filed as **#364**:

```go
service.ParseAmount("99999999999999999999", 9999)
// -> {Ok:true Value:-9223372036854775808}
```

`ParseAmount` converts the evaluated float to `int` with no range check. Out-of-range float→int is implementation-defined in Go and yields `math.MinInt64` on amd64/arm64; `abs(math.MinInt64)` is itself negative, so `abs(rounded) > maxAbs` is false and the bound check waves it through. `handler.CreateEntry` then writes that straight into the CHECK-constrained `calorie_entries.amount` column — **a 500 where a 400 belongs**, the exact class the `maxAbs` argument exists to prevent. Twenty `9`s is enough; no operators needed.

**Left unfixed here on purpose:** #304 owns `ParseAmount`'s behaviour, and this PR does not touch it. Instead the target carries a narrowly-scoped, loudly-commented exemption for `Value == math.MinInt64` and seeds the overflowing inputs into the corpus, so fixing #364 is a matter of deleting the exemption block — the assertion under it is already written. The property is not weakened anywhere else.

## Note on #302 / #317

This branch originally re-applied #317's rounding fix so the `Ok implies Value > 0` property would be green on its own. **#317 has since merged into `staging`**, so the branch was rebased and the local copy dropped — the property is now enforceable against upstream code with **no source change**, which is exactly right. `FuzzParseWeight`/`FuzzParseBodyFat` are what keep #302 fixed. `FuzzParseWeight` uses the `service.MaxWeight` constant exported by #316 rather than a literal `1500`.

## Optional step 3: nightly workflow — included

`.github/workflows/fuzz.yml` runs each of the 8 targets for 5m on a 04:00 UTC cron (plus `workflow_dispatch` with a configurable `fuzztime`), matrixed with `fail-fast: false`. The fuzz corpus is cached per target and carried forward run to run, so each night resumes from the coverage previous nights found instead of restarting from the seeds. Public repo on `ubuntu-latest`, so ~40 runner-minutes/night at no cost, ~6 min wall clock.

One deliberate deviation from the issue text: a crasher is **uploaded as an artifact rather than auto-committed**. Pushing from a scheduled job needs `contents: write`, and a red nightly with the reproducer attached is enough to act on — drop the artifact into `internal/<pkg>/testdata/fuzz/<Target>/` in a PR to make it a permanent seed. Actions are SHA-pinned to match the repo's existing convention.

## Verification

`export GOFLAGS=-p=2 GOMAXPROCS=2` throughout, on the rebased tree.

<details open>
<summary><code>go build ./... && go vet ./... && go test ./...</code></summary>

```
=== build ===
OK
=== vet ===
OK
=== go test ./... ===
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	(cached)
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	(cached)
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	(cached)
ok  	schautrack/internal/handler	(cached)
ok  	schautrack/internal/middleware	(cached)
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	(cached)
ok  	schautrack/internal/release	(cached)
ok  	schautrack/internal/service	(cached)
ok  	schautrack/internal/session	(cached)
ok  	schautrack/internal/sse	(cached)
```
</details>

<details>
<summary>All eight fuzz runs, <code>-fuzztime=20s</code> each, one at a time</summary>

```
$ go test ./internal/service/ -run '^$' -fuzz FuzzParseWeight -fuzztime=20s
fuzz: elapsed: 0s, gathering baseline coverage: 0/78 completed
fuzz: elapsed: 1s, gathering baseline coverage: 78/78 completed, now fuzzing with 2 workers
fuzz: elapsed: 3s, execs: 14036 (4678/sec), new interesting: 0 (total: 78)
fuzz: elapsed: 6s, execs: 38539 (8168/sec), new interesting: 0 (total: 78)
fuzz: elapsed: 9s, execs: 61047 (7501/sec), new interesting: 1 (total: 79)
fuzz: elapsed: 12s, execs: 79736 (6230/sec), new interesting: 2 (total: 80)
fuzz: elapsed: 15s, execs: 103720 (7994/sec), new interesting: 3 (total: 81)
fuzz: elapsed: 18s, execs: 120458 (5580/sec), new interesting: 4 (total: 82)
fuzz: elapsed: 20s, execs: 133776 (6447/sec), new interesting: 5 (total: 83)
PASS
ok  	schautrack/internal/service	20.085s

$ go test ./internal/service/ -run '^$' -fuzz FuzzParseBodyFat -fuzztime=20s
fuzz: elapsed: 0s, gathering baseline coverage: 0/76 completed
fuzz: elapsed: 1s, gathering baseline coverage: 76/76 completed, now fuzzing with 2 workers
fuzz: elapsed: 3s, execs: 17328 (5775/sec), new interesting: 0 (total: 76)
fuzz: elapsed: 6s, execs: 40796 (7821/sec), new interesting: 2 (total: 78)
fuzz: elapsed: 9s, execs: 77343 (12181/sec), new interesting: 4 (total: 80)
fuzz: elapsed: 12s, execs: 110758 (11140/sec), new interesting: 5 (total: 81)
fuzz: elapsed: 15s, execs: 140935 (10059/sec), new interesting: 7 (total: 83)
fuzz: elapsed: 18s, execs: 171368 (10143/sec), new interesting: 8 (total: 84)
fuzz: elapsed: 20s, execs: 199525 (13500/sec), new interesting: 10 (total: 86)
PASS
ok  	schautrack/internal/service	20.102s

$ go test ./internal/service/ -run '^$' -fuzz FuzzParseAmount -fuzztime=20s
fuzz: elapsed: 0s, gathering baseline coverage: 0/59 completed
fuzz: elapsed: 0s, gathering baseline coverage: 59/59 completed, now fuzzing with 2 workers
fuzz: elapsed: 3s, execs: 16545 (5515/sec), new interesting: 42 (total: 101)
fuzz: elapsed: 6s, execs: 35984 (6478/sec), new interesting: 64 (total: 123)
fuzz: elapsed: 9s, execs: 52128 (5383/sec), new interesting: 78 (total: 137)
fuzz: elapsed: 12s, execs: 87200 (11690/sec), new interesting: 103 (total: 162)
fuzz: elapsed: 15s, execs: 123673 (12157/sec), new interesting: 106 (total: 165)
fuzz: elapsed: 18s, execs: 150036 (8785/sec), new interesting: 109 (total: 168)
fuzz: elapsed: 20s, execs: 161095 (5243/sec), new interesting: 110 (total: 169)
PASS
ok  	schautrack/internal/service	20.128s

$ go test ./internal/service/ -run '^$' -fuzz FuzzValidateSchedule -fuzztime=20s
fuzz: elapsed: 0s, gathering baseline coverage: 0/21 completed
fuzz: elapsed: 0s, gathering baseline coverage: 21/21 completed, now fuzzing with 2 workers
fuzz: elapsed: 3s, execs: 12764 (4253/sec), new interesting: 43 (total: 64)
fuzz: elapsed: 6s, execs: 33532 (6924/sec), new interesting: 76 (total: 97)
fuzz: elapsed: 9s, execs: 62147 (9537/sec), new interesting: 89 (total: 110)
fuzz: elapsed: 12s, execs: 84613 (7491/sec), new interesting: 110 (total: 131)
fuzz: elapsed: 15s, execs: 98600 (4662/sec), new interesting: 117 (total: 138)
fuzz: elapsed: 18s, execs: 136258 (12554/sec), new interesting: 121 (total: 142)
fuzz: elapsed: 20s, execs: 146976 (4735/sec), new interesting: 122 (total: 143)
PASS
ok  	schautrack/internal/service	20.276s

$ go test ./internal/handler/ -run '^$' -fuzz FuzzIsValidDate -fuzztime=20s
fuzz: elapsed: 0s, gathering baseline coverage: 0/29 completed
fuzz: elapsed: 0s, gathering baseline coverage: 29/29 completed, now fuzzing with 2 workers
fuzz: elapsed: 3s, execs: 17017 (5671/sec), new interesting: 0 (total: 29)
fuzz: elapsed: 6s, execs: 49287 (10756/sec), new interesting: 0 (total: 29)
fuzz: elapsed: 9s, execs: 76745 (9153/sec), new interesting: 0 (total: 29)
fuzz: elapsed: 12s, execs: 98055 (7104/sec), new interesting: 0 (total: 29)
fuzz: elapsed: 15s, execs: 123574 (8506/sec), new interesting: 0 (total: 29)
fuzz: elapsed: 18s, execs: 143319 (6582/sec), new interesting: 0 (total: 29)
fuzz: elapsed: 20s, execs: 156689 (6338/sec), new interesting: 0 (total: 29)
PASS
ok  	schautrack/internal/handler	20.124s

$ go test ./internal/handler/ -run '^$' -fuzz FuzzDecodeCursor -fuzztime=20s
fuzz: elapsed: 0s, gathering baseline coverage: 0/26 completed
fuzz: elapsed: 0s, gathering baseline coverage: 26/26 completed, now fuzzing with 2 workers
fuzz: elapsed: 3s, execs: 15015 (5003/sec), new interesting: 2 (total: 28)
fuzz: elapsed: 6s, execs: 42052 (9013/sec), new interesting: 4 (total: 30)
fuzz: elapsed: 9s, execs: 65093 (7681/sec), new interesting: 5 (total: 31)
fuzz: elapsed: 12s, execs: 79321 (4743/sec), new interesting: 5 (total: 31)
fuzz: elapsed: 15s, execs: 94625 (5101/sec), new interesting: 5 (total: 31)
fuzz: elapsed: 18s, execs: 107500 (4292/sec), new interesting: 5 (total: 31)
fuzz: elapsed: 21s, execs: 114078 (2192/sec), new interesting: 5 (total: 31)
PASS
ok  	schautrack/internal/handler	21.020s

$ go test ./internal/handler/ -run '^$' -fuzz FuzzTruncateUTF8 -fuzztime=20s
fuzz: elapsed: 0s, gathering baseline coverage: 0/19 completed
fuzz: elapsed: 0s, gathering baseline coverage: 19/19 completed, now fuzzing with 2 workers
fuzz: elapsed: 3s, execs: 14659 (4886/sec), new interesting: 9 (total: 28)
fuzz: elapsed: 6s, execs: 31677 (5672/sec), new interesting: 11 (total: 30)
fuzz: elapsed: 9s, execs: 40672 (2998/sec), new interesting: 12 (total: 31)
fuzz: elapsed: 12s, execs: 40672 (0/sec), new interesting: 12 (total: 31)
fuzz: elapsed: 15s, execs: 40672 (0/sec), new interesting: 12 (total: 31)
fuzz: elapsed: 18s, execs: 40672 (0/sec), new interesting: 12 (total: 31)
fuzz: elapsed: 21s, execs: 40672 (0/sec), new interesting: 12 (total: 31)
PASS
ok  	schautrack/internal/handler	21.030s

$ go test ./internal/handler/ -run '^$' -fuzz FuzzDecodeV1 -fuzztime=20s
fuzz: elapsed: 0s, gathering baseline coverage: 0/80 completed
fuzz: elapsed: 1s, gathering baseline coverage: 80/80 completed, now fuzzing with 2 workers
fuzz: elapsed: 3s, execs: 8857 (2951/sec), new interesting: 7 (total: 87)
fuzz: elapsed: 6s, execs: 29529 (6891/sec), new interesting: 20 (total: 100)
fuzz: elapsed: 9s, execs: 49213 (6562/sec), new interesting: 38 (total: 118)
fuzz: elapsed: 12s, execs: 66198 (5662/sec), new interesting: 38 (total: 118)
fuzz: elapsed: 15s, execs: 75711 (3171/sec), new interesting: 44 (total: 124)
fuzz: elapsed: 18s, execs: 86383 (3558/sec), new interesting: 48 (total: 128)
fuzz: elapsed: 21s, execs: 90045 (1221/sec), new interesting: 51 (total: 131)
PASS
ok  	schautrack/internal/handler	21.044s
```
</details>

All eight pass. No `testdata/fuzz/` directory was created anywhere, i.e. **no crasher was produced** beyond the known #364 class that the documented exemption covers.

**Two runs were re-run and the first attempt is not shown above, honestly noted here:** `FuzzParseBodyFat` and `FuzzDecodeV1` each failed once with `context deadline exceeded` and *no* reproducer written. That is the Go fuzz coordinator timing out while shutting its workers down, not a property violation — the box was at load average 11.4 with the run showing `0 execs/sec` stalls (`FuzzDecodeV1` sat at 7605 execs for 9 seconds, then burst to 20k/sec). Both passed cleanly on re-run, which is what is quoted. The same starvation is visible in the quoted `FuzzTruncateUTF8` and `FuzzDecodeCursor` output as trailing `0/sec` samples.

The workflow's anchored regex form was verified separately:

```
$ go test ./internal/service/ -run '^$' -fuzz '^FuzzParseWeight$' -fuzztime=5s
...
PASS
ok  	schautrack/internal/service	5.126s
```

`gofmt -l` is clean on all five new files (the repo has pre-existing unformatted files, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)