### PR TITLE
fix: propagate http.ErrAbortHandler, and log recovered panics through slog

### DIFF
--- a/internal/middleware/accesslog.go
+++ b/internal/middleware/accesslog.go
@@ -25,6 +25,13 @@ import (
 // OIDC authorization codes and other short-lived secrets that must not land in
 // logs. The health endpoint is skipped so Kubernetes liveness/readiness probes
 // do not drown the access log.
+//
+// It does not recover panics, which is what lets Recovery's deliberate
+// re-panic of http.ErrAbortHandler reach net/http and close the connection.
+// The consequence is that a request aborted that way gets no access-log line
+// at all: this middleware's slog call sits after next.ServeHTTP and is skipped
+// when the stack unwinds. That is accepted — an abandoned response has no
+// meaningful status, byte count or latency to report.
 func AccessLog(trustProxy bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/middleware/recovery.go
+++ b/internal/middleware/recovery.go
@@ -2,7 +2,8 @@ package middleware
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"runtime/debug"
 
@@ -19,7 +20,8 @@ import (
 //
 // http.ErrAbortHandler is the one panic value it does not recover: a handler
 // panicking with it is deliberately abandoning the response, so it propagates
-// to net/http, which closes the connection and logs nothing.
+// to net/http, which closes the connection and logs nothing. Recovered panics
+// are logged as a single structured slog record ("panic recovered").
 func Recovery(next http.Handler) http.Handler {
 	return recoverWith(next, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -74,13 +76,40 @@ func recoverWith(next http.Handler, write func(http.ResponseWriter, *http.Reques
 			// other would still catch the sentinel.
 			//
 			// Nothing is logged, on purpose. An intentional abort is not an
-			// error. AccessLog sits above this middleware and does not
-			// recover, so an aborted request also gets no access-log line —
-			// accepted: an abandoned response has no meaningful status to
-			// report. Same precedent as chi's Recoverer.
+			// error, and a scary "panic recovered" record for one would train
+			// operators to ignore the alert that matters. AccessLog sits above
+			// this middleware and does not recover, so an aborted request also
+			// gets no access-log line — accepted: an abandoned response has no
+			// meaningful status to report. Same precedent as chi's Recoverer.
 			if rec == http.ErrAbortHandler {
 				panic(rec)
 			}
+
+			// This was log.Printf. main.go calls slog.SetDefault, which
+			// reroutes the log package through the same JSON handler, so the
+			// old call did reach stdout — but as a record at INFO (the level
+			// slog hardcodes for log package output) whose msg was the panic
+			// plus the entire stack. A panic therefore sat below the error
+			// threshold, carried no request context, and had a msg unique to
+			// each occurrence, which no alert rule can match and no two
+			// occurrences can be grouped by. Hence ERROR, a fixed msg, and the
+			// stack as its own attribute. The msg is the same on both branches
+			// so one rule catches every panic; response_committed marks the
+			// unsalvageable case.
+			//
+			// The panic value and the stack stop at the operator's log. Both
+			// routinely carry request data, and a stack frame hands out the
+			// server's package and file layout; the client gets the fixed,
+			// generic body write produces instead. The path is logged without
+			// its query string for the same reason AccessLog does so: query
+			// strings carry OIDC codes and other short-lived secrets.
+			slog.Error("panic recovered",
+				"panic", fmt.Sprint(rec),
+				"method", r.Method,
+				"path", r.URL.Path,
+				"response_committed", rw.committed,
+				"stack", string(debug.Stack()),
+			)
 
 			if rw.committed {
 				// The handler already wrote a status and probably part of a
@@ -90,16 +119,9 @@ func recoverWith(next http.Handler, write func(http.ResponseWriter, *http.Reques
 				// line — already on the wire — would still claim success.
 				// Nothing can be salvaged: leave the response truncated so the
 				// framing, not a bogus body, tells the client it is incomplete.
-				log.Printf("panic after response was committed (%s %s), response left truncated: %v\n%s",
-					r.Method, r.URL.Path, rec, debug.Stack())
 				return
 			}
 
-			// The panic value and the stack go to the operator's log and stop
-			// there. Both routinely carry request data, and a stack frame hands
-			// out the server's package and file layout; the client gets the
-			// fixed, generic body write produces instead.
-			log.Printf("panic: %v\n%s", rec, debug.Stack())
 			write(rw, r)
 		}()
 		next.ServeHTTP(rw, r)

--- a/internal/middleware/recovery.go
+++ b/internal/middleware/recovery.go
@@ -16,6 +16,10 @@ import (
 // globally in cmd/server/main.go. The public API must NOT answer in this shape
 // — v1 errors are RFC 9457 problem details — so /api/v1 mounts ProblemRecovery
 // inside its own router instead. See handler.MountAPIV1.
+//
+// http.ErrAbortHandler is the one panic value it does not recover: a handler
+// panicking with it is deliberately abandoning the response, so it propagates
+// to net/http, which closes the connection and logs nothing.
 func Recovery(next http.Handler) http.Handler {
 	return recoverWith(next, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -44,6 +48,8 @@ func ProblemRecovery(next http.Handler) http.Handler {
 // recoverWith is the shared body of Recovery and ProblemRecovery: catch the
 // panic, log it with its stack, and let write render the surface-appropriate
 // error document.
+//
+// http.ErrAbortHandler is deliberately not recovered — see the re-panic below.
 func recoverWith(next http.Handler, write func(http.ResponseWriter, *http.Request)) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rw := &recoveryWriter{ResponseWriter: w}
@@ -51,6 +57,29 @@ func recoverWith(next http.Handler, write func(http.ResponseWriter, *http.Reques
 			rec := recover()
 			if rec == nil {
 				return
+			}
+
+			// http.ErrAbortHandler is not a failure: it is the sentinel a
+			// handler panics with to say "abandon this response and close the
+			// connection, quietly". net/http special-cases it in conn.serve,
+			// so re-panicking gets exactly that behaviour. Recovering it
+			// instead would write a 500 onto a response the handler asked to
+			// be abandoned — into a writer whose framing may already be gone
+			// if the stream was half-sent or the connection hijacked — and log
+			// a stack trace for something that is by definition not a bug.
+			//
+			// It must be handled here in the shared body rather than in
+			// Recovery/ProblemRecovery: on a v1 route the inner
+			// ProblemRecovery runs first, so if only one layer re-panicked the
+			// other would still catch the sentinel.
+			//
+			// Nothing is logged, on purpose. An intentional abort is not an
+			// error. AccessLog sits above this middleware and does not
+			// recover, so an aborted request also gets no access-log line —
+			// accepted: an abandoned response has no meaningful status to
+			// report. Same precedent as chi's Recoverer.
+			if rec == http.ErrAbortHandler {
+				panic(rec)
 			}
 
 			if rw.committed {

--- a/internal/middleware/recovery_test.go
+++ b/internal/middleware/recovery_test.go
@@ -35,6 +35,32 @@ func panicking(v any) http.HandlerFunc {
 	return func(http.ResponseWriter, *http.Request) { panic(v) }
 }
 
+// serveCatchingPanic serves the request and returns whatever panic escaped the
+// handler chain, or nil if none did.
+func serveCatchingPanic(h http.Handler, w http.ResponseWriter, r *http.Request) (escaped any) {
+	defer func() { escaped = recover() }()
+	h.ServeHTTP(w, r)
+	return nil
+}
+
+// writeSpy records whether anything was written, so a test can tell "nothing
+// was written" apart from httptest.ResponseRecorder's default 200/empty body.
+type writeSpy struct {
+	http.ResponseWriter
+	wroteHeader bool
+	wroteBody   bool
+}
+
+func (w *writeSpy) WriteHeader(code int) {
+	w.wroteHeader = true
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *writeSpy) Write(b []byte) (int, error) {
+	w.wroteBody = true
+	return w.ResponseWriter.Write(b)
+}
+
 // v1Router mirrors the real composition in cmd/server/main.go and
 // handler.MountAPIV1: the legacy Recovery wraps everything, and the /api/v1
 // sub-router mounts ProblemRecovery of its own. Rebuilt here rather than
@@ -241,6 +267,93 @@ func TestRecoveryAfterPartialWrite(t *testing.T) {
 			t.Errorf("server logged a superfluous WriteHeader: %q", serverLog.String())
 		}
 	})
+}
+
+// TestRecoveryPropagatesErrAbortHandlerWithoutLogging is the regression test
+// for #331. http.ErrAbortHandler is the sentinel a handler panics with to
+// abandon a response on purpose (httputil.ReverseProxy raises it, and it is the
+// idiomatic way to kill a stuck long-lived stream — we have one in
+// internal/sse). Recovering it would write a 500 onto a response the handler
+// asked to be abandoned and log a stack for something that is not a bug, so it
+// must propagate untouched to net/http, which closes the connection quietly.
+func TestRecoveryPropagatesErrAbortHandlerWithoutLogging(t *testing.T) {
+	// Both middlewares, wrapped directly: the sentinel has to be handled in
+	// the shared recoverWith, not in one of them.
+	for _, tc := range []struct {
+		name string
+		mw   func(http.Handler) http.Handler
+	}{
+		{"Recovery", Recovery},
+		{"ProblemRecovery", ProblemRecovery},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logged := captureLog(t)
+
+			spy := &writeSpy{ResponseWriter: httptest.NewRecorder()}
+			escaped := serveCatchingPanic(
+				tc.mw(panicking(http.ErrAbortHandler)),
+				spy,
+				httptest.NewRequest(http.MethodGet, "/entries", nil),
+			)
+
+			if escaped != http.ErrAbortHandler {
+				t.Fatalf("escaped panic = %v (%T), want http.ErrAbortHandler — "+
+					"the abort was swallowed and turned into a response", escaped, escaped)
+			}
+			assertResponseUntouched(t, spy)
+			assertNothingLogged(t, logged)
+		})
+	}
+
+	// Note 1 on #331: on a v1 route the inner ProblemRecovery recovers first
+	// and the outer legacy Recovery sits above it. If only one layer
+	// re-panicked, the other would still catch the sentinel — worse than not
+	// fixing it — so assert it escapes the real nested composition.
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"spa", "/settings"},
+		{"v1 through both recovery layers", "/api/v1/entries"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logged := captureLog(t)
+
+			spy := &writeSpy{ResponseWriter: httptest.NewRecorder()}
+			escaped := serveCatchingPanic(
+				v1Router(panicking(http.ErrAbortHandler)),
+				spy,
+				httptest.NewRequest(http.MethodGet, tc.path, nil),
+			)
+
+			if escaped != http.ErrAbortHandler {
+				t.Fatalf("escaped panic = %v (%T), want http.ErrAbortHandler", escaped, escaped)
+			}
+			assertResponseUntouched(t, spy)
+			assertNothingLogged(t, logged)
+		})
+	}
+}
+
+func assertResponseUntouched(t *testing.T, spy *writeSpy) {
+	t.Helper()
+	if spy.wroteHeader {
+		t.Error("a status was written to a response the handler aborted")
+	}
+	if spy.wroteBody {
+		t.Error("a body was written to a response the handler aborted")
+	}
+	if rec, ok := spy.ResponseWriter.(*httptest.ResponseRecorder); ok && rec.Body.Len() != 0 {
+		t.Errorf("response body = %q, want empty", rec.Body.String())
+	}
+}
+
+func assertNothingLogged(t *testing.T, logged *bytes.Buffer) {
+	t.Helper()
+	if logged.Len() != 0 {
+		t.Errorf("an intentional abort was logged: %q — http.ErrAbortHandler is "+
+			"not an error and must stay silent", logged.String())
+	}
 }
 
 // TestRecoveryWriterIsTransparent guards the wrapper Recovery installs to spot

--- a/internal/middleware/recovery_test.go
+++ b/internal/middleware/recovery_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,20 +16,38 @@ import (
 	"schautrack/internal/apierr"
 )
 
-// captureLog redirects the standard logger (which Recovery uses) into a buffer
-// for the duration of a test, both to keep panic stacks out of the test output
-// and so a test can assert what was logged.
+// captureLog redirects slog — which Recovery logs through, like the rest of the
+// app — into a buffer for the duration of a test, both to keep panic stacks out
+// of the test output and so a test can assert what was logged.
+//
+// It is the same swap as captureLogs in accesslog_test.go, but hands back the
+// raw buffer instead of taking a closure: these tests inspect the log after
+// serving a request, and several only want the stacks suppressed.
 func captureLog(t *testing.T) *bytes.Buffer {
 	t.Helper()
 	var buf bytes.Buffer
-	prevWriter, prevFlags := log.Writer(), log.Flags()
-	log.SetOutput(&buf)
-	log.SetFlags(0)
-	t.Cleanup(func() {
-		log.SetOutput(prevWriter)
-		log.SetFlags(prevFlags)
-	})
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
 	return &buf
+}
+
+// logRecords decodes what captureLog collected. One panic must produce exactly
+// one record, so the count is itself an assertion in several tests below.
+func logRecords(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var recs []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("log line is not JSON: %v (line: %q)", err, line)
+		}
+		recs = append(recs, m)
+	}
+	return recs
 }
 
 func panicking(v any) http.HandlerFunc {
@@ -276,6 +295,9 @@ func TestRecoveryAfterPartialWrite(t *testing.T) {
 // internal/sse). Recovering it would write a 500 onto a response the handler
 // asked to be abandoned and log a stack for something that is not a bug, so it
 // must propagate untouched to net/http, which closes the connection quietly.
+//
+// The no-log half is the reason #331 and #332 landed together: once panics log
+// at ERROR through slog, recovering an intentional abort would page someone.
 func TestRecoveryPropagatesErrAbortHandlerWithoutLogging(t *testing.T) {
 	// Both middlewares, wrapped directly: the sentinel has to be handled in
 	// the shared recoverWith, not in one of them.
@@ -301,7 +323,7 @@ func TestRecoveryPropagatesErrAbortHandlerWithoutLogging(t *testing.T) {
 					"the abort was swallowed and turned into a response", escaped, escaped)
 			}
 			assertResponseUntouched(t, spy)
-			assertNothingLogged(t, logged)
+			assertNoLogRecords(t, logged)
 		})
 	}
 
@@ -330,7 +352,7 @@ func TestRecoveryPropagatesErrAbortHandlerWithoutLogging(t *testing.T) {
 				t.Fatalf("escaped panic = %v (%T), want http.ErrAbortHandler", escaped, escaped)
 			}
 			assertResponseUntouched(t, spy)
-			assertNothingLogged(t, logged)
+			assertNoLogRecords(t, logged)
 		})
 	}
 }
