### PR TITLE
test: exercise every /api/v1 endpoint against a real database

### DIFF
--- a/internal/handler/v1_auth_integration_test.go
+++ b/internal/handler/v1_auth_integration_test.go
@@ -1,0 +1,209 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"schautrack/internal/service"
+)
+
+// RequireAPIToken's rejection branches, exercised against real token rows
+// rather than against a nil pool. api-tokens.spec.ts covers minting and
+// revoking through the session UI; none of it checks what /api/v1 does with the
+// resulting token.
+
+// TestV1RejectsMalformedAuthorizationHeaders covers ParseBearer through the
+// middleware, including the case that must NOT be rejected: RFC 7235 makes the
+// scheme name case-insensitive.
+func TestV1RejectsMalformedAuthorizationHeaders(t *testing.T) {
+	e := newV1Env(t)
+	valid := e.token(service.ScopeEntriesRead)
+
+	rejected := map[string]string{
+		"empty":            "",
+		"bare token":       valid,
+		"basic auth":       "Basic dXNlcjpwYXNz",
+		"scheme only":      "Bearer",
+		"scheme and space": "Bearer ",
+		"wrong scheme":     "Token " + valid,
+		"prefix only":      "Bearer stk_",
+		"not a token":      "Bearer hunter2",
+		"double bearer":    "Bearer Bearer " + valid,
+	}
+
+	for name, header := range rejected {
+		t.Run(name, func(t *testing.T) {
+			rec := e.do(call{Method: http.MethodGet, Path: "/api/v1/me",
+				Headers: map[string]string{"Authorization": header}})
+			requireProblem(t, rec, http.StatusUnauthorized)
+		})
+	}
+
+	accepted := map[string]string{
+		"canonical":  "Bearer " + valid,
+		"lowercase":  "bearer " + valid,
+		"mixed case": "BeArEr " + valid,
+	}
+	for name, header := range accepted {
+		t.Run(name, func(t *testing.T) {
+			rec := e.do(call{Method: http.MethodGet, Path: "/api/v1/me",
+				Headers: map[string]string{"Authorization": header}})
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 — the Bearer scheme is case-insensitive (body: %s)",
+					rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestV1RevokedTokenIsRejected: revocation must take effect on the API surface,
+// not only in the management UI's list.
+func TestV1RevokedTokenIsRejected(t *testing.T) {
+	e := newV1Env(t)
+
+	tok, raw, err := service.CreateAPIToken(e.Ctx, e.Pool, e.UserID, "to be revoked",
+		[]string{service.ScopeEntriesRead}, nil)
+	if err != nil {
+		t.Fatalf("minting: %v", err)
+	}
+	if rec := e.get("/api/v1/me", raw); rec.Code != http.StatusOK {
+		t.Fatalf("before revocation: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	revoked, err := service.RevokeAPIToken(e.Ctx, e.Pool, e.UserID, tok.ID)
+	if err != nil || !revoked {
+		t.Fatalf("revoking: revoked = %v, err = %v", revoked, err)
+	}
+
+	rec := e.get("/api/v1/me", raw)
+	requireProblem(t, rec, http.StatusUnauthorized)
+	if auth := rec.Header().Get("WWW-Authenticate"); !strings.Contains(auth, "invalid_token") {
+		t.Errorf("WWW-Authenticate = %q, want it to carry error=\"invalid_token\"", auth)
+	}
+}
+
+// TestV1ExpiredTokenIsRejected covers model.APIToken.Active through the
+// middleware. The expiry is backdated directly because CreateAPIToken refuses
+// to mint one already in the past.
+func TestV1ExpiredTokenIsRejected(t *testing.T) {
+	e := newV1Env(t)
+
+	future := time.Now().Add(time.Hour)
+	tok, raw, err := service.CreateAPIToken(e.Ctx, e.Pool, e.UserID, "expiring",
+		[]string{service.ScopeEntriesRead}, &future)
+	if err != nil {
+		t.Fatalf("minting: %v", err)
+	}
+	if _, err := e.Pool.Exec(e.Ctx,
+		`UPDATE api_tokens SET expires_at = NOW() - INTERVAL '1 minute' WHERE id = $1`, tok.ID); err != nil {
+		t.Fatalf("backdating the expiry: %v", err)
+	}
+
+	requireProblem(t, e.get("/api/v1/me", raw), http.StatusUnauthorized)
+}
+
+// TestV1TokenOfADeletedUserIsRejected covers the fail-closed branch in
+// RequireAPIToken: a token whose user cannot be loaded must 401, not 500.
+func TestV1TokenOfADeletedUserIsRejected(t *testing.T) {
+	e := newV1Env(t)
+
+	doomedID, doomedEmail := e.seedUser("-doomed")
+	raw := e.tokenFor(doomedID, service.ScopeEntriesRead)
+
+	if rec := e.get("/api/v1/me", raw); rec.Code != http.StatusOK {
+		t.Fatalf("before deletion: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if _, err := e.Pool.Exec(e.Ctx, `DELETE FROM users WHERE email = $1`, doomedEmail); err != nil {
+		t.Fatalf("deleting the user: %v", err)
+	}
+
+	// The FK cascade takes the token with the user, so this is the
+	// unknown-token path; either way it must be a 401 and never a 500.
+	rec := e.get("/api/v1/me", raw)
+	requireProblem(t, rec, http.StatusUnauthorized)
+}
+
+// TestV1TokenUseIsRecorded checks the fire-and-forget last_used_at update
+// actually lands. It is how a user answers "was this leaked token used?", so a
+// silently failing goroutine would be worth knowing about.
+func TestV1TokenUseIsRecorded(t *testing.T) {
+	e := newV1Env(t)
+
+	tok, raw, err := service.CreateAPIToken(e.Ctx, e.Pool, e.UserID, "touched",
+		[]string{service.ScopeEntriesRead}, nil)
+	if err != nil {
+		t.Fatalf("minting: %v", err)
+	}
+	if rec := e.get("/api/v1/me", raw); rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	// The update is deliberately off the request path, so poll briefly rather
+	// than assume it has landed.
+	var lastUsed *time.Time
+	for i := 0; i < 50; i++ {
+		if err := e.Pool.QueryRow(e.Ctx,
+			`SELECT last_used_at FROM api_tokens WHERE id = $1`, tok.ID).Scan(&lastUsed); err != nil {
+			t.Fatalf("reading last_used_at: %v", err)
+		}
+		if lastUsed != nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Error("last_used_at is still NULL a second after an authenticated request")
+}
+
+// TestV1ConcurrentIdempotentRetriesCreateOnce is the claim CLAUDE.md makes
+// about INSERT ... ON CONFLICT DO NOTHING: "of two concurrent retries exactly
+// one claims it and the other observes the claim — neither can execute twice."
+// A check-then-insert would pass every sequential test in this package and fail
+// this one.
+func TestV1ConcurrentIdempotentRetriesCreateOnce(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	const n = 8
+	c := call{Method: http.MethodPost, Path: "/api/v1/entries", Token: token,
+		Body:    `{"date":"2026-08-05","calories":450,"name":"Concurrent"}`,
+		Headers: idempotent("one-logical-operation")}
+
+	statuses := make([]int, n)
+	var wg sync.WaitGroup
+	var start sync.WaitGroup
+	start.Add(1)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			start.Wait()
+			statuses[i] = e.do(c).Code
+		}(i)
+	}
+	start.Done()
+	wg.Wait()
+
+	for i, s := range statuses {
+		if s >= 500 {
+			t.Errorf("request %d returned %d; a concurrent retry must not be a server error", i, s)
+		}
+		// 201 (won the claim, or replayed it) and 409 (saw it in flight) are
+		// both correct answers; anything else is not.
+		if s != http.StatusCreated && s != http.StatusConflict {
+			t.Errorf("request %d returned %d, want 201 or 409", i, s)
+		}
+	}
+
+	var entries int
+	if err := e.Pool.QueryRow(e.Ctx,
+		`SELECT COUNT(*)::int FROM calorie_entries WHERE user_id = $1`, e.UserID).Scan(&entries); err != nil {
+		t.Fatalf("counting entries: %v", err)
+	}
+	if entries != 1 {
+		t.Fatalf("%d entries after %d concurrent retries with one key, want exactly 1 — "+
+			"the claim is not atomic (statuses: %v)", entries, n, statuses)
+	}
+}

--- a/internal/handler/v1_autocalc_integration_test.go
+++ b/internal/handler/v1_autocalc_integration_test.go
@@ -1,0 +1,198 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"schautrack/internal/service"
+)
+
+// Auto-calculated calories, the body-size ceiling, and the collection gaps that
+// other open issues own.
+//
+// Auto-calc is the most intricate branch in v1_entries.go: it overrides a
+// supplied calorie value, it rejects a macro combination whose computed total
+// would break the amount CHECK, and the recompute shares a transaction with the
+// field update precisely so a rejected total cannot leave macros committed
+// against a stale calorie value. None of that was executed by a test.
+
+// enableAutoCalc turns on the macro set that makes IsAutoCalcCalories true.
+func (e *v1Env) enableAutoCalc() {
+	e.t.Helper()
+
+	if _, err := e.Pool.Exec(e.Ctx,
+		`UPDATE users SET macros_enabled = '{"protein":true,"carbs":true,"fat":true,"auto_calc_calories":true}'::jsonb
+		 WHERE id = $1`, e.UserID); err != nil {
+		e.t.Fatalf("enabling auto-calc: %v", err)
+	}
+}
+
+// TestV1AutoCalcDerivesCaloriesFromMacros: with auto-calc on, macros are
+// authoritative and a supplied calorie value is recomputed rather than trusted
+// — so an API-created entry is indistinguishable from a UI-created one.
+func TestV1AutoCalcDerivesCaloriesFromMacros(t *testing.T) {
+	e := newV1Env(t)
+	e.enableAutoCalc()
+	token := e.token(service.ScopeEntriesWrite)
+
+	// 10*4 + 20*4 + 5*9 = 165, not the 5000 the caller asked for.
+	rec := e.post("/api/v1/entries", token, `{"calories":5000,"protein_g":10,"carbs_g":20,"fat_g":5}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	var entry v1Entry
+	decodeJSON(t, rec, &entry)
+	if entry.Calories != 165 {
+		t.Errorf("calories = %d, want the computed 165", entry.Calories)
+	}
+}
+
+// TestV1AutoCalcRejectsAnImpossibleTotal: 999g of each macro computes to 16983,
+// far past the amount CHECK. It must be a 422, not a constraint violation.
+func TestV1AutoCalcRejectsAnImpossibleTotal(t *testing.T) {
+	e := newV1Env(t)
+	e.enableAutoCalc()
+	token := e.token(service.ScopeEntriesWrite)
+
+	rec := e.post("/api/v1/entries", token,
+		fmt.Sprintf(`{"protein_g":%d,"carbs_g":%d,"fat_g":%d}`, MaxEntryMacro, MaxEntryMacro, MaxEntryMacro))
+
+	p := requireProblem(t, rec, http.StatusUnprocessableEntity)
+	if len(p.InvalidParams) == 0 || p.InvalidParams[0].Name != "calories" {
+		t.Errorf("invalid_params = %+v, want it to name calories", p.InvalidParams)
+	}
+	var n int
+	if err := e.Pool.QueryRow(e.Ctx,
+		`SELECT COUNT(*)::int FROM calorie_entries WHERE user_id = $1`, e.UserID).Scan(&n); err != nil {
+		t.Fatalf("counting entries: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("%d entries were written despite the 422", n)
+	}
+}
+
+// TestV1AutoCalcMakesCaloriesReadOnly covers the PATCH branch: setting calories
+// directly on an auto-calc account is refused rather than silently overwritten
+// on the next macro edit.
+func TestV1AutoCalcMakesCaloriesReadOnly(t *testing.T) {
+	e := newV1Env(t)
+	e.enableAutoCalc()
+	token := e.token(service.ScopeEntriesWrite)
+
+	entry := e.createEntry(token, `{"protein_g":10}`)
+
+	rec := e.patch(fmt.Sprintf("/api/v1/entries/%d", entry.ID), token, `{"calories":500}`)
+	p := requireProblem(t, rec, http.StatusUnprocessableEntity)
+	if len(p.InvalidParams) == 0 || p.InvalidParams[0].Name != "calories" {
+		t.Errorf("invalid_params = %+v, want it to name calories", p.InvalidParams)
+	}
+}
+
+// TestV1AutoCalcRollsBackARejectedRecompute is the transaction assertion that
+// UpdateEntryV1's comment promises. The macro UPDATE lands first and the
+// recompute rejects afterwards; without the shared transaction the macros would
+// be committed against a stale calorie value.
+func TestV1AutoCalcRollsBackARejectedRecompute(t *testing.T) {
+	e := newV1Env(t)
+	e.enableAutoCalc()
+	token := e.token(service.ScopeEntriesWrite)
+
+	entry := e.createEntry(token, `{"protein_g":10}`) // 40 kcal
+
+	rec := e.patch(fmt.Sprintf("/api/v1/entries/%d", entry.ID), token,
+		fmt.Sprintf(`{"protein_g":%d,"carbs_g":%d,"fat_g":%d}`, MaxEntryMacro, MaxEntryMacro, MaxEntryMacro))
+	requireProblem(t, rec, http.StatusUnprocessableEntity)
+
+	var protein, carbs, fat *int
+	var amount int
+	if err := e.Pool.QueryRow(e.Ctx,
+		`SELECT protein_g, carbs_g, fat_g, amount FROM calorie_entries WHERE id = $1`, entry.ID,
+	).Scan(&protein, &carbs, &fat, &amount); err != nil {
+		t.Fatalf("reading the entry back: %v", err)
+	}
+	if protein == nil || *protein != 10 {
+		t.Errorf("protein_g = %v, want the original 10 — the rejected PATCH was not rolled back", protein)
+	}
+	if carbs != nil || fat != nil {
+		t.Errorf("carbs_g = %v, fat_g = %v; the rejected PATCH committed macros", carbs, fat)
+	}
+	if amount != 40 {
+		t.Errorf("amount = %d, want the original 40", amount)
+	}
+}
+
+// TestV1BodyLimitIsEnforced: v1 caps a body at 1 MB, tighter than the global
+// 15 MB, because nothing here takes a payload that size.
+func TestV1BodyLimitIsEnforced(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	oversized := fmt.Sprintf(`{"calories":100,"name":%q}`, repeat("x", maxV1Body+1024))
+
+	rec := e.post("/api/v1/entries", token, oversized)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413 (body: %s)", rec.Code, truncateForLog(rec.Body.String()))
+	}
+	requireProblemShape(t, rec)
+
+	// With an Idempotency-Key the body is read by the wrapper instead, which
+	// must still refuse it as a client error rather than buffering it or 500ing.
+	withKey := e.do(call{Method: http.MethodPost, Path: "/api/v1/entries", Token: token,
+		Body: oversized, Headers: idempotent("too-big")})
+	if withKey.Code < 400 || withKey.Code >= 500 {
+		t.Fatalf("with an Idempotency-Key: status = %d, want a 4xx (body: %s)",
+			withKey.Code, truncateForLog(withKey.Body.String()))
+	}
+	requireProblemShape(t, withKey)
+}
+
+// TestV1SavedFoodsCollectionDoesNotPaginate documents the behaviour #298 owns:
+// GET /saved-foods honours `limit` but never reports that it truncated, so a
+// sync client cannot tell a short page from a complete one.
+//
+// TODO(#298): when has_more/next_cursor are added (or the limit is dropped),
+// turn this into the same pagination walk TestV1EntriesKeysetPagination... does.
+func TestV1SavedFoodsCollectionDoesNotPaginate(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeFoodsWrite)
+
+	for i := 0; i < 3; i++ {
+		rec := e.post("/api/v1/saved-foods", token, fmt.Sprintf(`{"name":"Food %d","calories":%d}`, i, 100+i))
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("seeding food %d: status = %d (body: %s)", i, rec.Code, rec.Body.String())
+		}
+	}
+
+	rec := e.get("/api/v1/saved-foods?limit=2", token)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	requireSchema(t, rec, "SavedFoodList")
+
+	var page v1List[v1SavedFood]
+	decodeJSON(t, rec, &page)
+	if len(page.Data) != 2 {
+		t.Fatalf("got %d foods, want the requested 2", len(page.Data))
+	}
+	if page.HasMore != nil || page.NextCursor != nil {
+		t.Fatalf("has_more/next_cursor are now populated (%v/%v) — #298 is fixed, so replace this "+
+			"test with a real pagination walk", page.HasMore, page.NextCursor)
+	}
+}
+
+func repeat(s string, n int) string {
+	out := make([]byte, 0, n*len(s))
+	for i := 0; i < n; i++ {
+		out = append(out, s...)
+	}
+	return string(out)
+}
+
+// truncateForLog keeps a failure message readable when the body is a megabyte.
+func truncateForLog(s string) string {
+	if len(s) > 400 {
+		return s[:400] + "…"
+	}
+	return s
+}

--- a/internal/handler/v1_entries_integration_test.go
+++ b/internal/handler/v1_entries_integration_test.go
@@ -1,0 +1,464 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"schautrack/internal/service"
+)
+
+// Behaviour of /api/v1/entries: validation, the full create/read/update/delete
+// round trip, keyset pagination across a page boundary, and the Optional[T]
+// clear-a-macro path all the way into the SQL.
+
+// createEntry POSTs an entry and returns the decoded response, failing the test
+// if it was not created.
+func (e *v1Env) createEntry(token, body string) v1Entry {
+	e.t.Helper()
+
+	rec := e.post("/api/v1/entries", token, body)
+	if rec.Code != http.StatusCreated {
+		e.t.Fatalf("POST /entries %s: status = %d, want 201 (body: %s)", body, rec.Code, rec.Body.String())
+	}
+	var out v1Entry
+	decodeJSON(e.t, rec, &out)
+	return out
+}
+
+// TestV1CreateEntryRejectsOutOfRangeCalories is the case the issue names first:
+// an out-of-range calorie value must be a 422 that says which field is wrong,
+// not a 500 from the amount CHECK constraint.
+func TestV1CreateEntryRejectsOutOfRangeCalories(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	for _, body := range []string{
+		fmt.Sprintf(`{"calories":%d}`, MaxEntryCalories+1),
+		fmt.Sprintf(`{"calories":%d}`, -(MaxEntryCalories + 1)),
+		`{"calories":1000000}`,
+	} {
+		t.Run(body, func(t *testing.T) {
+			rec := e.post("/api/v1/entries", token, body)
+
+			p := requireProblem(t, rec, http.StatusUnprocessableEntity)
+			if len(p.InvalidParams) == 0 {
+				t.Fatal("invalid_params is empty; a client cannot highlight the offending field")
+			}
+			if p.InvalidParams[0].Name != "calories" {
+				t.Errorf("invalid_params[0].name = %q, want %q", p.InvalidParams[0].Name, "calories")
+			}
+			if p.InvalidParams[0].Reason == "" {
+				t.Error("invalid_params[0].reason is empty")
+			}
+		})
+	}
+}
+
+// TestV1CreateEntryReportsEveryBadMacroAtOnce covers validateMacros's documented
+// promise: collect ALL violations rather than making the caller fix them one
+// round trip at a time.
+func TestV1CreateEntryReportsEveryBadMacroAtOnce(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	rec := e.post("/api/v1/entries", token,
+		fmt.Sprintf(`{"protein_g":%d,"carbs_g":-1,"fat_g":%d}`, MaxEntryMacro+1, MaxEntryMacro+50))
+
+	p := requireProblem(t, rec, http.StatusUnprocessableEntity)
+	got := map[string]bool{}
+	for _, ip := range p.InvalidParams {
+		got[ip.Name] = true
+	}
+	for _, want := range []string{"protein_g", "carbs_g", "fat_g"} {
+		if !got[want] {
+			t.Errorf("invalid_params does not mention %s: %+v", want, p.InvalidParams)
+		}
+	}
+}
+
+// TestV1CreateEntryRejectsAnImpossibleDate: 2026-02-31 parses as a shape but is
+// not a calendar date. Postgres would reject it with a query error, i.e. a 500.
+func TestV1CreateEntryRejectsAnImpossibleDate(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	for _, date := range []string{"2026-02-31", "2026-13-01", "2026-8-5", "not-a-date", "1899-12-31"} {
+		t.Run(date, func(t *testing.T) {
+			rec := e.post("/api/v1/entries", token,
+				fmt.Sprintf(`{"calories":100,"date":%q}`, date))
+
+			p := requireProblem(t, rec, http.StatusUnprocessableEntity)
+			if len(p.InvalidParams) == 0 || p.InvalidParams[0].Name != "date" {
+				t.Errorf("invalid_params = %+v, want it to name date", p.InvalidParams)
+			}
+		})
+	}
+}
+
+// TestV1CreateEntryNeedsSomething checks the "an entry needs at least a calorie
+// value or one macro" branch.
+func TestV1CreateEntryNeedsSomething(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	rec := e.post("/api/v1/entries", token, `{"name":"Just a label"}`)
+	requireProblem(t, rec, http.StatusUnprocessableEntity)
+}
+
+// TestV1EntryRoundTrip walks the resource lifecycle the way a client would,
+// including following the Location header the create response advertises.
+func TestV1EntryRoundTrip(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	rec := e.post("/api/v1/entries", token,
+		`{"date":"2026-08-05","calories":450,"name":"Porridge","protein_g":12,"carbs_g":60}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 (body: %s)", rec.Code, rec.Body.String())
+	}
+	requireSchema(t, rec, "Entry")
+
+	location := rec.Header().Get("Location")
+	if location == "" {
+		t.Fatal("no Location header on 201; a client cannot address what it just created")
+	}
+
+	var created v1Entry
+	decodeJSON(t, rec, &created)
+	if created.Calories != 450 {
+		t.Errorf("calories = %d, want 450", created.Calories)
+	}
+	if created.Macros.ProteinG == nil || *created.Macros.ProteinG != 12 {
+		t.Errorf("protein_g = %v, want 12", created.Macros.ProteinG)
+	}
+	if created.Macros.FatG != nil {
+		t.Errorf("fat_g = %v, want null — an unrecorded macro must not read as 0", *created.Macros.FatG)
+	}
+
+	// The Location header must be usable verbatim.
+	got := e.get(location, token)
+	if got.Code != http.StatusOK {
+		t.Fatalf("GET %s: status = %d, want 200 (body: %s)", location, got.Code, got.Body.String())
+	}
+	requireSchema(t, got, "Entry")
+	var fetched v1Entry
+	decodeJSON(t, got, &fetched)
+	if fetched.ID != created.ID {
+		t.Errorf("Location pointed at entry %d, want %d", fetched.ID, created.ID)
+	}
+
+	// PATCH, then DELETE, then confirm it is gone and that deleting twice 404s
+	// rather than silently succeeding.
+	upd := e.patch(location, token, `{"calories":500,"name":"Porridge with berries"}`)
+	if upd.Code != http.StatusOK {
+		t.Fatalf("PATCH: status = %d, want 200 (body: %s)", upd.Code, upd.Body.String())
+	}
+	requireSchema(t, upd, "Entry")
+
+	del := e.do(call{Method: http.MethodDelete, Path: location, Token: token})
+	if del.Code != http.StatusNoContent {
+		t.Fatalf("DELETE: status = %d, want 204 (body: %s)", del.Code, del.Body.String())
+	}
+	if body := del.Body.String(); body != "" {
+		t.Errorf("204 carried a body: %q", body)
+	}
+	requireProblem(t, e.get(location, token), http.StatusNotFound)
+	requireProblem(t, e.do(call{Method: http.MethodDelete, Path: location, Token: token}), http.StatusNotFound)
+}
+
+// TestV1PatchClearsAMacroEndToEnd is the assertion v1_optional_test.go cannot
+// make: the decoder distinguishing null from absent is only useful if the SQL
+// that follows actually writes NULL. This checks the column, not the struct.
+func TestV1PatchClearsAMacroEndToEnd(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	entry := e.createEntry(token, `{"date":"2026-08-05","calories":450,"name":"Porridge","protein_g":12,"fiber_g":5}`)
+
+	// An absent key must leave the macro alone...
+	rec := e.patch(fmt.Sprintf("/api/v1/entries/%d", entry.ID), token, `{"calories":460}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH {calories}: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	var afterAbsent v1Entry
+	decodeJSON(t, rec, &afterAbsent)
+	if afterAbsent.Macros.ProteinG == nil || *afterAbsent.Macros.ProteinG != 12 {
+		t.Fatalf("protein_g = %v after a PATCH that did not mention it; absent must mean 'leave alone'",
+			afterAbsent.Macros.ProteinG)
+	}
+
+	// ...and an explicit null must clear it.
+	rec = e.patch(fmt.Sprintf("/api/v1/entries/%d", entry.ID), token, `{"protein_g":null}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH {protein_g:null}: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	requireSchema(t, rec, "Entry")
+	var afterNull v1Entry
+	decodeJSON(t, rec, &afterNull)
+	if afterNull.Macros.ProteinG != nil {
+		t.Errorf("protein_g = %d in the response after an explicit null", *afterNull.Macros.ProteinG)
+	}
+	if afterNull.Macros.FiberG == nil || *afterNull.Macros.FiberG != 5 {
+		t.Errorf("fiber_g = %v; clearing protein must not touch the other macros", afterNull.Macros.FiberG)
+	}
+
+	// The column itself, not just the response the handler assembled.
+	var protein *int
+	if err := e.Pool.QueryRow(e.Ctx,
+		`SELECT protein_g FROM calorie_entries WHERE id = $1`, entry.ID).Scan(&protein); err != nil {
+		t.Fatalf("reading protein_g back: %v", err)
+	}
+	if protein != nil {
+		t.Errorf("protein_g in the database = %d, want NULL — the response lied about clearing it", *protein)
+	}
+}
+
+// TestV1PatchClearsTheName covers the Optional[string] path, which writes NULL
+// through a different branch than the macros do.
+func TestV1PatchClearsTheName(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	entry := e.createEntry(token, `{"date":"2026-08-05","calories":450,"name":"Porridge"}`)
+
+	rec := e.patch(fmt.Sprintf("/api/v1/entries/%d", entry.ID), token, `{"name":null}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	var out v1Entry
+	decodeJSON(t, rec, &out)
+	if out.Name != nil {
+		t.Errorf("name = %q after an explicit null", *out.Name)
+	}
+}
+
+// TestV1PatchWithNothingToDoIs400 — an empty patch is a client mistake, and
+// answering 200 would let a typo'd field name look like a successful write.
+func TestV1PatchWithNothingToDoIs400(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	entry := e.createEntry(token, `{"calories":100}`)
+	requireProblem(t, e.patch(fmt.Sprintf("/api/v1/entries/%d", entry.ID), token, `{}`), http.StatusBadRequest)
+}
+
+// TestV1EntriesAreScopedToTheOwner: another account's entry must read as
+// missing, not as forbidden — 403 would confirm the id exists.
+func TestV1EntriesAreScopedToTheOwner(t *testing.T) {
+	e := newV1Env(t)
+
+	otherID, _ := e.seedUser("-other")
+	otherToken := e.tokenFor(otherID, service.ScopeEntriesWrite)
+	mine := e.token(service.ScopeEntriesWrite)
+
+	rec := e.post("/api/v1/entries", otherToken, `{"date":"2026-08-05","calories":450}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("seeding the other account's entry: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	var theirs v1Entry
+	decodeJSON(t, rec, &theirs)
+
+	path := fmt.Sprintf("/api/v1/entries/%d", theirs.ID)
+	requireProblem(t, e.get(path, mine), http.StatusNotFound)
+	requireProblem(t, e.patch(path, mine, `{"calories":1}`), http.StatusNotFound)
+	requireProblem(t, e.do(call{Method: http.MethodDelete, Path: path, Token: mine}), http.StatusNotFound)
+
+	// And the collection must not include it either.
+	list := e.get("/api/v1/entries", mine)
+	var page v1List[v1Entry]
+	decodeJSON(t, list, &page)
+	for _, en := range page.Data {
+		if en.ID == theirs.ID {
+			t.Fatalf("GET /entries returned another account's entry %d", theirs.ID)
+		}
+	}
+}
+
+// TestV1EntriesKeysetPaginationCrossesADateBoundary is the pagination assertion
+// the issue asks for: walk a paginated collection using next_cursor verbatim,
+// across a page boundary that falls between two dates, and check the pages
+// concatenate to exactly the full set in the documented order — no repeats, no
+// skips.
+func TestV1EntriesKeysetPaginationCrossesADateBoundary(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	// Three entries on the later day, two on the earlier one, so a limit of 2
+	// puts the second page's boundary in the middle of the date change.
+	var want []int
+	for _, spec := range []struct {
+		date     string
+		calories int
+	}{
+		{"2026-08-05", 101}, {"2026-08-05", 102}, {"2026-08-05", 103},
+		{"2026-08-04", 201}, {"2026-08-04", 202},
+	} {
+		en := e.createEntry(token, fmt.Sprintf(`{"date":%q,"calories":%d}`, spec.date, spec.calories))
+		want = append(want, en.ID)
+	}
+	// Documented order is entry_date DESC, id DESC.
+	expected := []int{want[2], want[1], want[0], want[4], want[3]}
+
+	var got []int
+	path := "/api/v1/entries?limit=2"
+	for page := 1; ; page++ {
+		if page > 10 {
+			t.Fatal("pagination did not terminate after 10 pages")
+		}
+		rec := e.get(path, token)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("page %d: status = %d (body: %s)", page, rec.Code, rec.Body.String())
+		}
+		requireSchema(t, rec, "EntryList")
+
+		var body v1List[v1Entry]
+		decodeJSON(t, rec, &body)
+		if body.HasMore == nil {
+			t.Fatalf("page %d has no has_more; a client cannot tell whether to keep going", page)
+		}
+		for _, en := range body.Data {
+			got = append(got, en.ID)
+		}
+
+		if !*body.HasMore {
+			if body.NextCursor != nil {
+				t.Errorf("the last page still advertised next_cursor = %q", *body.NextCursor)
+			}
+			break
+		}
+		if body.NextCursor == nil {
+			t.Fatalf("page %d says has_more but carries no next_cursor", page)
+		}
+		if len(body.Data) != 2 {
+			t.Errorf("page %d returned %d rows, want the requested limit of 2", page, len(body.Data))
+		}
+		// Verbatim, as the cursor's own error message instructs.
+		path = "/api/v1/entries?limit=2&cursor=" + *body.NextCursor
+	}
+
+	if len(got) != len(expected) {
+		t.Fatalf("paged through %d entries, want %d (got %v, want %v)", len(got), len(expected), got, expected)
+	}
+	for i := range expected {
+		if got[i] != expected[i] {
+			t.Fatalf("paged order = %v, want %v", got, expected)
+		}
+	}
+}
+
+// TestV1EntriesCursorFromOneResponseIsAcceptedVerbatim isolates the round trip
+// of the cursor itself: whatever the server emits, the server must accept.
+func TestV1EntriesCursorFromOneResponseIsAcceptedVerbatim(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	for i := 0; i < 3; i++ {
+		e.createEntry(token, fmt.Sprintf(`{"date":"2026-08-05","calories":%d}`, 100+i))
+	}
+
+	rec := e.get("/api/v1/entries?limit=1", token)
+	var first v1List[v1Entry]
+	decodeJSON(t, rec, &first)
+	if first.NextCursor == nil {
+		t.Fatal("no next_cursor on a page that has more")
+	}
+
+	// Not re-encoded, not URL-mangled: exactly the string that came back.
+	next := e.get("/api/v1/entries?limit=1&cursor="+*first.NextCursor, token)
+	if next.Code != http.StatusOK {
+		t.Fatalf("the server rejected its own next_cursor %q: status = %d (body: %s)",
+			*first.NextCursor, next.Code, next.Body.String())
+	}
+	var second v1List[v1Entry]
+	decodeJSON(t, next, &second)
+	if len(second.Data) != 1 {
+		t.Fatalf("second page has %d rows, want 1", len(second.Data))
+	}
+	if second.Data[0].ID == first.Data[0].ID {
+		t.Errorf("the cursor returned the same row again (id %d) — the page did not advance", second.Data[0].ID)
+	}
+}
+
+// TestV1EntriesLimitIsClampedNotRejected: over-large limits clamp to
+// maxPageSize, which is what stops a client asking for 100000 rows.
+func TestV1EntriesLimitIsClampedNotRejected(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesRead)
+
+	rec := e.get(fmt.Sprintf("/api/v1/entries?limit=%d", maxPageSize*100), token)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 — an over-large limit clamps (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestV1EntriesDateFiltersAreValidated covers the query-parameter branches of
+// ListEntries, including the mutually exclusive date/from-to pair.
+func TestV1EntriesDateFiltersAreValidated(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesRead)
+
+	cases := []struct {
+		query  string
+		status int
+	}{
+		{"?date=2026-08-05", http.StatusOK},
+		{"?from=2026-08-01&to=2026-08-31", http.StatusOK},
+		{"?date=2026-08-05&from=2026-08-01", http.StatusBadRequest},
+		{"?from=2026-08-31&to=2026-08-01", http.StatusUnprocessableEntity},
+		{"?date=2026-02-31", http.StatusBadRequest},
+		{"?limit=0", http.StatusBadRequest},
+		{"?cursor=not-base64", http.StatusBadRequest},
+		// Decodes as base64 but is not a date,id pair.
+		{"?cursor=Zm9vYmFy", http.StatusBadRequest},
+	}
+
+	for _, c := range cases {
+		t.Run(c.query, func(t *testing.T) {
+			rec := e.get("/api/v1/entries"+c.query, token)
+			if rec.Code != c.status {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, c.status, rec.Body.String())
+			}
+			if c.status >= 400 {
+				requireProblemShape(t, rec)
+			}
+		})
+	}
+}
+
+// TestV1EntryErrorsCarryAnInstance checks the RFC 9457 `instance` member is
+// populated from the request path, which is what makes a pasted error report
+// self-locating.
+func TestV1EntryErrorsCarryAnInstance(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	p := requireProblem(t, e.post("/api/v1/entries", token, `{"calories":999999}`),
+		http.StatusUnprocessableEntity)
+	if !strings.HasSuffix(p.Instance, "/entries") {
+		t.Errorf("instance = %q, want the request path", p.Instance)
+	}
+}
+
+// TestV1ProblemBodiesMatchTheDocumentedSchema closes the loop between the error
+// paths these tests exercise and the Problem schema the contract publishes.
+func TestV1ProblemBodiesMatchTheDocumentedSchema(t *testing.T) {
+	e := newV1Env(t)
+
+	cases := map[string]call{
+		"unauthorized":       {Method: http.MethodGet, Path: "/api/v1/entries"},
+		"insufficient scope": {Method: http.MethodGet, Path: "/api/v1/entries", Token: e.token(service.ScopeWeightRead)},
+		"not found":          {Method: http.MethodGet, Path: "/api/v1/entries/999999", Token: e.token(service.ScopeEntriesRead)},
+		"validation failed":  {Method: http.MethodPost, Path: "/api/v1/entries", Token: e.token(service.ScopeEntriesWrite), Body: `{"calories":999999}`},
+		"bad request":        {Method: http.MethodGet, Path: "/api/v1/entries?limit=x", Token: e.token(service.ScopeEntriesRead)},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			rec := e.do(c)
+			requireProblemShape(t, rec)
+			requireSchema(t, rec, "Problem")
+		})
+	}
+}

--- a/internal/handler/v1_harness_integration_test.go
+++ b/internal/handler/v1_harness_integration_test.go
@@ -1,0 +1,393 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"schautrack/internal/apierr"
+	"schautrack/internal/database"
+	"schautrack/internal/openapi"
+	"schautrack/internal/service"
+)
+
+// Shared harness for the DB-backed /api/v1 behaviour tests.
+//
+// The structural guards (v1_spec_test.go, v1_contract_test.go,
+// v1_optional_test.go) prove the route table, the response shapes and the
+// PATCH decoder are consistent. None of them sends a request to an endpoint,
+// so every apierr.* branch in the handlers was unexecuted. These tests build
+// the REAL router via MountAPIV1, mint a REAL token through
+// service.CreateAPIToken, and drive it with httptest against a real Postgres.
+//
+// Skipped unless TEST_DATABASE_URL is set, matching internal/database's
+// integration tests and internal/handler/onboarding_test.go.
+
+var (
+	v1PoolOnce sync.Once
+	v1Pool     *pgxpool.Pool
+	v1PoolErr  error
+)
+
+// v1TestPool returns a process-wide pool with the schema applied. It is shared
+// rather than per-test because InitSchemaWithRetry replays every migration,
+// which is far too slow to repeat once per test function.
+func v1TestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping integration test")
+	}
+
+	v1PoolOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
+
+		// database.NewPool, not pgxpool.New: the app registers a codec that
+		// scans DATE columns straight into string, and every v1 handler relies
+		// on it (v1Entry.Date, v1Weight.Date, …). A plain pool makes each of
+		// them 500 on a scan error — which is a property of the harness, not of
+		// the handler, so the harness must build the pool the way cmd/server
+		// does.
+		pool, err := database.NewPool(ctx, url)
+		if err != nil {
+			v1PoolErr = fmt.Errorf("pool: %w", err)
+			return
+		}
+		if err := database.InitSchemaWithRetry(ctx, pool, 3); err != nil {
+			v1PoolErr = fmt.Errorf("migrations: %w", err)
+			return
+		}
+		v1Pool = pool
+	})
+	if v1PoolErr != nil {
+		t.Fatalf("test database setup failed: %v", v1PoolErr)
+	}
+	return v1Pool
+}
+
+// v1Env is one test's world: a pool, a freshly seeded user, and the real
+// router mounted where it lives in production.
+type v1Env struct {
+	t      *testing.T
+	Pool   *pgxpool.Pool
+	Router http.Handler
+	Ctx    context.Context
+
+	UserID int
+	Email  string
+
+	// tokens memoises by scope set. service.MaxTokensPerUser caps an account at
+	// 20 live tokens, and a table over ~28 routes would blow through that in a
+	// single test if every case minted its own.
+	tokens map[string]string
+}
+
+// newV1Env seeds a user and mounts /api/v1 exactly as cmd/server does, so the
+// paths under test are the paths clients use and Location headers can be
+// followed verbatim.
+func newV1Env(t *testing.T) *v1Env {
+	t.Helper()
+	pool := v1TestPool(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	t.Cleanup(cancel)
+
+	e := &v1Env{t: t, Pool: pool, Ctx: ctx, tokens: map[string]string{}}
+	e.UserID, e.Email = e.seedUser("")
+
+	h := &V1Handler{Pool: pool, BuildVersion: "v1-integration-test"}
+	r := chi.NewRouter()
+	r.Mount("/api/v1", h.MountAPIV1(pool))
+	e.Router = r
+
+	return e
+}
+
+// seedUser inserts an account whose email is derived from the test name, so
+// concurrent packages and reruns cannot collide and a leftover row from a
+// crashed run is always overwritten.
+func (e *v1Env) seedUser(suffix string) (int, string) {
+	e.t.Helper()
+
+	slug := strings.NewReplacer("/", "-", " ", "-", "#", "-").Replace(e.t.Name())
+	email := strings.ToLower(slug) + suffix + "@v1.integration.test"
+
+	del := func() {
+		if _, err := e.Pool.Exec(context.Background(),
+			`DELETE FROM users WHERE email = $1`, email); err != nil {
+			e.t.Logf("cleanup of %s failed: %v", email, err)
+		}
+	}
+	del()
+	e.t.Cleanup(del)
+
+	// notes_enabled is on so the notes endpoints reach their own validation
+	// instead of short-circuiting on the feature flag; the 409 that flag
+	// produces has its own test.
+	var id int
+	if err := e.Pool.QueryRow(e.Ctx, `
+		INSERT INTO users (email, password_hash, email_verified, timezone, notes_enabled)
+		VALUES ($1, 'x', true, 'UTC', true) RETURNING id`, email).Scan(&id); err != nil {
+		e.t.Fatalf("seeding user %s failed: %v", email, err)
+	}
+	return id, email
+}
+
+// token returns a real API token for the env's user, minting one per distinct
+// scope set and reusing it thereafter.
+func (e *v1Env) token(scopes ...string) string {
+	e.t.Helper()
+
+	key := strings.Join(scopes, ",")
+	if raw, ok := e.tokens[key]; ok {
+		return raw
+	}
+	raw := e.tokenFor(e.UserID, scopes...)
+	e.tokens[key] = raw
+	return raw
+}
+
+func (e *v1Env) tokenFor(userID int, scopes ...string) string {
+	e.t.Helper()
+	_, raw, err := service.CreateAPIToken(e.Ctx, e.Pool, userID,
+		fmt.Sprintf("test-%d", time.Now().UnixNano()), scopes, nil)
+	if err != nil {
+		e.t.Fatalf("minting a token with scopes %v failed: %v", scopes, err)
+	}
+	return raw
+}
+
+// allScopesToken carries every grantable scope — used where the point of the
+// test is the endpoint's own validation rather than authorization.
+func (e *v1Env) allScopesToken() string {
+	e.t.Helper()
+	return e.token(service.AllScopes()...)
+}
+
+// call is one request. Token "" sends no Authorization header at all, which is
+// the anonymous case rather than a malformed one.
+type call struct {
+	Method  string
+	Path    string
+	Token   string
+	Body    string
+	Headers map[string]string
+}
+
+func (e *v1Env) do(c call) *httptest.ResponseRecorder {
+	e.t.Helper()
+
+	var body *strings.Reader
+	if c.Body != "" {
+		body = strings.NewReader(c.Body)
+	} else {
+		body = strings.NewReader("")
+	}
+	req := httptest.NewRequest(c.Method, c.Path, body)
+	req = req.WithContext(e.Ctx)
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+	if c.Body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range c.Headers {
+		req.Header.Set(k, v)
+	}
+
+	rec := httptest.NewRecorder()
+	e.Router.ServeHTTP(rec, req)
+	return rec
+}
+
+// get / post / patch / put / del are thin conveniences over do.
+func (e *v1Env) get(path, token string) *httptest.ResponseRecorder {
+	return e.do(call{Method: http.MethodGet, Path: path, Token: token})
+}
+
+func (e *v1Env) post(path, token, body string) *httptest.ResponseRecorder {
+	return e.do(call{Method: http.MethodPost, Path: path, Token: token, Body: body})
+}
+
+func (e *v1Env) patch(path, token, body string) *httptest.ResponseRecorder {
+	return e.do(call{Method: http.MethodPatch, Path: path, Token: token, Body: body})
+}
+
+// mustRequest builds a bare *http.Request, used where a test needs to compute
+// something the middleware would compute (e.g. an idempotency fingerprint)
+// without sending anything.
+func mustRequest(t *testing.T, method, path, body string) *http.Request {
+	t.Helper()
+	return httptest.NewRequest(method, path, strings.NewReader(body))
+}
+
+// --- Assertions -----------------------------------------------------------
+
+// requireProblem asserts the response is an RFC 9457 problem with the expected
+// status, and returns it. Invariant #3 of the API contract ("errors are
+// problem+json, always") is checked on every single error path this way.
+func requireProblem(t *testing.T, rec *httptest.ResponseRecorder, want int) apierr.Problem {
+	t.Helper()
+
+	if rec.Code != want {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, want, rec.Body.String())
+	}
+	return requireProblemShape(t, rec)
+}
+
+// requireProblemShape checks the problem+json content type and envelope
+// without pinning the status.
+func requireProblemShape(t *testing.T, rec *httptest.ResponseRecorder) apierr.Problem {
+	t.Helper()
+
+	if ct := rec.Header().Get("Content-Type"); ct != apierr.ContentType {
+		t.Errorf("Content-Type = %q, want %q (body: %s)", ct, apierr.ContentType, rec.Body.String())
+	}
+	var p apierr.Problem
+	if err := json.Unmarshal(rec.Body.Bytes(), &p); err != nil {
+		t.Fatalf("error body is not JSON: %v (body: %s)", err, rec.Body.String())
+	}
+	if p.Type == "" {
+		t.Errorf("problem has no type field: %s", rec.Body.String())
+	}
+	if p.Title == "" {
+		t.Errorf("problem has no title field: %s", rec.Body.String())
+	}
+	if p.Status != rec.Code {
+		t.Errorf("problem.status = %d but the HTTP status is %d; a client branching on the body would disagree with one branching on the status",
+			p.Status, rec.Code)
+	}
+	return p
+}
+
+// decodeJSON unmarshals a success body into dst.
+func decodeJSON(t *testing.T, rec *httptest.ResponseRecorder, dst any) {
+	t.Helper()
+	if err := json.Unmarshal(rec.Body.Bytes(), dst); err != nil {
+		t.Fatalf("response is not JSON: %v (body: %s)", err, rec.Body.String())
+	}
+}
+
+// requireSchema validates a success body against the schema the published
+// OpenAPI document declares for it, so a behaviour test also catches drift.
+func requireSchema(t *testing.T, rec *httptest.ResponseRecorder, schema string) {
+	t.Helper()
+	if err := openapi.Build("test", "").ValidateJSON(schema, rec.Body.Bytes()); err != nil {
+		t.Errorf("response does not match the documented %s schema: %v\n\nbody: %s",
+			schema, err, rec.Body.String())
+	}
+}
+
+// --- Route table ----------------------------------------------------------
+
+// v1Route is one served endpoint plus the scope guarding it.
+type v1Route struct {
+	Method  string
+	Pattern string // chi pattern, e.g. /entries/{id}
+	Scope   string // "" = any valid token
+}
+
+// v1Routes enumerates the endpoints from the REAL chi router, joined with the
+// scope each one declares in the OpenAPI document.
+//
+// Driving the tables off chi.Walk rather than a hand-written list is what makes
+// them a guard: a route added to MountAPIV1 tomorrow is covered by every table
+// in this package without anyone remembering to extend a list. (The spec is the
+// scope source because the router does not expose its middleware; the two are
+// kept in lockstep by TestV1RoutesMatchSpec.)
+func v1Routes(t *testing.T) []v1Route {
+	t.Helper()
+
+	scopes := map[string]string{}
+	documented := map[string]bool{}
+	for _, op := range openapi.Build("test", "").Operations() {
+		scopes[op.Method+" "+op.Path] = op.Scope
+		documented[op.Method+" "+op.Path] = true
+	}
+
+	var out []v1Route
+	h := &V1Handler{}
+	if err := chi.Walk(h.MountAPIV1(nil), func(method, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		route = strings.TrimSuffix(route, "/")
+		if route == "" {
+			route = "/"
+		}
+		if route == "/openapi.json" {
+			return nil // public by design; it has its own test
+		}
+		key := method + " " + route
+		if !documented[key] {
+			t.Errorf("route %s is served but undocumented; TestV1RoutesMatchSpec should have caught this", key)
+			return nil
+		}
+		out = append(out, v1Route{Method: method, Pattern: route, Scope: scopes[key]})
+		return nil
+	}); err != nil {
+		t.Fatalf("chi.Walk: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("no v1 routes discovered — the walk is broken, not the router")
+	}
+	return out
+}
+
+// pathParams are the concrete values substituted into a chi pattern.
+//
+// Deliberately exhaustive: an unknown parameter fails the test rather than
+// being skipped, so adding /api/v1/{thing}/{newparam} forces a decision about
+// what a valid value looks like instead of silently dropping coverage.
+var pathParams = map[string]string{
+	"{id}":   "1",
+	"{date}": "2026-08-05",
+	"{code}": "4006381333931",
+}
+
+func concretePath(t *testing.T, pattern string) string {
+	t.Helper()
+
+	out := pattern
+	for name, value := range pathParams {
+		out = strings.ReplaceAll(out, name, value)
+	}
+	if strings.ContainsAny(out, "{}") {
+		t.Fatalf("route %s has a path parameter with no test value; add one to pathParams", pattern)
+	}
+	return "/api/v1" + out
+}
+
+// hasBody reports whether a method carries a request body the handlers decode.
+func (r v1Route) hasBody() bool {
+	switch r.Method {
+	case http.MethodPost, http.MethodPatch, http.MethodPut:
+		return true
+	}
+	return false
+}
+
+// otherScope returns a grantable scope that does NOT satisfy r.Scope, for the
+// "wrong scope must 403" case. It returns "" when the route needs no scope.
+func (r v1Route) otherScope() string {
+	if r.Scope == "" {
+		return ""
+	}
+	for _, s := range service.AllScopes() {
+		if !service.ScopeSatisfies([]string{s}, r.Scope) {
+			return s
+		}
+	}
+	return ""
+}
+
+func (r v1Route) String() string { return r.Method + " " + r.Pattern }

--- a/internal/handler/v1_idempotency_integration_test.go
+++ b/internal/handler/v1_idempotency_integration_test.go
@@ -1,0 +1,326 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"schautrack/internal/service"
+)
+
+// Behaviour of withIdempotency (invariant #6). Every branch here was
+// unexecuted: the ON CONFLICT DO NOTHING claim, the replay, the
+// fingerprint-mismatch 409, the in-flight 409, and the release-on-error path at
+// v1_idempotency.go:126 — which is the subtlest of them, because getting it
+// wrong wedges a client on a mistake it has already fixed.
+
+// entryCount is how many calorie entries the env's user holds. Idempotency is
+// about how many rows exist, so that is what these tests assert on.
+func (e *v1Env) entryCount() int {
+	e.t.Helper()
+
+	var n int
+	if err := e.Pool.QueryRow(e.Ctx,
+		`SELECT COUNT(*)::int FROM calorie_entries WHERE user_id = $1`, e.UserID).Scan(&n); err != nil {
+		e.t.Fatalf("counting entries: %v", err)
+	}
+	return n
+}
+
+func idempotent(key string) map[string]string {
+	return map[string]string{idempotencyHeader: key}
+}
+
+// TestV1IdempotencyKeyReplaysInsteadOfCreatingTwice is the headline promise: a
+// retried POST returns the original response and creates nothing new.
+func TestV1IdempotencyKeyReplaysInsteadOfCreatingTwice(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	const body = `{"date":"2026-08-05","calories":450,"name":"Porridge"}`
+	c := call{Method: http.MethodPost, Path: "/api/v1/entries", Token: token,
+		Body: body, Headers: idempotent("retry-me-once")}
+
+	first := e.do(c)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first POST: status = %d, want 201 (body: %s)", first.Code, first.Body.String())
+	}
+	if first.Header().Get("Idempotency-Replayed") != "" {
+		t.Error("the first request was marked as a replay")
+	}
+	var created v1Entry
+	decodeJSON(t, first, &created)
+
+	second := e.do(c)
+	if second.Code != http.StatusCreated {
+		t.Fatalf("retry: status = %d, want the original 201 (body: %s)", second.Code, second.Body.String())
+	}
+	if second.Header().Get("Idempotency-Replayed") != "true" {
+		t.Error("no Idempotency-Replayed header; a client cannot tell a replay from a second create")
+	}
+	if got, want := second.Header().Get("Location"), first.Header().Get("Location"); got != want {
+		t.Errorf("replayed Location = %q, want %q", got, want)
+	}
+	if got, want := strings.TrimSpace(second.Body.String()), strings.TrimSpace(first.Body.String()); got != want {
+		t.Errorf("replayed body differs from the original:\n got %s\nwant %s", got, want)
+	}
+
+	var replayed v1Entry
+	decodeJSON(t, second, &replayed)
+	if replayed.ID != created.ID {
+		t.Errorf("replay returned entry %d, want the original %d", replayed.ID, created.ID)
+	}
+	if n := e.entryCount(); n != 1 {
+		t.Errorf("%d entries exist after a retry with the same key; the meal was logged twice", n)
+	}
+}
+
+// TestV1IdempotencyWithoutAKeyStillCreatesTwice pins the opt-in contract: the
+// feature must not change behaviour for a client that has never heard of it.
+func TestV1IdempotencyWithoutAKeyStillCreatesTwice(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	const body = `{"date":"2026-08-05","calories":450}`
+	e.post("/api/v1/entries", token, body)
+	e.post("/api/v1/entries", token, body)
+
+	if n := e.entryCount(); n != 2 {
+		t.Errorf("%d entries, want 2 — without a key two POSTs are two entries", n)
+	}
+}
+
+// TestV1IdempotencyRejectsAReusedKeyForADifferentRequest covers the fingerprint
+// mismatch: replaying would silently discard what the client just asked for.
+func TestV1IdempotencyRejectsAReusedKeyForADifferentRequest(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	const key = "recycled"
+	first := e.do(call{Method: http.MethodPost, Path: "/api/v1/entries", Token: token,
+		Body: `{"date":"2026-08-05","calories":450}`, Headers: idempotent(key)})
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first POST: status = %d (body: %s)", first.Code, first.Body.String())
+	}
+
+	second := e.do(call{Method: http.MethodPost, Path: "/api/v1/entries", Token: token,
+		Body: `{"date":"2026-08-05","calories":900}`, Headers: idempotent(key)})
+
+	p := requireProblem(t, second, http.StatusConflict)
+	if p.Detail == "" {
+		t.Error("the 409 does not say what went wrong")
+	}
+	if n := e.entryCount(); n != 1 {
+		t.Errorf("%d entries; the mismatched retry must not have created one", n)
+	}
+}
+
+// TestV1IdempotencyKeyIsScopedToTheUser: two accounts using the same key value
+// must not collide. A shared key namespace would let one account's retry replay
+// another's response.
+func TestV1IdempotencyKeyIsScopedToTheUser(t *testing.T) {
+	e := newV1Env(t)
+	mine := e.token(service.ScopeEntriesWrite)
+
+	otherID, _ := e.seedUser("-other")
+	theirs := e.tokenFor(otherID, service.ScopeEntriesWrite)
+
+	const key = "everyone-picks-1"
+	const body = `{"date":"2026-08-05","calories":450}`
+
+	a := e.do(call{Method: http.MethodPost, Path: "/api/v1/entries", Token: mine, Body: body, Headers: idempotent(key)})
+	b := e.do(call{Method: http.MethodPost, Path: "/api/v1/entries", Token: theirs, Body: body, Headers: idempotent(key)})
+
+	if a.Code != http.StatusCreated || b.Code != http.StatusCreated {
+		t.Fatalf("statuses = %d and %d, want 201 twice (bodies: %s / %s)",
+			a.Code, b.Code, a.Body.String(), b.Body.String())
+	}
+	if b.Header().Get("Idempotency-Replayed") == "true" {
+		t.Fatal("the second account's request replayed the first account's response")
+	}
+
+	var mineEntry, theirsEntry v1Entry
+	decodeJSON(t, a, &mineEntry)
+	decodeJSON(t, b, &theirsEntry)
+	if mineEntry.ID == theirsEntry.ID {
+		t.Fatalf("both accounts were handed entry %d", mineEntry.ID)
+	}
+}
+
+// TestV1IdempotencyReleasesTheClaimAfterAnError is the branch at
+// v1_idempotency.go:126, and the reason it exists: a client whose first attempt
+// was rejected fixes the body and retries with the SAME key (it is one logical
+// operation). If the failed attempt kept the claim, that retry would 409
+// forever and the meal could never be logged.
+func TestV1IdempotencyReleasesTheClaimAfterAnError(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	const key = "fix-and-retry"
+
+	bad := e.do(call{Method: http.MethodPost, Path: "/api/v1/entries", Token: token,
+		Body: fmt.Sprintf(`{"calories":%d}`, MaxEntryCalories+1), Headers: idempotent(key)})
+	requireProblem(t, bad, http.StatusUnprocessableEntity)
+
+	// The claim must be gone, not stored as a replayable 422.
+	var claims int
+	if err := e.Pool.QueryRow(e.Ctx,
+		`SELECT COUNT(*)::int FROM api_idempotency WHERE user_id = $1 AND idempotency_key = $2`,
+		e.UserID, key).Scan(&claims); err != nil {
+		t.Fatalf("counting claims: %v", err)
+	}
+	if claims != 0 {
+		t.Errorf("%d claim rows remain after a 422; the retry below only works because it is released", claims)
+	}
+
+	good := e.do(call{Method: http.MethodPost, Path: "/api/v1/entries", Token: token,
+		Body: `{"calories":450}`, Headers: idempotent(key)})
+	if good.Code != http.StatusCreated {
+		t.Fatalf("corrected retry: status = %d, want 201 — the failed attempt pinned the key (body: %s)",
+			good.Code, good.Body.String())
+	}
+	if good.Header().Get("Idempotency-Replayed") == "true" {
+		t.Error("the corrected retry replayed the failed attempt instead of executing")
+	}
+	if n := e.entryCount(); n != 1 {
+		t.Errorf("%d entries, want 1", n)
+	}
+}
+
+// TestV1IdempotencyReportsAnInFlightRequest covers the response_status = 0
+// branch. The row is claimed before the handler runs, so a concurrent retry
+// observes a claim with no stored response; it must be told to retry rather
+// than handed an empty body.
+func TestV1IdempotencyReportsAnInFlightRequest(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	const key = "still-running"
+	const body = `{"date":"2026-08-05","calories":450}`
+
+	// Stand in for the concurrent original by planting exactly the row it would
+	// have written: same fingerprint, response_status still 0.
+	req := mustRequest(t, http.MethodPost, "/api/v1/entries", body)
+	fingerprint := fingerprintRequest(req, []byte(body))
+	if _, err := e.Pool.Exec(e.Ctx, `
+		INSERT INTO api_idempotency (user_id, idempotency_key, request_fingerprint)
+		VALUES ($1, $2, $3)`, e.UserID, key, fingerprint); err != nil {
+		t.Fatalf("planting the in-flight claim: %v", err)
+	}
+
+	rec := e.do(call{Method: http.MethodPost, Path: "/api/v1/entries", Token: token,
+		Body: body, Headers: idempotent(key)})
+
+	p := requireProblem(t, rec, http.StatusConflict)
+	if !strings.Contains(strings.ToLower(p.Detail), "progress") {
+		t.Errorf("detail = %q; it should tell the caller the original is still running", p.Detail)
+	}
+	if n := e.entryCount(); n != 0 {
+		t.Errorf("%d entries; a request that saw an in-flight claim must not execute", n)
+	}
+}
+
+// TestV1IdempotencyKeyLengthIsBounded — an unbounded header would be a cheap
+// way to write large rows.
+func TestV1IdempotencyKeyLengthIsBounded(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	rec := e.do(call{Method: http.MethodPost, Path: "/api/v1/entries", Token: token,
+		Body: `{"calories":450}`, Headers: idempotent(strings.Repeat("k", maxIdempotencyKeyLen+1))})
+
+	requireProblem(t, rec, http.StatusBadRequest)
+	if n := e.entryCount(); n != 0 {
+		t.Errorf("%d entries; the over-long key must be rejected before the handler runs", n)
+	}
+
+	// Exactly at the limit is fine.
+	ok := e.do(call{Method: http.MethodPost, Path: "/api/v1/entries", Token: token,
+		Body: `{"calories":450}`, Headers: idempotent(strings.Repeat("k", maxIdempotencyKeyLen))})
+	if ok.Code != http.StatusCreated {
+		t.Fatalf("a %d-character key: status = %d, want 201 (body: %s)",
+			maxIdempotencyKeyLen, ok.Code, ok.Body.String())
+	}
+}
+
+// TestV1IdempotencyAppliesToTrackingASavedFood: the other endpoint CLAUDE.md
+// names as wrapped. Tracking twice with one key must produce one entry and one
+// use_count increment.
+func TestV1IdempotencyAppliesToTrackingASavedFood(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeFoodsWrite, service.ScopeEntriesWrite)
+
+	rec := e.post("/api/v1/saved-foods", token, `{"name":"Banana","calories":105}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("creating the saved food: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	var food v1SavedFood
+	decodeJSON(t, rec, &food)
+
+	c := call{
+		Method: http.MethodPost, Path: fmt.Sprintf("/api/v1/saved-foods/%d/track", food.ID),
+		Token: token, Body: `{"date":"2026-08-05","quantity":1}`, Headers: idempotent("track-once"),
+	}
+	if first := e.do(c); first.Code != http.StatusCreated {
+		t.Fatalf("first track: status = %d (body: %s)", first.Code, first.Body.String())
+	}
+	second := e.do(c)
+	if second.Code != http.StatusCreated {
+		t.Fatalf("retried track: status = %d, want the original 201 (body: %s)", second.Code, second.Body.String())
+	}
+	if second.Header().Get("Idempotency-Replayed") != "true" {
+		t.Error("the retried track was not marked as a replay")
+	}
+
+	if n := e.entryCount(); n != 1 {
+		t.Errorf("%d entries after a retried track, want 1", n)
+	}
+	var useCount int
+	if err := e.Pool.QueryRow(e.Ctx,
+		`SELECT use_count FROM saved_foods WHERE id = $1`, food.ID).Scan(&useCount); err != nil {
+		t.Fatalf("reading use_count: %v", err)
+	}
+	if useCount != 1 {
+		t.Errorf("use_count = %d after a replayed track, want 1", useCount)
+	}
+}
+
+// TestV1IdempotencyIsIgnoredWhereItIsNotImplemented documents today's behaviour
+// on the two creates that are NOT wrapped, so the gap is visible in the test
+// output rather than only in prose.
+//
+// TODO(#294): once POST /todos and POST /saved-foods are wrapped, these become
+// replay assertions like the ones above. Asserting the current behaviour keeps
+// the suite honest in the meantime: the header is accepted and ignored, which
+// is exactly the silent double-create #294 describes.
+func TestV1IdempotencyIsIgnoredWhereItIsNotImplemented(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeTodosWrite)
+
+	c := call{Method: http.MethodPost, Path: "/api/v1/todos", Token: token,
+		Body:    `{"name":"Walk the dog","schedule":{"type":"daily"}}`,
+		Headers: idempotent("todo-key")}
+
+	first := e.do(c)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first POST /todos: status = %d (body: %s)", first.Code, first.Body.String())
+	}
+	second := e.do(c)
+	if second.Code != http.StatusCreated {
+		t.Fatalf("second POST /todos: status = %d (body: %s)", second.Code, second.Body.String())
+	}
+
+	var todos int
+	if err := e.Pool.QueryRow(e.Ctx,
+		`SELECT COUNT(*)::int FROM todos WHERE user_id = $1 AND archived = FALSE`, e.UserID).Scan(&todos); err != nil {
+		t.Fatalf("counting todos: %v", err)
+	}
+	if todos != 2 {
+		t.Fatalf("got %d todos; this test asserts the CURRENT (buggy) behaviour of #294 — "+
+			"if POST /todos now honours Idempotency-Key, turn this into a replay assertion", todos)
+	}
+	if second.Header().Get("Idempotency-Replayed") != "" {
+		t.Error("Idempotency-Replayed appeared on an endpoint that does not implement replay")
+	}
+}

--- a/internal/handler/v1_links_integration_test.go
+++ b/internal/handler/v1_links_integration_test.go
@@ -1,0 +1,304 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"schautrack/internal/service"
+)
+
+// Behaviour of resolveTarget — the `?user=` parameter that lets a token read a
+// linked account's shared data. This is the highest-consequence branch on the
+// whole surface: every failure mode here is either a data leak or a lockout,
+// and none of it was executed by a test.
+
+// link creates an accepted account link and sets what each side shares.
+// shares maps a service.Share* category to whether that side shares it.
+func (e *v1Env) link(requesterID, targetID int, requesterShares, targetShares map[string]bool) {
+	e.t.Helper()
+
+	if _, err := e.Pool.Exec(e.Ctx, `
+		INSERT INTO account_links (requester_id, target_id, status, requester_shares, target_shares)
+		VALUES ($1, $2, 'accepted', $3, $4)`,
+		requesterID, targetID, shareJSON(requesterShares), shareJSON(targetShares)); err != nil {
+		e.t.Fatalf("linking %d and %d: %v", requesterID, targetID, err)
+	}
+}
+
+func shareJSON(m map[string]bool) map[string]bool {
+	out := map[string]bool{}
+	for _, c := range service.ShareCategories {
+		out[c] = m[c]
+	}
+	return out
+}
+
+// all / none are the two share sets the tests use.
+func allShares() map[string]bool {
+	out := map[string]bool{}
+	for _, c := range service.ShareCategories {
+		out[c] = true
+	}
+	return out
+}
+
+func noShares() map[string]bool { return map[string]bool{} }
+
+// linkedReadEndpoints are the routes that honour ?user=. Kept as a list rather
+// than derived, because the set is a deliberate product decision — see #293,
+// which is about the routes that are NOT on it.
+var linkedReadEndpoints = []struct {
+	name, path, scope string
+}{
+	{"entries", "/api/v1/entries", service.ScopeEntriesRead},
+	{"weight", "/api/v1/weight", service.ScopeWeightRead},
+	{"todos for a day", "/api/v1/todos/day/2026-08-05", service.ScopeTodosRead},
+	{"notes", "/api/v1/notes/2026-08-05", service.ScopeNotesRead},
+}
+
+// TestV1LinkedReadsRejectAnUnlinkedAccount is the leak test: pointing ?user= at
+// an account you are not linked to must be refused, and refused with 403 rather
+// than 404 — a 404 that turned into a 403 once the id existed would be an
+// oracle for enumerating accounts.
+func TestV1LinkedReadsRejectAnUnlinkedAccount(t *testing.T) {
+	e := newV1Env(t)
+	strangerID, _ := e.seedUser("-stranger")
+
+	for _, ep := range linkedReadEndpoints {
+		t.Run(ep.name, func(t *testing.T) {
+			token := e.token(ep.scope, service.ScopeLinksRead)
+			rec := e.get(fmt.Sprintf("%s?user=%d", ep.path, strangerID), token)
+
+			requireProblem(t, rec, http.StatusForbidden)
+			if body := rec.Body.String(); containsAny(body, `"data"`, `"content"`) {
+				t.Errorf("the refusal carried payload fields: %s", body)
+			}
+		})
+	}
+}
+
+// TestV1LinkedReadsRejectANonexistentAccount: an id nobody owns must look
+// exactly like an id you are simply not linked to.
+func TestV1LinkedReadsRejectANonexistentAccount(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesRead, service.ScopeLinksRead)
+
+	rec := e.get("/api/v1/entries?user=2147483000", token)
+	requireProblem(t, rec, http.StatusForbidden)
+}
+
+// TestV1LinkedReadsNeedTheLinksScope: being linked is not enough — the token
+// must also carry links:read, and the 403 must name it so the client knows what
+// to re-mint.
+func TestV1LinkedReadsNeedTheLinksScope(t *testing.T) {
+	e := newV1Env(t)
+
+	friendID, _ := e.seedUser("-friend")
+	e.link(friendID, e.UserID, allShares(), allShares())
+
+	token := e.token(service.ScopeEntriesRead) // no links:read
+	rec := e.get(fmt.Sprintf("/api/v1/entries?user=%d", friendID), token)
+
+	p := requireProblem(t, rec, http.StatusForbidden)
+	if p.RequiredScope != service.ScopeLinksRead {
+		t.Errorf("required_scope = %q, want %q", p.RequiredScope, service.ScopeLinksRead)
+	}
+}
+
+// TestV1LinkedReadsRespectTheSharedCategory: a link that shares weight does not
+// share nutrition. The check is per-category, not per-link.
+func TestV1LinkedReadsRespectTheSharedCategory(t *testing.T) {
+	e := newV1Env(t)
+
+	friendID, _ := e.seedUser("-friend")
+	// The friend is the requester and shares only weight with us.
+	e.link(friendID, e.UserID, map[string]bool{service.ShareWeight: true}, allShares())
+
+	weightToken := e.token(service.ScopeWeightRead, service.ScopeLinksRead)
+	if rec := e.get(fmt.Sprintf("/api/v1/weight?user=%d", friendID), weightToken); rec.Code != http.StatusOK {
+		t.Fatalf("weight is shared but the read was refused: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	entriesToken := e.token(service.ScopeEntriesRead, service.ScopeLinksRead)
+	rec := e.get(fmt.Sprintf("/api/v1/entries?user=%d", friendID), entriesToken)
+	p := requireProblem(t, rec, http.StatusForbidden)
+	if p.Detail == "" {
+		t.Error("the 403 does not say which category is missing")
+	}
+}
+
+// TestV1LinkedReadsReturnTheirDataWhenShared is the positive half — without it
+// the tests above would pass on an endpoint that refuses everything.
+func TestV1LinkedReadsReturnTheirDataWhenShared(t *testing.T) {
+	e := newV1Env(t)
+
+	friendID, _ := e.seedUser("-friend")
+	e.link(friendID, e.UserID, allShares(), noShares())
+
+	friendToken := e.tokenFor(friendID, service.ScopeEntriesWrite)
+	rec := e.post("/api/v1/entries", friendToken, `{"date":"2026-08-05","calories":777,"name":"Their lunch"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("seeding the friend's entry: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	var theirs v1Entry
+	decodeJSON(t, rec, &theirs)
+
+	token := e.token(service.ScopeEntriesRead, service.ScopeLinksRead)
+	list := e.get(fmt.Sprintf("/api/v1/entries?user=%d", friendID), token)
+	if list.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", list.Code, list.Body.String())
+	}
+	requireSchema(t, list, "EntryList")
+
+	var page v1List[v1Entry]
+	decodeJSON(t, list, &page)
+	found := false
+	for _, en := range page.Data {
+		if en.ID == theirs.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("the shared entry %d is missing from %s", theirs.ID, list.Body.String())
+	}
+
+	// Without ?user= the same token must see nothing of theirs.
+	own := e.get("/api/v1/entries", token)
+	var ownPage v1List[v1Entry]
+	decodeJSON(t, own, &ownPage)
+	if len(ownPage.Data) != 0 {
+		t.Errorf("our own entries list is not empty: %s", own.Body.String())
+	}
+}
+
+// TestV1LinkedWritesAreNotPossible: ?user= is a read-only facility. A write
+// endpoint that honoured it would let a token mutate someone else's account.
+func TestV1LinkedWritesAreNotPossible(t *testing.T) {
+	e := newV1Env(t)
+
+	friendID, _ := e.seedUser("-friend")
+	e.link(friendID, e.UserID, allShares(), allShares())
+
+	token := e.token(service.ScopeEntriesWrite, service.ScopeLinksRead)
+	rec := e.post(fmt.Sprintf("/api/v1/entries?user=%d", friendID), token,
+		`{"date":"2026-08-05","calories":450,"name":"Not yours"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	// The entry must belong to the caller, not to the account named in ?user=.
+	var owner int
+	if err := e.Pool.QueryRow(e.Ctx,
+		`SELECT user_id FROM calorie_entries WHERE entry_name = 'Not yours'`).Scan(&owner); err != nil {
+		t.Fatalf("finding the created entry: %v", err)
+	}
+	if owner != e.UserID {
+		t.Fatalf("the entry was written to account %d; ?user= must never redirect a write (caller is %d)",
+			owner, e.UserID)
+	}
+}
+
+// TestV1LinkedReadOfYourOwnIdIsAllowed: ?user=<self> is a no-op, and must not
+// require links:read.
+func TestV1LinkedReadOfYourOwnIdIsAllowed(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesRead)
+
+	rec := e.get(fmt.Sprintf("/api/v1/entries?user=%d", e.UserID), token)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestV1LinksListsWhatEachSideShares covers GET /links, including the direction
+// of shares_with_me vs shares_to_them — getting them backwards would tell a
+// client it can read data it cannot.
+func TestV1LinksListsWhatEachSideShares(t *testing.T) {
+	e := newV1Env(t)
+
+	friendID, friendEmail := e.seedUser("-friend")
+	// The friend shares everything with us; we share nothing back.
+	e.link(friendID, e.UserID, allShares(), noShares())
+
+	rec := e.get("/api/v1/links", e.token(service.ScopeLinksRead))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	requireSchema(t, rec, "LinkList")
+
+	var page v1List[v1Link]
+	decodeJSON(t, rec, &page)
+	if len(page.Data) != 1 {
+		t.Fatalf("got %d links, want 1: %s", len(page.Data), rec.Body.String())
+	}
+	l := page.Data[0]
+	if l.UserID != friendID {
+		t.Errorf("user_id = %d, want %d", l.UserID, friendID)
+	}
+	if l.Email != friendEmail {
+		t.Errorf("email = %q, want %q", l.Email, friendEmail)
+	}
+	for _, c := range service.ShareCategories {
+		if !l.SharesWithMe[c] {
+			t.Errorf("shares_with_me[%s] = false, but the friend shares it", c)
+		}
+		if l.SharesToThem[c] {
+			t.Errorf("shares_to_them[%s] = true, but we share nothing", c)
+		}
+	}
+
+	// The user_id GET /links hands out must be usable as ?user= — that is the
+	// documented purpose of the field.
+	follow := e.get(fmt.Sprintf("/api/v1/entries?user=%d", l.UserID),
+		e.token(service.ScopeEntriesRead, service.ScopeLinksRead))
+	if follow.Code != http.StatusOK {
+		t.Errorf("?user=%d from GET /links was refused: status = %d (body: %s)",
+			l.UserID, follow.Code, follow.Body.String())
+	}
+}
+
+// TestV1LinkedEntryIdsAreNotFetchableIndividually documents the bug #293 owns:
+// GET /entries?user= hands out ids that GET /entries/{id} cannot resolve,
+// because that endpoint never calls resolveTarget.
+//
+// TODO(#293): when GET /entries/{id} honours ?user=, this becomes a 200 and the
+// assertion flips. It is here as the current behaviour rather than as a
+// weakened version of the right one, so the fix has a test waiting for it.
+func TestV1LinkedEntryIdsAreNotFetchableIndividually(t *testing.T) {
+	e := newV1Env(t)
+
+	friendID, _ := e.seedUser("-friend")
+	e.link(friendID, e.UserID, allShares(), noShares())
+
+	friendToken := e.tokenFor(friendID, service.ScopeEntriesWrite)
+	rec := e.post("/api/v1/entries", friendToken, `{"date":"2026-08-05","calories":777}`)
+	var theirs v1Entry
+	decodeJSON(t, rec, &theirs)
+
+	token := e.token(service.ScopeEntriesRead, service.ScopeLinksRead)
+
+	list := e.get(fmt.Sprintf("/api/v1/entries?user=%d", friendID), token)
+	var page v1List[v1Entry]
+	decodeJSON(t, list, &page)
+	if len(page.Data) == 0 {
+		t.Fatalf("the collection returned nothing to follow: %s", list.Body.String())
+	}
+
+	one := e.get(fmt.Sprintf("/api/v1/entries/%d?user=%d", theirs.ID, friendID), token)
+	if one.Code != http.StatusNotFound {
+		t.Fatalf("status = %d; if GET /entries/{id} now honours ?user= (#293), update this test "+
+			"to assert 200 and the entry's contents (body: %s)", one.Code, one.Body.String())
+	}
+	requireProblemShape(t, one)
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/handler/v1_nul_bytes_integration_test.go
+++ b/internal/handler/v1_nul_bytes_integration_test.go
@@ -1,0 +1,129 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"schautrack/internal/service"
+)
+
+// A NUL byte in a text field is a 500. See #378.
+//
+// nulEscape below is the six characters backslash-u-zero-zero-zero-zero: a
+// perfectly legal JSON escape that decodes to a Go string containing 0x00.
+// Postgres TEXT cannot store that byte, so the INSERT fails with SQLSTATE 22021
+// and dbFail turns a client mistake into an internal-error problem.
+//
+// These tests assert the CURRENT behaviour deliberately. Writing them the right
+// way round would mean committing a red suite; writing them loosely ("4xx or
+// 5xx, whatever") would mean the fix lands with nothing noticing. Pinned to 500
+// with a pointer to #378, they fail the moment someone fixes it — which is the
+// signal the fixer needs to invert them.
+//
+// TODO(#378): when a NUL is rejected before it reaches SQL, change every
+// expected status below to the 4xx it should have been all along and rename
+// this file to say what it now guards.
+const nulEscape = `\u0000`
+
+func TestV1NulByteInATextFieldIsAn500(t *testing.T) {
+	e := newV1Env(t)
+	token := e.allScopesToken()
+
+	// Seed the resources the PATCH cases address.
+	entry := e.createEntry(token, `{"calories":100,"name":"ok"}`)
+
+	foodRec := e.post("/api/v1/saved-foods", token, `{"name":"ok food","calories":10}`)
+	if foodRec.Code != http.StatusCreated {
+		t.Fatalf("seeding a saved food: status = %d (body: %s)", foodRec.Code, foodRec.Body.String())
+	}
+	var food v1SavedFood
+	decodeJSON(t, foodRec, &food)
+
+	todoRec := e.post("/api/v1/todos", token, `{"name":"ok todo","schedule":{"type":"daily"}}`)
+	if todoRec.Code != http.StatusCreated {
+		t.Fatalf("seeding a todo: status = %d (body: %s)", todoRec.Code, todoRec.Body.String())
+	}
+	var todo v1Todo
+	decodeJSON(t, todoRec, &todo)
+
+	cases := []struct{ name, method, path, body string }{
+		{"POST /entries name", http.MethodPost, "/api/v1/entries",
+			`{"calories":100,"name":"a` + nulEscape + `b"}`},
+		{"PATCH /entries/{id} name", http.MethodPatch, fmt.Sprintf("/api/v1/entries/%d", entry.ID),
+			`{"name":"a` + nulEscape + `b"}`},
+		{"POST /saved-foods name", http.MethodPost, "/api/v1/saved-foods",
+			`{"name":"a` + nulEscape + `b","calories":10}`},
+		{"POST /saved-foods emoji", http.MethodPost, "/api/v1/saved-foods",
+			`{"name":"emoji case","emoji":"a` + nulEscape + `b"}`},
+		{"PATCH /saved-foods/{id} name", http.MethodPatch, fmt.Sprintf("/api/v1/saved-foods/%d", food.ID),
+			`{"name":"a` + nulEscape + `b"}`},
+		{"PATCH /saved-foods/{id} emoji", http.MethodPatch, fmt.Sprintf("/api/v1/saved-foods/%d", food.ID),
+			`{"emoji":"a` + nulEscape + `b"}`},
+		{"POST /todos name", http.MethodPost, "/api/v1/todos",
+			`{"name":"a` + nulEscape + `b","schedule":{"type":"daily"}}`},
+		{"PATCH /todos/{id} name", http.MethodPatch, fmt.Sprintf("/api/v1/todos/%d", todo.ID),
+			`{"name":"a` + nulEscape + `b"}`},
+		{"PUT /notes/{date} content", http.MethodPut, "/api/v1/notes/2026-08-05",
+			`{"content":"a` + nulEscape + `b"}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := e.do(call{Method: c.method, Path: c.path, Token: token, Body: c.body})
+
+			if rec.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d — if this is now a 4xx, #378 is fixed: invert every assertion "+
+					"in this file and rename it (body: %s)", rec.Code, rec.Body.String())
+			}
+			// Whatever the status, the contract's error format still holds.
+			requireProblemShape(t, rec)
+		})
+	}
+}
+
+// TestV1ValidatedFieldsRejectNulProperly is the other half of #378, and the
+// reason the fix is worth making: the fields that go through a parser or a
+// closed set already answer 422. The string columns are the exception, not the
+// rule.
+func TestV1ValidatedFieldsRejectNulProperly(t *testing.T) {
+	e := newV1Env(t)
+	token := e.allScopesToken()
+
+	cases := []struct{ name, method, path, body string }{
+		{"timezone", http.MethodPatch, "/api/v1/me", `{"timezone":"UTC` + nulEscape + `"}`},
+		{"language", http.MethodPatch, "/api/v1/me", `{"language":"e` + nulEscape + `n"}`},
+		{"weight_unit", http.MethodPatch, "/api/v1/me", `{"weight_unit":"kg` + nulEscape + `"}`},
+		{"entry date", http.MethodPost, "/api/v1/entries", `{"calories":1,"date":"` + nulEscape + `"}`},
+		{"todo time_of_day", http.MethodPost, "/api/v1/todos",
+			`{"name":"tod","schedule":{"type":"daily"},"time_of_day":"08:0` + nulEscape + `"}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := e.do(call{Method: c.method, Path: c.path, Token: token, Body: c.body})
+			if rec.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("status = %d, want 422 (body: %s)", rec.Code, rec.Body.String())
+			}
+			requireProblemShape(t, rec)
+		})
+	}
+}
+
+// TestV1NulByteInAQueryParameterIsRejected: the query-string validators do get
+// this right, so the parsing layer is not the problem — the missing check is on
+// the free-text body fields.
+func TestV1NulByteInAQueryParameterIsRejected(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesRead, service.ScopeLinksRead)
+
+	for _, q := range []string{"?date=2026-08-05%00", "?user=1%00", "?limit=5%00", "?cursor=abc%00"} {
+		t.Run(q, func(t *testing.T) {
+			rec := e.get("/api/v1/entries"+q, token)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 (body: %s)", rec.Code, rec.Body.String())
+			}
+			requireProblemShape(t, rec)
+		})
+	}
+}

--- a/internal/handler/v1_resources_integration_test.go
+++ b/internal/handler/v1_resources_integration_test.go
@@ -1,0 +1,590 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"schautrack/internal/service"
+)
+
+// Behaviour of the remaining resources: weight, notes, todos, saved foods and
+// /me. Between them these hold the majority of the unexecuted apierr.* branches
+// the issue counts (v1_foods.go 13, v1_capabilities.go 11, v1_weight.go 4,
+// v1_todos.go 3, v1_misc.go 2).
+
+// --- Weight ---------------------------------------------------------------
+
+// TestV1WeightPutIsAnUpsert covers the 201-then-200 distinction PutWeightV1
+// documents, which is how a scale integration tells "first reading today" from
+// "corrected reading".
+func TestV1WeightPutIsAnUpsert(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeWeightWrite)
+
+	first := e.do(call{Method: http.MethodPut, Path: "/api/v1/weight/2026-08-05",
+		Token: token, Body: `{"weight":82.4}`})
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first PUT: status = %d, want 201 (body: %s)", first.Code, first.Body.String())
+	}
+	if first.Header().Get("Location") == "" {
+		t.Error("no Location header on the 201")
+	}
+	requireSchema(t, first, "Weight")
+
+	second := e.do(call{Method: http.MethodPut, Path: "/api/v1/weight/2026-08-05",
+		Token: token, Body: `{"weight":82.1}`})
+	if second.Code != http.StatusOK {
+		t.Fatalf("replacing PUT: status = %d, want 200 (body: %s)", second.Code, second.Body.String())
+	}
+
+	var w v1Weight
+	decodeJSON(t, second, &w)
+	if w.Weight != 82.1 {
+		t.Errorf("weight = %v, want 82.1", w.Weight)
+	}
+
+	// Exactly one row: the unique index is what makes PUT idempotent.
+	var n int
+	if err := e.Pool.QueryRow(e.Ctx,
+		`SELECT COUNT(*)::int FROM weight_entries WHERE user_id = $1`, e.UserID).Scan(&n); err != nil {
+		t.Fatalf("counting weight rows: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("%d weight rows for one date, want 1", n)
+	}
+}
+
+// TestV1WeightRejectsUnusableValues covers ParseWeight's bounds reached through
+// the API, including the values a CHECK constraint would otherwise turn into a
+// 500.
+func TestV1WeightRejectsUnusableValues(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeWeightWrite)
+
+	for _, body := range []string{
+		`{"weight":0}`,
+		`{"weight":-5}`,
+		`{"weight":1501}`,
+		`{"weight":1e30}`,
+		`{}`, // absent weight decodes to the zero value, which is not usable
+	} {
+		t.Run(body, func(t *testing.T) {
+			rec := e.do(call{Method: http.MethodPut, Path: "/api/v1/weight/2026-08-05",
+				Token: token, Body: body})
+
+			p := requireProblem(t, rec, http.StatusUnprocessableEntity)
+			if len(p.InvalidParams) == 0 || p.InvalidParams[0].Name != "weight" {
+				t.Errorf("invalid_params = %+v, want it to name weight", p.InvalidParams)
+			}
+		})
+	}
+}
+
+// TestV1WeightMissingAndDeleted covers the two 404 branches.
+func TestV1WeightMissingAndDeleted(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeWeightWrite)
+
+	requireProblem(t, e.get("/api/v1/weight/2026-08-05", token), http.StatusNotFound)
+	requireProblem(t, e.do(call{Method: http.MethodDelete, Path: "/api/v1/weight/2026-08-05", Token: token}),
+		http.StatusNotFound)
+
+	e.do(call{Method: http.MethodPut, Path: "/api/v1/weight/2026-08-05", Token: token, Body: `{"weight":82.4}`})
+
+	if rec := e.get("/api/v1/weight/2026-08-05", token); rec.Code != http.StatusOK {
+		t.Fatalf("GET after PUT: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if rec := e.do(call{Method: http.MethodDelete, Path: "/api/v1/weight/2026-08-05", Token: token}); rec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE: status = %d, want 204 (body: %s)", rec.Code, rec.Body.String())
+	}
+	requireProblem(t, e.get("/api/v1/weight/2026-08-05", token), http.StatusNotFound)
+}
+
+// TestV1WeightPaginatesAcrossDates: weight is the collection that grows a row
+// per day forever, so its cursor has to work.
+func TestV1WeightPaginatesAcrossDates(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeWeightWrite)
+
+	dates := []string{"2026-08-01", "2026-08-02", "2026-08-03", "2026-08-04"}
+	for i, d := range dates {
+		rec := e.do(call{Method: http.MethodPut, Path: "/api/v1/weight/" + d,
+			Token: token, Body: fmt.Sprintf(`{"weight":%d.5}`, 80+i)})
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("seeding %s: status = %d (body: %s)", d, rec.Code, rec.Body.String())
+		}
+	}
+
+	var got []string
+	path := "/api/v1/weight?limit=2"
+	for page := 1; page <= 5; page++ {
+		rec := e.get(path, token)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("page %d: status = %d (body: %s)", page, rec.Code, rec.Body.String())
+		}
+		requireSchema(t, rec, "WeightList")
+
+		var body v1List[v1Weight]
+		decodeJSON(t, rec, &body)
+		for _, w := range body.Data {
+			got = append(got, w.Date)
+		}
+		if body.HasMore == nil || !*body.HasMore {
+			break
+		}
+		if body.NextCursor == nil {
+			t.Fatalf("page %d says has_more but has no next_cursor", page)
+		}
+		path = "/api/v1/weight?limit=2&cursor=" + *body.NextCursor
+	}
+
+	want := []string{"2026-08-04", "2026-08-03", "2026-08-02", "2026-08-01"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("paged dates = %v, want %v", got, want)
+	}
+}
+
+// --- Notes ----------------------------------------------------------------
+
+// TestV1NoteRoundTrip covers the "no note is 200 with empty content, not 404"
+// decision and the "writing an empty string deletes" one.
+func TestV1NoteRoundTrip(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeNotesWrite)
+
+	rec := e.get("/api/v1/notes/2026-08-05", token)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("a day with no note: status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	requireSchema(t, rec, "Note")
+	var empty v1Note
+	decodeJSON(t, rec, &empty)
+	if empty.Content != "" || empty.UpdatedAt != nil {
+		t.Errorf("empty day returned %+v", empty)
+	}
+
+	put := e.do(call{Method: http.MethodPut, Path: "/api/v1/notes/2026-08-05",
+		Token: token, Body: `{"content":"Felt good."}`})
+	if put.Code != http.StatusOK {
+		t.Fatalf("PUT: status = %d (body: %s)", put.Code, put.Body.String())
+	}
+	requireSchema(t, put, "Note")
+
+	var saved v1Note
+	decodeJSON(t, e.get("/api/v1/notes/2026-08-05", token), &saved)
+	if saved.Content != "Felt good." {
+		t.Errorf("content = %q after a write", saved.Content)
+	}
+
+	// Writing empty deletes.
+	e.do(call{Method: http.MethodPut, Path: "/api/v1/notes/2026-08-05", Token: token, Body: `{"content":"   "}`})
+	var cleared v1Note
+	decodeJSON(t, e.get("/api/v1/notes/2026-08-05", token), &cleared)
+	if cleared.Content != "" {
+		t.Errorf("content = %q after writing whitespace, want it cleared", cleared.Content)
+	}
+}
+
+// TestV1NoteTooLong covers the maxNoteLen branch.
+func TestV1NoteTooLong(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeNotesWrite)
+
+	rec := e.do(call{Method: http.MethodPut, Path: "/api/v1/notes/2026-08-05",
+		Token: token, Body: fmt.Sprintf(`{"content":%q}`, strings.Repeat("x", maxNoteLen+1))})
+
+	p := requireProblem(t, rec, http.StatusUnprocessableEntity)
+	if len(p.InvalidParams) == 0 || p.InvalidParams[0].Name != "content" {
+		t.Errorf("invalid_params = %+v, want it to name content", p.InvalidParams)
+	}
+}
+
+// TestV1NotesDisabledIs409 covers requireNotesEnabled: the endpoint exists and
+// the token may use it, the account simply has the feature off — which is a
+// state the caller can fix, so it must be said rather than 404'd.
+func TestV1NotesDisabledIs409(t *testing.T) {
+	e := newV1Env(t)
+	if _, err := e.Pool.Exec(e.Ctx, `UPDATE users SET notes_enabled = FALSE WHERE id = $1`, e.UserID); err != nil {
+		t.Fatalf("disabling notes: %v", err)
+	}
+	token := e.token(service.ScopeNotesWrite)
+
+	requireProblem(t, e.get("/api/v1/notes/2026-08-05", token), http.StatusConflict)
+	requireProblem(t, e.do(call{Method: http.MethodPut, Path: "/api/v1/notes/2026-08-05",
+		Token: token, Body: `{"content":"hi"}`}), http.StatusConflict)
+}
+
+// --- Todos ----------------------------------------------------------------
+
+// TestV1TodoValidation covers CreateTodoV1's rejection branches.
+func TestV1TodoValidation(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeTodosWrite)
+
+	cases := []struct {
+		name, body, param string
+	}{
+		{"no name", `{"schedule":{"type":"daily"}}`, "name"},
+		{"blank name", `{"name":"   ","schedule":{"type":"daily"}}`, "name"},
+		{"no schedule", `{"name":"Walk"}`, "schedule"},
+		{"unknown schedule type", `{"name":"Walk","schedule":{"type":"hourly"}}`, "schedule"},
+		{"weekdays with no days", `{"name":"Walk","schedule":{"type":"weekdays","days":[]}}`, "schedule"},
+		{"weekdays out of range", `{"name":"Walk","schedule":{"type":"weekdays","days":[0,9]}}`, "schedule"},
+		{"bad time of day", `{"name":"Walk","schedule":{"type":"daily"},"time_of_day":"25:99"}`, "time_of_day"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := e.post("/api/v1/todos", token, c.body)
+
+			p := requireProblem(t, rec, http.StatusUnprocessableEntity)
+			if len(p.InvalidParams) == 0 || p.InvalidParams[0].Name != c.param {
+				t.Errorf("invalid_params = %+v, want it to name %s", p.InvalidParams, c.param)
+			}
+		})
+	}
+}
+
+// TestV1TodoLifecycle covers create, the day view, completion (twice, to prove
+// PUT really is idempotent), un-completion, and the archive-on-delete.
+func TestV1TodoLifecycle(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeTodosWrite)
+
+	rec := e.post("/api/v1/todos", token, `{"name":"Walk the dog","schedule":{"type":"daily"},"time_of_day":"08:00"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST /todos: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	requireSchema(t, rec, "Todo")
+	var todo v1Todo
+	decodeJSON(t, rec, &todo)
+
+	day := e.get("/api/v1/todos/day/2026-08-05", token)
+	if day.Code != http.StatusOK {
+		t.Fatalf("GET /todos/day: status = %d (body: %s)", day.Code, day.Body.String())
+	}
+	requireSchema(t, day, "TodoDayList")
+
+	completion := fmt.Sprintf("/api/v1/todos/%d/completions/2026-08-05", todo.ID)
+	for i := 0; i < 2; i++ {
+		rec := e.do(call{Method: http.MethodPut, Path: completion, Token: token, Body: `{"completed":true}`})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("completion %d: status = %d (body: %s)", i+1, rec.Code, rec.Body.String())
+		}
+		requireSchema(t, rec, "Completion")
+	}
+	var rows int
+	if err := e.Pool.QueryRow(e.Ctx,
+		`SELECT COUNT(*)::int FROM todo_completions WHERE todo_id = $1`, todo.ID).Scan(&rows); err != nil {
+		t.Fatalf("counting completions: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("%d completion rows after two identical PUTs, want 1", rows)
+	}
+
+	// Stating the desired state, not toggling: false means false.
+	if rec := e.do(call{Method: http.MethodPut, Path: completion, Token: token, Body: `{"completed":false}`}); rec.Code != http.StatusOK {
+		t.Fatalf("un-completing: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if err := e.Pool.QueryRow(e.Ctx,
+		`SELECT COUNT(*)::int FROM todo_completions WHERE todo_id = $1`, todo.ID).Scan(&rows); err != nil {
+		t.Fatalf("counting completions: %v", err)
+	}
+	if rows != 0 {
+		t.Errorf("%d completion rows after completed:false, want 0", rows)
+	}
+
+	// Deleting archives; every read endpoint must then behave as if it is gone.
+	if rec := e.do(call{Method: http.MethodDelete, Path: fmt.Sprintf("/api/v1/todos/%d", todo.ID), Token: token}); rec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	var list v1List[v1Todo]
+	decodeJSON(t, e.get("/api/v1/todos", token), &list)
+	if len(list.Data) != 0 {
+		t.Errorf("an archived todo is still listed: %+v", list.Data)
+	}
+	requireProblem(t, e.patch(fmt.Sprintf("/api/v1/todos/%d", todo.ID), token, `{"name":"x"}`), http.StatusNotFound)
+	requireProblem(t, e.do(call{Method: http.MethodPut, Path: completion, Token: token, Body: `{"completed":true}`}),
+		http.StatusNotFound)
+}
+
+// TestV1TodoCompletionForAnUnknownTodoIs404 checks the ownership probe rather
+// than letting an FK violation surface as a 500.
+func TestV1TodoCompletionForAnUnknownTodoIs404(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeTodosWrite)
+
+	rec := e.do(call{Method: http.MethodPut, Path: "/api/v1/todos/999999/completions/2026-08-05",
+		Token: token, Body: `{"completed":true}`})
+	requireProblem(t, rec, http.StatusNotFound)
+}
+
+// TestV1TodoLimitIs409 covers the MaxTodos branch.
+func TestV1TodoLimitIs409(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeTodosWrite)
+
+	for i := 0; i < service.MaxTodos; i++ {
+		rec := e.post("/api/v1/todos", token,
+			fmt.Sprintf(`{"name":"Todo %d","schedule":{"type":"daily"}}`, i))
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("creating todo %d: status = %d (body: %s)", i, rec.Code, rec.Body.String())
+		}
+	}
+	rec := e.post("/api/v1/todos", token, `{"name":"One too many","schedule":{"type":"daily"}}`)
+	requireProblem(t, rec, http.StatusConflict)
+}
+
+// --- Saved foods ----------------------------------------------------------
+
+// TestV1SavedFoodDuplicateNameIs409 covers the 23505 translation: the unique
+// index on (user_id, lower(name)) must surface as a conflict, not a 500.
+func TestV1SavedFoodDuplicateNameIs409(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeFoodsWrite)
+
+	if rec := e.post("/api/v1/saved-foods", token, `{"name":"Banana","calories":105}`); rec.Code != http.StatusCreated {
+		t.Fatalf("first create: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	requireProblem(t, e.post("/api/v1/saved-foods", token, `{"name":"Banana","calories":110}`), http.StatusConflict)
+	// Case-insensitively, since the index is on lower(name).
+	requireProblem(t, e.post("/api/v1/saved-foods", token, `{"name":"banana","calories":110}`), http.StatusConflict)
+}
+
+// TestV1SavedFoodValidation covers the name/calorie/macro rejection branches.
+func TestV1SavedFoodValidation(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeFoodsWrite)
+
+	cases := []struct{ name, body, param string }{
+		{"no name", `{"calories":105}`, "name"},
+		{"blank name", `{"name":"  ","calories":105}`, "name"},
+		{"calories too high", fmt.Sprintf(`{"name":"X","calories":%d}`, MaxEntryCalories+1), "calories"},
+		{"macro too high", fmt.Sprintf(`{"name":"X","protein_g":%d}`, MaxEntryMacro+1), "protein_g"},
+		{"negative macro", `{"name":"X","carbs_g":-1}`, "carbs_g"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := requireProblem(t, e.post("/api/v1/saved-foods", token, c.body), http.StatusUnprocessableEntity)
+			if len(p.InvalidParams) == 0 || p.InvalidParams[0].Name != c.param {
+				t.Errorf("invalid_params = %+v, want it to name %s", p.InvalidParams, c.param)
+			}
+		})
+	}
+}
+
+// TestV1SavedFoodPatchClearsWithNull is the Optional[T] path on a second
+// resource, including the calorie column that is nullable here but not on an
+// entry.
+func TestV1SavedFoodPatchClearsWithNull(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeFoodsWrite)
+
+	rec := e.post("/api/v1/saved-foods", token, `{"name":"Banana","emoji":"🍌","calories":105,"protein_g":1}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	requireSchema(t, rec, "SavedFood")
+	var food v1SavedFood
+	decodeJSON(t, rec, &food)
+
+	upd := e.patch(fmt.Sprintf("/api/v1/saved-foods/%d", food.ID), token,
+		`{"emoji":null,"calories":null,"protein_g":null}`)
+	if upd.Code != http.StatusOK {
+		t.Fatalf("PATCH: status = %d (body: %s)", upd.Code, upd.Body.String())
+	}
+	requireSchema(t, upd, "SavedFood")
+
+	var after v1SavedFood
+	decodeJSON(t, upd, &after)
+	if after.Emoji != nil {
+		t.Errorf("emoji = %q after an explicit null", *after.Emoji)
+	}
+	if after.Calories != nil {
+		t.Errorf("calories = %d after an explicit null", *after.Calories)
+	}
+	if after.Macros.ProteinG != nil {
+		t.Errorf("protein_g = %d after an explicit null", *after.Macros.ProteinG)
+	}
+	if after.Name != "Banana" {
+		t.Errorf("name = %q; a PATCH that did not mention it must leave it alone", after.Name)
+	}
+}
+
+// TestV1TrackSavedFoodValidation covers the quantity bounds and the
+// "multiplying would exceed the entry limits" branch, which is the one that
+// would otherwise hit the amount CHECK constraint as a 500.
+func TestV1TrackSavedFoodValidation(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeFoodsWrite, service.ScopeEntriesWrite)
+
+	rec := e.post("/api/v1/saved-foods", token, `{"name":"Big meal","calories":900,"protein_g":50}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	var food v1SavedFood
+	decodeJSON(t, rec, &food)
+	path := fmt.Sprintf("/api/v1/saved-foods/%d/track", food.ID)
+
+	for _, c := range []struct{ name, body string }{
+		{"quantity zero", `{"quantity":0}`},
+		{"quantity negative", `{"quantity":-1}`},
+		{"quantity above 99", `{"quantity":100}`},
+		{"quantity overflows the entry limits", `{"quantity":99}`},
+		{"impossible date", `{"date":"2026-02-31"}`},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			p := requireProblem(t, e.post(path, token, c.body), http.StatusUnprocessableEntity)
+			if len(p.InvalidParams) == 0 {
+				t.Errorf("invalid_params is empty: %+v", p)
+			}
+		})
+	}
+
+	requireProblem(t, e.post("/api/v1/saved-foods/999999/track", token, `{}`), http.StatusNotFound)
+
+	// The happy path, to prove the rejections above are not the endpoint simply
+	// refusing everything.
+	ok := e.post(path, token, `{"date":"2026-08-05","quantity":1}`)
+	if ok.Code != http.StatusCreated {
+		t.Fatalf("tracking one serving: status = %d (body: %s)", ok.Code, ok.Body.String())
+	}
+	requireSchema(t, ok, "Entry")
+}
+
+// --- /me ------------------------------------------------------------------
+
+// TestV1MeDescribesTheToken checks /me reports the scopes actually held, which
+// is the only way a client can discover what it may do.
+func TestV1MeDescribesTheToken(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesRead, service.ScopeWeightRead)
+
+	rec := e.get("/api/v1/me", token)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	requireSchema(t, rec, "Me")
+
+	var me v1Me
+	decodeJSON(t, rec, &me)
+	if me.User.ID != e.UserID {
+		t.Errorf("user.id = %d, want %d", me.User.ID, e.UserID)
+	}
+	if me.User.Email != e.Email {
+		t.Errorf("user.email = %q, want %q", me.User.Email, e.Email)
+	}
+	if len(me.Token.Scopes) != 2 {
+		t.Errorf("token.scopes = %v, want the two the token was minted with", me.Token.Scopes)
+	}
+	if me.Server.Version == "" || me.Server.Today == "" {
+		t.Errorf("server block is incomplete: %+v", me.Server)
+	}
+}
+
+// TestV1MeSettingsValidation covers every rejection branch in UpdateMeV1.
+func TestV1MeSettingsValidation(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeSettingsWrite)
+
+	cases := []struct {
+		name, body, param string
+		status            int
+	}{
+		{"goal too low", `{"daily_goal":0}`, "daily_goal", http.StatusUnprocessableEntity},
+		{"goal too high", fmt.Sprintf(`{"daily_goal":%d}`, MaxEntryCalories+1), "daily_goal", http.StatusUnprocessableEntity},
+		{"unknown timezone", `{"timezone":"Mars/Olympus_Mons"}`, "timezone", http.StatusUnprocessableEntity},
+		{"unknown weight unit", `{"weight_unit":"stone"}`, "weight_unit", http.StatusUnprocessableEntity},
+		{"unsupported language", `{"language":"tlh"}`, "language", http.StatusUnprocessableEntity},
+		{"nothing to update", `{}`, "", http.StatusBadRequest},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := requireProblem(t, e.patch("/api/v1/me", token, c.body), c.status)
+			if c.param == "" {
+				return
+			}
+			if len(p.InvalidParams) == 0 || p.InvalidParams[0].Name != c.param {
+				t.Errorf("invalid_params = %+v, want it to name %s", p.InvalidParams, c.param)
+			}
+		})
+	}
+}
+
+// TestV1MeSettingsApply checks the writes land and that /me reflects them,
+// including the Optional[T] clear on daily_goal.
+func TestV1MeSettingsApply(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeSettingsWrite)
+
+	rec := e.patch("/api/v1/me", token, `{"daily_goal":2000,"timezone":"Europe/Berlin","weight_unit":"lb","language":"de"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	requireSchema(t, rec, "Me")
+
+	var me v1Me
+	decodeJSON(t, rec, &me)
+	if me.User.DailyGoal == nil || *me.User.DailyGoal != 2000 {
+		t.Errorf("daily_goal = %v, want 2000", me.User.DailyGoal)
+	}
+	if me.User.Timezone != "Europe/Berlin" {
+		t.Errorf("timezone = %q", me.User.Timezone)
+	}
+	if me.User.WeightUnit != "lb" {
+		t.Errorf("weight_unit = %q", me.User.WeightUnit)
+	}
+	if me.User.Language == nil || *me.User.Language != "de" {
+		t.Errorf("language = %v, want de", me.User.Language)
+	}
+
+	// Explicit null clears the goal rather than leaving it alone.
+	cleared := e.patch("/api/v1/me", token, `{"daily_goal":null}`)
+	if cleared.Code != http.StatusOK {
+		t.Fatalf("clearing the goal: status = %d (body: %s)", cleared.Code, cleared.Body.String())
+	}
+	decodeJSON(t, cleared, &me)
+	if me.User.DailyGoal != nil {
+		t.Errorf("daily_goal = %d after an explicit null", *me.User.DailyGoal)
+	}
+
+	var goal *int
+	if err := e.Pool.QueryRow(e.Ctx, `SELECT daily_goal FROM users WHERE id = $1`, e.UserID).Scan(&goal); err != nil {
+		t.Fatalf("reading daily_goal back: %v", err)
+	}
+	if goal != nil {
+		t.Errorf("daily_goal in the database = %d, want NULL", *goal)
+	}
+}
+
+// TestV1MeNeedsNoScopeButPatchDoes is invariant #5's neighbour: reading who you
+// are is free, changing settings is not.
+func TestV1MeNeedsNoScopeButPatchDoes(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesRead)
+
+	if rec := e.get("/api/v1/me", token); rec.Code != http.StatusOK {
+		t.Fatalf("GET /me with an unrelated scope: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	p := requireProblem(t, e.patch("/api/v1/me", token, `{"weight_unit":"lb"}`), http.StatusForbidden)
+	if p.RequiredScope != service.ScopeSettingsWrite {
+		t.Errorf("required_scope = %q, want %q", p.RequiredScope, service.ScopeSettingsWrite)
+	}
+}
+
+// --- Disabled features ----------------------------------------------------
+
+// TestV1DisabledFeaturesAre404 covers the nil-handler branches: a server built
+// without barcode lookup or an AI provider must answer 404, not 500.
+func TestV1DisabledFeaturesAre404(t *testing.T) {
+	e := newV1Env(t)
+
+	requireProblem(t, e.get("/api/v1/barcode/4006381333931", e.token(service.ScopeFoodsRead)),
+		http.StatusNotFound)
+	requireProblem(t, e.post("/api/v1/ai/estimate", e.token(service.ScopeAIEstimate), `{}`),
+		http.StatusNotFound)
+}

--- a/internal/handler/v1_routes_integration_test.go
+++ b/internal/handler/v1_routes_integration_test.go
@@ -1,0 +1,348 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"schautrack/internal/service"
+)
+
+// The tables in this file are the ones the issue calls the "minimum first
+// slice": for EVERY endpoint the router serves,
+//
+//  1. no token           → 401 problem+json
+//  2. wrong scope        → 403 problem+json, naming the scope it wanted
+//  3. a malformed body   → 4xx problem+json, and never 5xx
+//  4. Content-Type is application/problem+json on every error path
+//
+// They are driven off chi.Walk (see v1Routes), so a route added to MountAPIV1
+// is covered the moment it exists. That is the difference between a guard and
+// a snapshot.
+
+// TestV1EveryEndpointRejectsAnonymous covers invariant #1 (bearer tokens only)
+// and #3 (problem+json errors) across the whole surface, rather than the five
+// hand-picked paths TestV1UnauthenticatedRequestsAreRejected checks.
+func TestV1EveryEndpointRejectsAnonymous(t *testing.T) {
+	e := newV1Env(t)
+
+	for _, rt := range v1Routes(t) {
+		t.Run(rt.String(), func(t *testing.T) {
+			rec := e.do(call{Method: rt.Method, Path: concretePath(t, rt.Pattern)})
+
+			p := requireProblem(t, rec, http.StatusUnauthorized)
+			if p.Detail == "" {
+				t.Error("a 401 with no detail tells the caller nothing about how to authenticate")
+			}
+			if auth := rec.Header().Get("WWW-Authenticate"); auth == "" {
+				t.Error("no WWW-Authenticate header; RFC 6750 §3 requires the scheme be advertised on a 401")
+			}
+		})
+	}
+}
+
+// TestV1EveryEndpointRejectsAnInvalidToken checks a syntactically plausible but
+// unknown token is refused the same way, rather than falling through to a
+// handler with a nil user (which would panic into a 500).
+func TestV1EveryEndpointRejectsAnInvalidToken(t *testing.T) {
+	e := newV1Env(t)
+
+	// Right shape, never minted.
+	const bogus = "stk_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+	for _, rt := range v1Routes(t) {
+		t.Run(rt.String(), func(t *testing.T) {
+			rec := e.do(call{Method: rt.Method, Path: concretePath(t, rt.Pattern), Token: bogus})
+			requireProblem(t, rec, http.StatusUnauthorized)
+		})
+	}
+}
+
+// TestV1EveryEndpointEnforcesItsScope is the assertion CLAUDE.md's scope table
+// was making on trust. api-tokens.spec.ts checks scope enforcement on the two
+// endpoints it happens to hit; this checks all of them.
+func TestV1EveryEndpointEnforcesItsScope(t *testing.T) {
+	e := newV1Env(t)
+
+	for _, rt := range v1Routes(t) {
+		if rt.Scope == "" {
+			continue // GET /me deliberately needs only a valid token
+		}
+		t.Run(rt.String(), func(t *testing.T) {
+			wrong := rt.otherScope()
+			if wrong == "" {
+				t.Fatalf("no grantable scope fails to satisfy %q — the test cannot distinguish", rt.Scope)
+			}
+			token := e.token(wrong)
+
+			rec := e.do(call{
+				Method: rt.Method, Path: concretePath(t, rt.Pattern), Token: token,
+				Body: "{}",
+			})
+
+			p := requireProblem(t, rec, http.StatusForbidden)
+			if p.RequiredScope != rt.Scope {
+				t.Errorf("required_scope = %q, want %q; a client cannot tell the user which scope to add",
+					p.RequiredScope, rt.Scope)
+			}
+		})
+	}
+}
+
+// TestV1ScopeIsCheckedBeforeTheBodyIsRead guards the ordering: a token that may
+// not touch an endpoint must be turned away before its payload is parsed, or a
+// 400 would leak that the request WOULD have been valid.
+func TestV1ScopeIsCheckedBeforeTheBodyIsRead(t *testing.T) {
+	e := newV1Env(t)
+
+	for _, rt := range v1Routes(t) {
+		if rt.Scope == "" || !rt.hasBody() {
+			continue
+		}
+		t.Run(rt.String(), func(t *testing.T) {
+			token := e.token(rt.otherScope())
+			rec := e.do(call{
+				Method: rt.Method, Path: concretePath(t, rt.Pattern), Token: token,
+				Body: "this is not json at all",
+			})
+			requireProblem(t, rec, http.StatusForbidden)
+		})
+	}
+}
+
+// malformedBodies are payloads no v1 endpoint may accept. Each must produce a
+// 4xx problem — a 5xx here means an unvalidated value reached the database.
+var malformedBodies = []struct {
+	name, body string
+}{
+	{"truncated json", `{"calories":`},
+	{"not an object", `[1,2,3]`},
+	{"unknown field", `{"__definitely_not_a_field__":1}`},
+	{"wrong field type", `{"name":12345}`},
+	{"two json values", `{} {}`},
+	{"bare string", `"hello"`},
+}
+
+// TestV1MalformedBodiesAreNeverA500 is the table that would have caught the
+// open v1 bugs: every writable endpoint, every kind of bad payload, asserting
+// only what the contract promises — a 4xx problem+json, never a 5xx.
+func TestV1MalformedBodiesAreNeverA500(t *testing.T) {
+	e := newV1Env(t)
+	token := e.allScopesToken()
+
+	for _, rt := range v1Routes(t) {
+		if !rt.hasBody() {
+			continue
+		}
+		for _, bad := range malformedBodies {
+			t.Run(rt.String()+"/"+bad.name, func(t *testing.T) {
+				rec := e.do(call{
+					Method: rt.Method, Path: concretePath(t, rt.Pattern),
+					Token: token, Body: bad.body,
+				})
+
+				if rec.Code >= 500 {
+					t.Fatalf("status = %d for a malformed body; a client error must never surface as a server error (body: %s)",
+						rec.Code, rec.Body.String())
+				}
+				if rec.Code < 400 {
+					t.Fatalf("status = %d — the payload %s was accepted (body: %s)",
+						rec.Code, bad.body, rec.Body.String())
+				}
+				requireProblemShape(t, rec)
+			})
+		}
+	}
+}
+
+// TestV1MalformedPathParametersAreNeverA500 does the same for the values that
+// arrive in the URL. An id of "not-an-int" or a date of "2026-02-31" must be
+// rejected by the handler, not by Postgres.
+func TestV1MalformedPathParametersAreNeverA500(t *testing.T) {
+	e := newV1Env(t)
+	token := e.allScopesToken()
+
+	bad := map[string][]string{
+		"{id}":   {"not-an-int", "0", "-1", "9999999999999999999999"},
+		"{date}": {"not-a-date", "2026-02-31", "2026-13-01", "2026-1-1", "0001-01-01"},
+	}
+
+	for _, rt := range v1Routes(t) {
+		for param, values := range bad {
+			if !containsParam(rt.Pattern, param) {
+				continue
+			}
+			for _, v := range values {
+				t.Run(rt.String()+"/"+param+"="+v, func(t *testing.T) {
+					path := concretePath(t, replaceParam(rt.Pattern, param, v))
+					rec := e.do(call{
+						Method: rt.Method, Path: path, Token: token,
+						Body: bodyFor(rt),
+					})
+					if rec.Code >= 500 {
+						t.Fatalf("status = %d for %s=%q; the handler must reject it before it reaches SQL (body: %s)",
+							rec.Code, param, v, rec.Body.String())
+					}
+					if rec.Code < 400 {
+						t.Fatalf("status = %d — %s=%q was accepted (body: %s)",
+							rec.Code, param, v, rec.Body.String())
+					}
+					requireProblemShape(t, rec)
+				})
+			}
+		}
+	}
+}
+
+// TestV1MalformedQueryParametersAreNeverA500 covers the query-string
+// validators: limit, cursor, the date filters, and ?user=.
+func TestV1MalformedQueryParametersAreNeverA500(t *testing.T) {
+	e := newV1Env(t)
+	token := e.allScopesToken()
+
+	queries := []string{
+		"?limit=abc",
+		"?limit=0",
+		"?limit=-5",
+		"?limit=99999999999999999999",
+		"?cursor=not-base64!!",
+		"?cursor=" + "Zm9vYmFy", // decodes, but is not date,id
+		"?from=nope",
+		"?to=2026-02-31",
+		"?from=2026-08-05&to=2026-08-01",
+		"?date=2026-08-05&from=2026-08-01",
+		"?user=abc",
+		"?user=-1",
+		"?user=99999999999999999999",
+	}
+
+	for _, rt := range v1Routes(t) {
+		if rt.Method != http.MethodGet {
+			continue
+		}
+		for _, q := range queries {
+			t.Run(rt.String()+"/"+q, func(t *testing.T) {
+				rec := e.get(concretePath(t, rt.Pattern)+q, token)
+				if rec.Code >= 500 {
+					t.Fatalf("status = %d for %s; a bad query parameter is the caller's error (body: %s)",
+						rec.Code, q, rec.Body.String())
+				}
+				if rec.Code >= 400 {
+					requireProblemShape(t, rec)
+				}
+			})
+		}
+	}
+}
+
+// TestV1ReadsSucceedForAFreshAccount is the smoke half of the table: with a
+// full-scope token and an account holding no data at all, no read may 500.
+// An empty account is the state every new integration starts in.
+func TestV1ReadsSucceedForAFreshAccount(t *testing.T) {
+	e := newV1Env(t)
+	token := e.allScopesToken()
+
+	for _, rt := range v1Routes(t) {
+		if rt.Method != http.MethodGet {
+			continue
+		}
+		t.Run(rt.String(), func(t *testing.T) {
+			rec := e.get(concretePath(t, rt.Pattern), token)
+			if rec.Code >= 500 {
+				t.Fatalf("status = %d on an empty account (body: %s)", rec.Code, rec.Body.String())
+			}
+			if rec.Code >= 400 {
+				requireProblemShape(t, rec)
+			}
+		})
+	}
+}
+
+// TestV1UnknownPathsAndMethodsAreProblemJSON checks chi's own generated
+// responses, including the authenticated case where the token is valid but the
+// path is not.
+func TestV1UnknownPathsAndMethodsAreProblemJSON(t *testing.T) {
+	e := newV1Env(t)
+	token := e.allScopesToken()
+
+	cases := []struct {
+		name   string
+		call   call
+		status int
+	}{
+		{"unknown path, anonymous", call{Method: http.MethodGet, Path: "/api/v1/nope"}, http.StatusNotFound},
+		{"unknown path, authenticated", call{Method: http.MethodGet, Path: "/api/v1/nope", Token: token}, http.StatusNotFound},
+		{"unknown nested path", call{Method: http.MethodGet, Path: "/api/v1/entries/1/nope", Token: token}, http.StatusNotFound},
+		{"method not allowed", call{Method: http.MethodDelete, Path: "/api/v1/me", Token: token}, http.StatusMethodNotAllowed},
+		{"method not allowed on a collection", call{Method: http.MethodPut, Path: "/api/v1/entries", Token: token}, http.StatusMethodNotAllowed},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			requireProblem(t, e.do(c.call), c.status)
+		})
+	}
+}
+
+// TestV1CookieDoesNotAuthenticateAnyEndpoint extends invariant #1 from the one
+// endpoint TestV1CookiesAreNotAccepted checks to the whole surface, with a
+// session cookie that is real rather than made up in the sense that matters:
+// the middleware must not even look at it.
+func TestV1CookieDoesNotAuthenticateAnyEndpoint(t *testing.T) {
+	e := newV1Env(t)
+
+	for _, rt := range v1Routes(t) {
+		t.Run(rt.String(), func(t *testing.T) {
+			rec := e.do(call{
+				Method: rt.Method, Path: concretePath(t, rt.Pattern),
+				Headers: map[string]string{"Cookie": "schautrack.sid=whatever"},
+			})
+			requireProblem(t, rec, http.StatusUnauthorized)
+		})
+	}
+}
+
+// TestV1WriteScopeImpliesRead asserts the ScopeSatisfies rule end-to-end: a
+// token holding only entries:write really can GET /entries. The unit test
+// proves the predicate; this proves the middleware uses it.
+func TestV1WriteScopeImpliesRead(t *testing.T) {
+	e := newV1Env(t)
+	token := e.token(service.ScopeEntriesWrite)
+
+	rec := e.get("/api/v1/entries", token)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 — entries:write must satisfy entries:read (body: %s)",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// --- helpers --------------------------------------------------------------
+
+func containsParam(pattern, param string) bool { return strings.Contains(pattern, param) }
+
+func replaceParam(pattern, param, value string) string {
+	return strings.Replace(pattern, param, value, 1)
+}
+
+// bodyFor supplies a minimally valid body so a path-parameter test fails on the
+// parameter rather than on a missing payload.
+func bodyFor(rt v1Route) string {
+	if !rt.hasBody() {
+		return ""
+	}
+	switch rt.Pattern {
+	case "/weight/{date}":
+		return `{"weight":82.4}`
+	case "/notes/{date}":
+		return `{"content":"hello"}`
+	case "/todos/{id}/completions/{date}":
+		return `{"completed":true}`
+	case "/entries/{id}":
+		return `{"calories":100}`
+	case "/saved-foods/{id}":
+		return `{"name":"x"}`
+	case "/saved-foods/{id}/track":
+		return `{"quantity":1}`
+	}
+	return `{}`
+}


### PR DESCRIPTION
Closes #311

## What this does

`/api/v1`'s **structure** was well guarded — `v1_spec_test.go` walks the real chi router against the OpenAPI document, `v1_contract_test.go` validates every response shape, `v1_optional_test.go` covers `Optional[T]`. Its **behaviour** was not: no test sent a request to a v1 endpoint and asserted what came back, so ~63 client-facing `apierr.*` branches had never executed.

This adds nine DB-backed handler test files (approach **A** from the issue) that build the real router via `MountAPIV1`, mint real tokens through `service.CreateAPIToken`, and drive them with `httptest` against a real Postgres. All are gated on `TEST_DATABASE_URL` exactly like `internal/database/migrations_test.go` and `internal/handler/onboarding_test.go`, so they skip cleanly with no database.

| File | Covers |
| --- | --- |
| `v1_harness_integration_test.go` | pool, seeded user, token minting, request helper, problem+json assertions, the chi-derived route table |
| `v1_routes_integration_test.go` | the per-endpoint tables (the issue's "minimum first slice") |
| `v1_entries_integration_test.go` | entry validation, lifecycle, keyset pagination, `Optional[T]` clears |
| `v1_idempotency_integration_test.go` | every `withIdempotency` branch |
| `v1_links_integration_test.go` | `?user=` link-scoped reads |
| `v1_resources_integration_test.go` | weight, notes, todos, saved foods, `/me` |
| `v1_autocalc_integration_test.go` | auto-calculated calories, the 1 MB body cap, #298's gap |
| `v1_auth_integration_test.go` | `RequireAPIToken` rejections, concurrent idempotent retries |
| `v1_nul_bytes_integration_test.go` | #378 (filed by this work) |

### The route tables are a guard, not a snapshot

They are driven off `chi.Walk` over the real router, joined with the scope each endpoint declares in the OpenAPI document (the two are kept in lockstep by the existing `TestV1RoutesMatchSpec`). **A route added to `MountAPIV1` tomorrow is covered by every table without anyone remembering to extend a list** — and a path parameter with no test value fails the suite rather than silently dropping coverage.

For every one of the 28 endpoints:

1. no token → 401 problem+json, with `WWW-Authenticate`
2. an unknown-but-plausible token → 401
3. wrong scope → 403 whose `required_scope` names the scope to re-mint
4. a session cookie → 401 (invariant #1, extended from one endpoint to all)
5. six kinds of malformed body → 4xx problem+json, **never** 5xx
6. malformed `{id}` / `{date}` path parameters → 4xx, never 5xx
7. thirteen malformed query strings → never 5xx
8. an empty account → no read 500s
9. `problem.status` always equals the HTTP status, and `Content-Type` is always `application/problem+json`

### Behaviours the issue named as unverified

- **Out-of-range calories** → 422 with `invalid_params` naming `calories`, plus all-violations-at-once for macros.
- **`Idempotency-Key`** → replay returns the original body/`Location` with `Idempotency-Replayed: true` and exactly one row; fingerprint mismatch → 409; in-flight claim → 409; the **release-the-claim-on-a-non-2xx branch at `:126`** verified by asserting the claim row is gone *and* that a corrected retry with the same key succeeds; keys are scoped per user; length bounded. Eight goroutines hitting one key concurrently produce **exactly one entry** — a check-then-insert would pass every sequential test here and fail that one.
- **Keyset pagination** → five entries over two dates walked with `limit=2` so a page boundary falls mid-date-change, feeding `next_cursor` back **verbatim**, asserting the pages concatenate to the full set in `entry_date DESC, id DESC` order with no repeats or skips, and that the last page drops `next_cursor`.
- **`?user=` link-scoped reads** → unlinked and nonexistent accounts get **403, not 404** (404→403 would be an id-enumeration oracle) and carry no payload; missing `links:read` → 403 naming it; per-category sharing honoured; the positive case returns the friend's rows; and `?user=` on a write never redirects the write.
- **`PATCH {"protein_g": null}`** → asserted against `SELECT protein_g` in the database, not against the response the handler assembled, plus the absent-key case proving "leave alone" still works. Same for entry `name`, saved-food `emoji`/`calories`, and `/me`'s `daily_goal`.
- **Scope enforcement on every endpoint**, not just the two `api-tokens.spec.ts` happens to hit — including that scope is checked *before* the body is read, and that `entries:write` really does satisfy `entries:read`.

## Coverage

`internal/handler`, measured on `818aa7a5` — "before" is this same commit with the nine new files moved aside, so both columns are against identical surrounding code:

| | before | after |
| --- | --- | --- |
| `go test ./internal/handler/` (no DB) | 18.0% | 18.0% |
| with `TEST_DATABASE_URL` | **18.1%** | **34.2%** |

Mean per-function coverage across `internal/handler/v1_*.go` is now 79.9% over 75 functions. `decodeV1`, `CreateEntryV1`, `validateMacros`, `pathID`, `pathDate`, `queryDate`, `queryLimit`, `queryCursor` and `dbFail` are at 100%; `resolveTarget` 91.7%, `ListEntries` 91.5%, `UpdateMeV1` 89.8%, `withIdempotency` 86.7%.

The no-DB number is deliberately unchanged: these tests skip without a database, which is why **#313 (`ci-postgres-service`) is a hard dependency for any of this to run in CI**. Until it merges, the suite is green-because-skipped in the pipeline and only meaningful locally.

## Rebased onto `staging`

This branch was rebased onto `staging` after it was first pushed. One thing changed underneath it in the interim, which is worth flagging so the diff does not look arbitrary:

**`openapi.Build` gained a second parameter, `baseURL`** (`func Build(version, baseURL string) *Document`). The harness calls it in two places, so `openapi.Build("test")` became `openapi.Build("test", "")` — matching how `v1_spec_test.go` and `v1_contract_test.go` now call it. Empty string is the no-server-override form those tests already use; `cmd/apidocs` passes `openapi.CanonicalBaseURL` because it writes the published document.

Without the rebase this would have surfaced as a compile failure of the whole `internal/handler` package at merge time:

```
vet: v1_harness_integration_test.go:287:32: not enough arguments in call to openapi.Build
	have (string)  want (string, string)
```

Every figure and transcript below is from `818aa7a5`, after that fix.

## Verification

Both passes run against `818aa7a5`, verbatim.

**Without a database — the new tests must skip cleanly:**

```
$ export GOFLAGS=-p=2 GOMAXPROCS=2
$ go build ./... && go vet ./... && go test ./...
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	0.010s
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	0.005s
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	0.005s
ok  	schautrack/internal/handler	1.566s
ok  	schautrack/internal/middleware	0.662s
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	0.065s
ok  	schautrack/internal/release	0.007s
ok  	schautrack/internal/service	0.242s
ok  	schautrack/internal/session	0.017s
ok  	schautrack/internal/sse	0.019s
```

**With a database — the point of the exercise:**

```
$ docker run -d --rm --name pg-311b -e POSTGRES_PASSWORD=postgres -p 55311:5432 postgres:18
$ TEST_DATABASE_URL='postgres://postgres:postgres@localhost:55311/postgres?sslmode=disable' go test ./... 2>&1 | tail -20
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	(cached)
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	(cached)
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	0.598s
ok  	schautrack/internal/handler	5.164s
ok  	schautrack/internal/middleware	3.696s
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	(cached)
ok  	schautrack/internal/release	(cached)
ok  	schautrack/internal/service	0.658s
ok  	schautrack/internal/session	(cached)
ok  	schautrack/internal/sse	(cached)
$ docker rm -f pg-311b
```

All **79 new top-level tests pass (522 subtests, 0 failures)**. The route tables discover **28 endpoints** from the live chi router. CI's `test` job passes on this commit.

## Bugs found

### #378 — a NUL byte in any text field is a 500 (new, filed by this work)

`{"name":"a\^@b"}` is valid JSON. Go decodes it to a string holding `0x00`; Postgres `TEXT` cannot store one, so the INSERT fails with `SQLSTATE 22021` and `dbFail` turns a pure client mistake into `internal-error`. **Ten paths** across five handlers: `POST`/`PATCH /entries` (`name`), `POST`/`PATCH /saved-foods` (`name`, `emoji`), `POST`/`PATCH /todos` (`name`), `PUT /notes/{date}` (`content`), and the `Idempotency-Key` header. Validated fields (`timezone`, `language`, `weight_unit`, `date`, `time_of_day`) correctly answer 422 — the string columns are the exception.

**Not fixed here, deliberately.** The fix touches four handlers plus either `decodeV1` or the shared `truncateUTF8` (which the session surface also uses), so it is not a one-liner and does not belong in a test-only PR. `v1_nul_bytes_integration_test.go` pins the current 500 with a `TODO(#378)` and a failure message telling the fixer to invert the assertions — so the fix cannot land unnoticed, and nothing here weakens an assertion to go green.

### Bugs owned by other issues — asserted as-is, with TODOs

Per the coordination note, these were independently reproduced but **not** fixed here:

- **#293** (`v1-linked-account-reads`) — `TestV1LinkedEntryIdsAreNotFetchableIndividually` confirms `GET /entries?user=` hands out ids that `GET /entries/{id}` 404s on. Asserts today's 404 with `TODO(#293)` and a message telling the fixer to flip it to 200.
- **#294** (`Idempotency-Key` on `POST /todos`/`/saved-foods`) — `TestV1IdempotencyIsIgnoredWhereItIsNotImplemented` confirms two identical POSTs with one key create two todos and no `Idempotency-Replayed` header. `TODO(#294)`.
- **#298** (`/saved-foods` silent truncation) — `TestV1SavedFoodsCollectionDoesNotPaginate` confirms `?limit=2` returns two rows with no `has_more`/`next_cursor`. `TODO(#298)`.

Each of those three tests fails loudly with an explanatory message the moment its issue is fixed, so the owning PR gets a prompt rather than a stale test.

**#292** (v1 AI/barcode bypass the strict rate limiters) and **#296** (no `body_fat` in v1) are not reachable from this harness — the limiters live in `cmd/server`'s middleware chain, which `MountAPIV1` does not build, and `body_fat` is an absent field rather than a wrong one. Issue #311 assigns cross-cutting middleware to approach (B), which is #312's territory.

### One finding that is a harness property, not a product bug

`v1TestPool` must use `database.NewPool`, not `pgxpool.New`. The app registers a codec that scans `DATE` straight into `string`, and every v1 handler depends on it (`v1Entry.Date`, `v1Weight.Date`, …). A plain pool makes each of them 500 on a scan error. Noted in a comment so the next person does not re-derive it. (`onboarding_test.go` uses a plain pool and is fine, because it touches no date columns.)

## Not done

- **Approach (B)**, the Playwright spec (`e2e/api-v1.spec.ts`) covering the middleware stack this harness skips — rate limiters, the global body limit, the recovery middleware. Out of scope here and owned by #312.
- `BarcodeV1` (12.5%) and `EstimateV1` (10.3%) only reach their nil-handler 404s. Their translation logic needs an injected fake `http.HandlerFunc`; worth a follow-up but it is a different shape of test.
- `GET /plan` is exercised for status and never-500, not for the correctness of the projection — `service.AssemblePlan` deserves its own unit tests rather than assertions through an HTTP layer.
- `replayIdempotent`'s `pgx.ErrNoRows` branch (claim released between the failed insert and the read) is inherently racy and is the one branch left unexecuted.

## Dependency

**#313** adds Postgres to `build.yml`. Until it merges these tests skip in CI, which is reported as a pass. They are fully exercised locally today (both runs above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