@@ -348,12 +370,115 @@ func assertResponseUntouched(t *testing.T, spy *writeSpy) {
 	}
 }
 
-func assertNothingLogged(t *testing.T, logged *bytes.Buffer) {
+func assertNoLogRecords(t *testing.T, logged *bytes.Buffer) {
 	t.Helper()
-	if logged.Len() != 0 {
-		t.Errorf("an intentional abort was logged: %q — http.ErrAbortHandler is "+
-			"not an error and must stay silent", logged.String())
+	if recs := logRecords(t, logged); len(recs) != 0 {
+		t.Errorf("an intentional abort logged %d record(s): %q — "+
+			"http.ErrAbortHandler is not an error and must stay silent",
+			len(recs), logged.String())
 	}
+}
+
+// TestRecoveryLogsOneStructuredRecord is the regression test for #332. Panics
+// used to go through log.Printf. That did not land on stderr as unstructured
+// text the way #332 assumed — main.go calls slog.SetDefault, which reroutes the
+// log package through the same JSON handler — but it did emit the panic and its
+// entire stack as one giant "msg" at INFO, the level slog hardcodes for log
+// package output. So the single most alertable event in the request path sat
+// below the error threshold, carried no method/path, and had a msg that was
+// different for every panic, which no alert rule can match and no two
+// occurrences can be grouped by.
+//
+// Pinned here: level ERROR, a fixed msg, the request context as fields, and the
+// stack as its own attribute rather than smuggled into the message.
+func TestRecoveryLogsOneStructuredRecord(t *testing.T) {
+	const panicValue = "kaboom-9f3c"
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"spa", "/settings"},
+		{"v1", "/api/v1/entries"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logged := captureLog(t)
+
+			h := v1Router(panicking(panicValue))
+			w := httptest.NewRecorder()
+			// The query string must not reach the log: it carries OIDC codes
+			// and other short-lived secrets, same rule as AccessLog.
+			h.ServeHTTP(w, httptest.NewRequest(http.MethodPost, tc.path+"?code=super-secret-oidc-code", nil))
+
+			recs := logRecords(t, logged)
+			if len(recs) != 1 {
+				t.Fatalf("got %d log records, want exactly 1 — one panic must stay one "+
+					"queryable object, stack included: %q", len(recs), logged.String())
+			}
+			rec := recs[0]
+
+			if rec["level"] != "ERROR" {
+				t.Errorf("level = %v, want ERROR", rec["level"])
+			}
+			if rec["msg"] != "panic recovered" {
+				t.Errorf("msg = %v, want %q — the alert rule matches on it", rec["msg"], "panic recovered")
+			}
+			if rec["panic"] != panicValue {
+				t.Errorf("panic = %v, want %q", rec["panic"], panicValue)
+			}
+			if rec["method"] != http.MethodPost {
+				t.Errorf("method = %v, want %s", rec["method"], http.MethodPost)
+			}
+			if rec["path"] != tc.path {
+				t.Errorf("path = %v, want %q", rec["path"], tc.path)
+			}
+			if rec["response_committed"] != false {
+				t.Errorf("response_committed = %v, want false", rec["response_committed"])
+			}
+
+			stack, ok := rec["stack"].(string)
+			if !ok {
+				t.Fatalf("stack = %v (%T), want a single string attribute", rec["stack"], rec["stack"])
+			}
+			if !strings.Contains(stack, "goroutine ") || !strings.Contains(stack, "recovery.go") {
+				t.Errorf("stack does not look like a stack trace: %q", stack)
+			}
+
+			if strings.Contains(logged.String(), "super-secret-oidc-code") {
+				t.Errorf("the query string was logged: %q", logged.String())
+			}
+		})
+	}
+
+	// The committed branch logs the same message so one alert rule catches
+	// every panic; response_committed is what tells an operator the client got
+	// a truncated response rather than an error document.
+	t.Run("after the response was committed", func(t *testing.T) {
+		logged := captureLog(t)
+
+		h := v1Router(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, "partial")
+			panic(panicValue)
+		}))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/entries", nil))
+
+		recs := logRecords(t, logged)
+		if len(recs) != 1 {
+			t.Fatalf("got %d log records, want exactly 1: %q", len(recs), logged.String())
+		}
+		if recs[0]["msg"] != "panic recovered" {
+			t.Errorf("msg = %v, want %q", recs[0]["msg"], "panic recovered")
+		}
+		if recs[0]["response_committed"] != true {
+			t.Errorf("response_committed = %v, want true — an operator cannot otherwise tell "+
+				"the client got a truncated response", recs[0]["response_committed"])
+		}
+		if recs[0]["panic"] != panicValue {
+			t.Errorf("panic = %v, want %q", recs[0]["panic"], panicValue)
+		}
+	})
 }
 
 // TestRecoveryWriterIsTransparent guards the wrapper Recovery installs to spot


### PR DESCRIPTION
Closes #331
Closes #332

## Why these two are one PR

Both edit the same ~15-line `recoverWith` body that #329 (PR for #307) just introduced. Split across two branches they would conflict on every line for no review benefit — and, more importantly, they interact: **#332 makes panics log at ERROR, which is exactly what #331 must not do for an intentional abort.** Getting that combination right needs both changes visible at once.

Stacked on `recovery-problem-json-v1` (#329). That merged while this was in flight, so it is rebased onto and targeted at `staging` directly.

Two commits, one per issue, each building and passing on its own.

---

## #331 — `http.ErrAbortHandler` was being swallowed

`recoverWith` recovered *every* panic value. `http.ErrAbortHandler` is the stdlib sentinel a handler panics with to abandon a response deliberately; recovering it turned an intentional abort into a 500 write onto a response the handler asked to be dropped — into a writer whose framing may already be gone if the stream was half-sent or the connection hijacked — plus a stack trace for something that is by definition not a bug.

```go
if rec == http.ErrAbortHandler {
    panic(rec) // net/http closes the connection and logs nothing
}
```

Placed in the shared `recoverWith`, per note 1 on the issue. Putting it in only one of `Recovery`/`ProblemRecovery` would be **worse than not fixing it**: on a v1 route the inner `ProblemRecovery` recovers first, so the outer legacy `Recovery` would catch the sentinel the inner one re-panicked. `TestRecoveryPropagatesErrAbortHandlerWithoutLogging` asserts it escapes both middlewares individually *and* the real nested `v1Router` composition.

Latent today — nothing panics with it yet — but `internal/sse` is the long-lived stream this sentinel exists for, and `httputil.ReverseProxy` raises it.

Per note 2: `AccessLog` sits above `Recovery` and does not recover, so an aborted request now gets no access-log line either. Accepted as a conscious trade (an abandoned response has no meaningful status, byte count or latency), and written into `AccessLog`'s doc comment — the only line touched outside `recovery.go`/`recovery_test.go`.

## #332 — panic logs bypassed the structured pipeline

Converted to `slog.Error` with fields. **But the issue's stated symptom was not what actually happened, and the real defect is worse.**

`main.go` calls `slog.SetDefault`, and since Go 1.21 that also swaps the `log` package's output for a `handlerWriter` ([`logger.go:62`](https://cs.opensource.google/go/go/+/refs/tags/go1.26.0:src/log/slog/logger.go;l=62)). So `log.Printf` was *already* reaching stdout as a single JSON record — not stderr text, and not ~40 collector records. Verified empirically: running the new test against pre-fix `recovery.go` produces exactly **1** record, at `level=INFO`, with the panic and the whole stack as `msg`.

What was actually broken:

- **emitted at INFO** — `logLoggerLevel`, which slog hardcodes for `log` package output. The single most alertable event in the request path sat *below the error threshold*, invisible to any level-based alert or `level=ERROR` filter.
- **`msg` unique per occurrence** (panic value + full stack interpolated into it) — no alert rule can match it, and no two occurrences can be grouped or counted.
- **no request context**, unlike `AccessLog` for the very same request.

### Decisions, as asked

| | choice | why |
|---|---|---|
| level | `ERROR` | it is a bug by definition; matches `AccessLog`'s 5xx level so the two records agree |
| msg | fixed `"panic recovered"` | stable alert target; same on both branches so **one** rule catches every panic |
| fields | `panic`, `method`, `path`, `response_committed`, `stack` | `panic` via `fmt.Sprint` so an arbitrary panic value can't break JSON marshalling |
| stack | own attribute, not multi-line msg | keeps one panic as one queryable object and out of `msg` |
| `path` | no query string | same rule as `AccessLog`: query strings carry OIDC codes. Test asserts a planted `?code=` never appears in the log |
| request id | **none** — there is no request-ID middleware in this codebase (the `RequestID` hits in `internal/handler/settings.go` are account-link ids). Not inventing one here |
| committed branch | same msg + `response_committed: true` | one alert rule; the field is what tells an operator the client got a truncated response rather than an error document |

`recovery_test.go`'s `captureLog` now swaps `slog.SetDefault` instead of `log.SetOutput`, per the note on the issue, matching `captureLogs` in `accesslog_test.go`. It is used only by `recovery_test.go`.

I have left #332's description as-is rather than editing it; the corrected mechanism is recorded in the commit message and in a code comment at the `slog.Error` call.

## The interaction (the reason for one PR)

An aborted request logs **nothing at all**. The `ErrAbortHandler` re-panic returns before the `slog.Error` call, so an intentional abort cannot produce a scary ERROR record — which, now that panics page, would train operators to ignore the alert that matters. Asserted directly: every `ErrAbortHandler` case checks the captured log has **zero** records, and that neither a status nor a body was written (via a `writeSpy`, so "nothing written" is distinguishable from `httptest.ResponseRecorder`'s default 200/empty body).

## Verification

`export GOFLAGS=-p=2 GOMAXPROCS=2`, rebased onto `origin/staging`. `go build ./...`, `go vet ./...`, `go test ./...` all clean; `go test -race ./internal/middleware/ -run TestRecovery` clean.

All of #329's recovery tests still pass, including `TestRecoveryDoesNotLeakPanicDetail`:

```
--- PASS: TestRecoveryReturnsLegacyShapeOnSPARoutes (0.00s)
--- PASS: TestRecoveryReturnsProblemJSONOnV1Routes (0.00s)
--- PASS: TestRecoveryDoesNotLeakPanicDetail (0.00s)
    --- PASS: TestRecoveryDoesNotLeakPanicDetail/spa (0.00s)
    --- PASS: TestRecoveryDoesNotLeakPanicDetail/v1 (0.00s)
--- PASS: TestRecoveryAfterPartialWrite (0.00s)
    --- PASS: TestRecoveryAfterPartialWrite/spa (0.00s)
    --- PASS: TestRecoveryAfterPartialWrite/v1 (0.00s)
    --- PASS: TestRecoveryAfterPartialWrite/no_superfluous_WriteHeader_on_a_real_server (0.00s)
--- PASS: TestRecoveryPropagatesErrAbortHandlerWithoutLogging (0.00s)      <- new, #331
    --- PASS: .../Recovery (0.00s)
    --- PASS: .../ProblemRecovery (0.00s)
    --- PASS: .../spa (0.00s)
    --- PASS: .../v1_through_both_recovery_layers (0.00s)
--- PASS: TestRecoveryLogsOneStructuredRecord (0.00s)                      <- new, #332
    --- PASS: .../spa (0.00s)
    --- PASS: .../v1 (0.00s)
    --- PASS: .../after_the_response_was_committed (0.00s)
--- PASS: TestRecoveryWriterIsTransparent (0.00s)
ok  	schautrack/internal/middleware	0.007s
```

Both new tests were confirmed to **fail** against pre-fix `recovery.go` (checked out from #329) rather than passing vacuously:

```
--- FAIL: TestRecoveryPropagatesErrAbortHandlerWithoutLogging/Recovery
    escaped panic = <nil> (<nil>), want http.ErrAbortHandler — the abort was swallowed and turned into a response
--- FAIL: TestRecoveryPropagatesErrAbortHandlerWithoutLogging/ProblemRecovery
    escaped panic = <nil> (<nil>), want http.ErrAbortHandler — the abort was swallowed and turned into a response
--- FAIL: TestRecoveryPropagatesErrAbortHandlerWithoutLogging/spa
--- FAIL: TestRecoveryPropagatesErrAbortHandlerWithoutLogging/v1_through_both_recovery_layers
--- FAIL: TestRecoveryLogsOneStructuredRecord/spa
    level = INFO, want ERROR
    msg = panic: kaboom-9f3c
        goroutine 27 [running]: ...   (the whole stack, in msg)
      want "panic recovered" — the alert rule matches on it
```

## Filed while here

- #389 — the same `log.Printf`-at-INFO problem at 7 other call sites, including `SMTP send failed`, `Schema init failed`, `Link auth check failed` and `Failed to load user from session`. Not fixed here: two of them are in `internal/middleware/{auth,links}.go`, which another branch is editing.
- #390 — CI runs only `go test ./...`; no `gofmt`/`go vet` gate, and 15 files are unformatted on `staging` today (none of them mine — my three files are clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)