### PR TITLE
feat(helm): expose the update check and captcha threshold as chart values

### DIFF
--- a/helm/schautrack/Chart.yaml
+++ b/helm/schautrack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: schautrack
 description: A simple nutrition tracking web application
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "0.1.9"
 keywords:
   - nutrition

--- a/helm/schautrack/README.md
+++ b/helm/schautrack/README.md
@@ -219,6 +219,44 @@ Behind an ingress, `config.trustProxy` must stay at its default (`true`) or
 every request will share one bucket keyed by the ingress controller's IP, and
 the per-IP limits below become effectively global.
 
+### Opting out of the update check
+
+By default the application asks GitHub (`api.github.com`) once an hour for the
+newest published release, so the footer can tell you your instance is out of
+date. That is the only unsolicited outbound request the application makes. If
+you would rather it made none — a privacy-sensitive deployment, or an
+air-gapped cluster where the call can only ever fail — turn it off:
+
+```yaml
+config:
+  updateCheck:
+    enabled: false
+```
+
+`enabled: false` is the *only* value that changes anything: the application
+reads `UPDATE_CHECK_ENABLED != "false"`, so anything else (including leaving it
+empty) means "on". `--set config.updateCheck.enabled=false` works too — the
+chart renders the boolean as the string `"false"` the application expects.
+
+Turning the check off does **not** remove the "Report an Issue" links; those
+are built from static configuration and keep working. Only the version lookup
+is skipped, and the footer stops claiming an update is available.
+
+The alternative to disabling it is to point it somewhere you control — a
+self-hosted GitHub Enterprise or GitLab mirror of the repository:
+
+```yaml
+config:
+  updateCheck:
+    provider: gitlab
+    repo: infra/mirrors/schautrack
+    baseUrl: https://gitlab.example.com
+```
+
+For GitHub Enterprise the API is assumed at `<baseUrl>/api/v3`, for GitLab at
+`<baseUrl>/api/v4`. Set all three together: `provider` alone would query
+GitLab for `schaurian/schautrack`, which does not exist there.
+
 ## Parameters
 
 ### Global
@@ -274,6 +312,31 @@ Both API limits reject with `429` and a `Retry-After` header.
 
 The barcode-lookup limiter (30 per minute) is not configurable in this release;
 see [issue #366](https://github.com/schaurian/schautrack/issues/366).
+
+### CAPTCHA
+
+| Parameter | Env var | Description | Default |
+|-----------|---------|-------------|---------|
+| `config.captcha.globalThreshold` | `LOGIN_CAPTCHA_GLOBAL_THRESHOLD` | Failed logins per account email or per client IP (cross-session, 15-minute window) before login demands a CAPTCHA. The per-session threshold is fixed at 3 and unaffected. Raise only where clients legitimately share one source IP (a test harness, or an egress NAT in front of many users) — otherwise the shared-IP counter CAPTCHA-gates unrelated sessions. `0` or less is ignored by the application, so it means "default". | `""` (`3`) |
+
+`CAPTCHA_BYPASS` is intentionally **not** exposed by this chart and should stay
+that way. It is a test-only escape hatch that makes CAPTCHA verification accept
+any non-empty answer, removing all brute-force protection from login and
+registration; it is set only by the end-to-end test harness
+(`compose.test.yml`).
+
+### Update check
+
+All optional; an empty value omits the environment variable and leaves the
+application's default in force. See
+[Opting out of the update check](#opting-out-of-the-update-check).
+
+| Parameter | Env var | Description | Default |
+|-----------|---------|-------------|---------|
+| `config.updateCheck.enabled` | `UPDATE_CHECK_ENABLED` | Set `false` to skip the hourly outbound release lookup — recommended for privacy-sensitive or air-gapped installs. Disable-only: the application reads `!= "false"`, so no other value has any effect. "Report an Issue" links keep working. | `""` (`true`) |
+| `config.updateCheck.provider` | `UPDATE_PROVIDER` | Release host to query: `github` or `gitlab`. An unknown value is logged and falls back. | `""` (`github`) |
+| `config.updateCheck.repo` | `UPDATE_REPO` | `owner/repo` (GitLab also accepts nested `group/subgroup/project`) | `""` (`schaurian/schautrack`) |
+| `config.updateCheck.baseUrl` | `UPDATE_BASE_URL` | Host override for self-hosted GitHub Enterprise (API at `<baseUrl>/api/v3`) or GitLab (`<baseUrl>/api/v4`) | `""` (provider's public host) |
 
 ### AI
 
@@ -383,7 +446,22 @@ see [issue #366](https://github.com/schaurian/schautrack/issues/366).
 ## Upgrading
 
 The chart follows semantic versioning; no breaking changes have been released
-through the current `0.3.x` series. `helm upgrade` in place is safe.
+through the current `0.4.x` series. `helm upgrade` in place is safe.
+
+### 0.4.0
+
+- Exposed the update check (`config.updateCheck.enabled`, `.provider`, `.repo`,
+  `.baseUrl`), so the privacy opt-out the application documents is finally
+  reachable from the chart. Setting `config.updateCheck.enabled: false` stops
+  the hourly request to `api.github.com`.
+- Exposed `config.captcha.globalThreshold`
+  (`LOGIN_CAPTCHA_GLOBAL_THRESHOLD`).
+- With this release every environment variable the application reads is
+  settable from the chart, except `BUILD_VERSION` (baked into the image at
+  build time) and `CAPTCHA_BYPASS` (test-only, deliberately unreachable).
+- All new values default to empty, which omits the environment variable and
+  leaves the application's own default in force — upgrading from `0.3.x`
+  changes no behaviour.
 
 ### 0.3.0
 

--- a/helm/schautrack/templates/configmap.yaml
+++ b/helm/schautrack/templates/configmap.yaml
@@ -54,6 +54,30 @@ data:
   {{- if .Values.config.enableRegistration }}
   ENABLE_REGISTRATION: {{ .Values.config.enableRegistration | quote }}
   {{- end }}
+  {{- with .Values.config.updateCheck }}
+  {{- /*
+    UPDATE_CHECK_ENABLED is a disable-only flag: the app reads it as
+    `os.Getenv("UPDATE_CHECK_ENABLED") != "false"`, so only the exact string
+    "false" turns the check off and *any* other value (including "") leaves it
+    on. A plain `{{- if .enabled }}` would therefore drop the one value that
+    has to reach the ConfigMap. The `kindIs "bool"` arm emits whenever the
+    value is a real boolean — true or false — while the bare `.enabled` arm
+    covers strings from --set-string; an unset value is neither, so the key is
+    omitted and the app default (on) applies.
+  */}}
+  {{- if or (kindIs "bool" .enabled) .enabled }}
+  UPDATE_CHECK_ENABLED: {{ .enabled | quote }}
+  {{- end }}
+  {{- if .provider }}
+  UPDATE_PROVIDER: {{ .provider | quote }}
+  {{- end }}
+  {{- if .repo }}
+  UPDATE_REPO: {{ .repo | quote }}
+  {{- end }}
+  {{- if .baseUrl }}
+  UPDATE_BASE_URL: {{ .baseUrl | quote }}
+  {{- end }}
+  {{- end }}
   {{- if .Values.config.trustProxy }}
   TRUST_PROXY: {{ .Values.config.trustProxy | quote }}
   {{- end }}
@@ -69,6 +93,17 @@ data:
   {{- end }}
   {{- if .apiToken }}
   RATE_LIMIT_API_TOKEN: {{ .apiToken | quote }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.config.captcha }}
+  {{- /*
+    The app ignores a non-positive LOGIN_CAPTCHA_GLOBAL_THRESHOLD (it requires
+    `n > 0`), so 0 correctly means "use the default" and truthiness is the
+    right guard here — unlike UPDATE_CHECK_ENABLED above.
+    CAPTCHA_BYPASS is deliberately absent; see values.yaml.
+  */}}
+  {{- if .globalThreshold }}
+  LOGIN_CAPTCHA_GLOBAL_THRESHOLD: {{ .globalThreshold | quote }}
   {{- end }}
   {{- end }}
   {{- if .Values.config.robotsIndex }}

--- a/helm/schautrack/values.yaml
+++ b/helm/schautrack/values.yaml
@@ -119,6 +119,46 @@ config:
   # Registration mode: "open" (default) or "false"/"invite" (requires invite code)
   # Also configurable via /admin settings page
   enableRegistration: ""
+  # Release/update check. The app asks the release provider (GitHub by default)
+  # for the newest published version so the footer can flag an outdated
+  # instance. That is an outbound request to api.github.com on a 1-hour cache.
+  # Every value here is OPTIONAL: leave it empty and the chart omits the
+  # environment variable entirely, so the app's own default applies.
+  updateCheck:
+    # UPDATE_CHECK_ENABLED — set to false to opt out of the outbound request
+    # entirely (recommended for privacy-sensitive or air-gapped installs; the
+    # app default is enabled). This is a DISABLE-ONLY flag: the app tests
+    # `!= "false"`, so false is the only value that changes behaviour, and it
+    # must reach the ConfigMap as the string "false" — the template handles
+    # that, so a plain YAML `false` here (or --set ...enabled=false) is correct.
+    # "Report an Issue" links keep working either way; only the version lookup
+    # is gated.
+    enabled: ""
+    # UPDATE_PROVIDER — "github" or "gitlab" (app default: github). Together
+    # with repo/baseUrl this points the check at your own mirror instead of
+    # disabling it. An unknown value makes the app log an error and fall back.
+    provider: ""
+    # UPDATE_REPO — "owner/repo" (GitLab also accepts nested
+    # "group/subgroup/project"). App default: schaurian/schautrack.
+    repo: ""
+    # UPDATE_BASE_URL — host override for self-hosted GitHub Enterprise
+    # (API assumed at <baseUrl>/api/v3) or self-hosted GitLab (<baseUrl>/api/v4).
+    # Empty = the provider's public host.
+    baseUrl: ""
+  # CAPTCHA tuning. Note there is deliberately NO value for CAPTCHA_BYPASS:
+  # it is a test-only escape hatch that makes VerifyCaptcha accept any
+  # non-empty answer, removing all brute-force protection from login and
+  # registration. It is set only by compose.test.yml and must stay unreachable
+  # from the chart — please do not "fix" this by adding it.
+  captcha:
+    # LOGIN_CAPTCHA_GLOBAL_THRESHOLD — failed logins per account email or per
+    # client IP (cross-session, 15-minute window) before login demands a
+    # captcha (app default: 3). The per-session threshold is fixed at 3 and is
+    # not affected. Raise this only where every client legitimately shares one
+    # source IP — a test harness, or an egress NAT in front of many users —
+    # since the shared-IP counter otherwise captcha-gates unrelated sessions.
+    # A value of 0 or less is ignored by the app, so it means "use the default".
+    globalThreshold: ""
   # Trust X-Forwarded-For headers for rate limiting (default: true)
   # Set to "false" for direct-access deployments without a reverse proxy
   trustProxy: ""


### PR DESCRIPTION
Closes #368

> **Stacked on #369** (`helm-rate-limit-values`), which established the conditional-templating pattern this PR follows and bumped the chart to `0.3.0`. Based against `helm-rate-limit-values` so the diff stays reviewable; GitHub retargets this to `staging` automatically once #369 merges. Review #369 first.

## The gap

`README.md` recommends `UPDATE_CHECK_ENABLED=false` "for privacy-sensitive or air-gapped self-hosts", but the chart templated **no** `UPDATE_*` variable at all. A chart-deployed instance called `api.github.com` hourly with no supported way to stop it — patching the ConfigMap out of band worked until the next `helm upgrade` reverted it. In an air-gapped cluster the call just failed on every check.

The Helm chart is the primary supported deployment path, so the documented remedy was unreachable for exactly the users it was written for.

## What changed

Diff is confined to `helm/`.

| New value | Env var |
|---|---|
| `config.updateCheck.enabled` | `UPDATE_CHECK_ENABLED` |
| `config.updateCheck.provider` | `UPDATE_PROVIDER` |
| `config.updateCheck.repo` | `UPDATE_REPO` |
| `config.updateCheck.baseUrl` | `UPDATE_BASE_URL` |
| `config.captcha.globalThreshold` | `LOGIN_CAPTCHA_GLOBAL_THRESHOLD` |

Following #369: every value is optional, an unset value **omits the env var entirely** so the app's own default applies, and no defaults are baked into `values.yaml`.

`CAPTCHA_BYPASS` is deliberately **not** exposed — #368 is right that it should stay unreachable. `values.yaml` now carries a comment saying so, so nobody "fixes" it later:

```yaml
  # CAPTCHA tuning. Note there is deliberately NO value for CAPTCHA_BYPASS:
  # it is a test-only escape hatch that makes VerifyCaptcha accept any
  # non-empty answer, removing all brute-force protection from login and
  # registration. It is set only by compose.test.yml and must stay unreachable
  # from the chart — please do not "fix" this by adding it.
```

## The boolean-false problem

#369 learned that an int `0` must be omitted because the app treats it as unset. The boolean equivalent here is the **opposite** and much nastier.

`internal/config/config.go:161`:

```go
UpdateCheckEnabled: os.Getenv("UPDATE_CHECK_ENABLED") != "false"
```

So the *only* value that has to reach the ConfigMap is the string `"false"` — and that is precisely the value a naive guard drops, because a boolean `false` is falsy in a Go template. Demonstrated on a throwaway chart using `{{- if .enabled }}`:

```
$ helm template n naive --set config.updateCheck.enabled=false | grep -E "NAIVE_UPDATE_CHECK_ENABLED|MARKER"
  MARKER: "end"
```

The env var is silently missing. The user sets the documented opt-out, `helm upgrade` reports success, and the instance keeps calling GitHub. Silent no-op — the worst failure mode for a privacy setting.

The guard used instead:

```gotemplate
{{- if or (kindIs "bool" .enabled) .enabled }}
UPDATE_CHECK_ENABLED: {{ .enabled | quote }}
{{- end }}
```

- `kindIs "bool"` arm → emits for **any** real boolean, `true` *or* `false`
- bare `.enabled` arm → covers strings from `--set-string`
- unset is neither → key omitted, app default (on) applies
- `| quote` renders the boolean as the string `"false"`, not a YAML bool — which ConfigMap `data` requires anyway

The captcha threshold keeps the ordinary truthiness guard **on purpose**: the app requires `n > 0` (`internal/handler/login_failures.go:25`), so `0` correctly means "use the default". Both behaviours are commented inline in the template.

## Verification

All output below is real, captured from this branch.

### `go build` / `go test`

```
$ export GOFLAGS=-p=2 GOMAXPROCS=2 && go build ./...
BUILD_EXIT=0

$ go test ./...
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	0.010s
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	0.004s
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	0.005s
ok  	schautrack/internal/handler	1.042s
ok  	schautrack/internal/middleware	0.068s
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	0.034s
ok  	schautrack/internal/release	0.008s
ok  	schautrack/internal/service	0.219s
ok  	schautrack/internal/session	0.008s
ok  	schautrack/internal/sse	0.017s
TEST_EXIT=0
```

### `helm lint`

```
$ helm lint helm/schautrack
==> Linting helm/schautrack
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
LINT_EXIT=0
```

### Case 1 — defaults, nothing set: no keys emitted

```
$ helm template test helm/schautrack | sed -n '/^kind: ConfigMap$/,/^---$/p'
kind: ConfigMap
metadata:
  name: test-schautrack
  labels:
    helm.sh/chart: schautrack-0.4.0
    app.kubernetes.io/name: schautrack
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.1.9"
    app.kubernetes.io/managed-by: Helm
data:
  PORT: "3000"
  IMPRINT_URL: "/imprint"
  SMTP_PORT: "587"
  AI_DAILY_LIMIT: "10"
  ANDROID_PACKAGE_NAME: "to.schauer.schautrack"
---
```

No `UPDATE_*`, no `LOGIN_CAPTCHA_GLOBAL_THRESHOLD`. App defaults in force.

### Case 2 — `--set config.updateCheck.enabled=false` (**the one that matters**)

```
$ helm template test helm/schautrack --set config.updateCheck.enabled=false | sed -n '/^kind: ConfigMap$/,/^---$/p'
kind: ConfigMap
metadata:
  name: test-schautrack
  labels:
    helm.sh/chart: schautrack-0.4.0
    app.kubernetes.io/name: schautrack
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.1.9"
    app.kubernetes.io/managed-by: Helm
data:
  PORT: "3000"
  IMPRINT_URL: "/imprint"
  SMTP_PORT: "587"
  AI_DAILY_LIMIT: "10"
  UPDATE_CHECK_ENABLED: "false"
  ANDROID_PACKAGE_NAME: "to.schauer.schautrack"
---
```

### Case 3 — `--set config.updateCheck.enabled=true`

```
$ helm template test helm/schautrack --set config.updateCheck.enabled=true | sed -n '/^kind: ConfigMap$/,/^---$/p'
kind: ConfigMap
metadata:
  name: test-schautrack
  labels:
    helm.sh/chart: schautrack-0.4.0
    app.kubernetes.io/name: schautrack
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.1.9"
    app.kubernetes.io/managed-by: Helm
data:
  PORT: "3000"
  IMPRINT_URL: "/imprint"
  SMTP_PORT: "587"
  AI_DAILY_LIMIT: "10"
  UPDATE_CHECK_ENABLED: "true"
  ANDROID_PACKAGE_NAME: "to.schauer.schautrack"
---
```

### Case 4 — mirror vars + captcha threshold

```
$ helm template test helm/schautrack \
    --set config.updateCheck.provider=gitlab \
    --set config.updateCheck.repo=infra/mirrors/schautrack \
    --set config.updateCheck.baseUrl=https://gitlab.example.com \
    --set config.captcha.globalThreshold=25 | sed -n '/^kind: ConfigMap$/,/^---$/p'
kind: ConfigMap
metadata:
  name: test-schautrack
  labels:
    helm.sh/chart: schautrack-0.4.0
    app.kubernetes.io/name: schautrack
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.1.9"
    app.kubernetes.io/managed-by: Helm
data:
  PORT: "3000"
  IMPRINT_URL: "/imprint"
  SMTP_PORT: "587"
  AI_DAILY_LIMIT: "10"
  UPDATE_PROVIDER: "gitlab"
  UPDATE_REPO: "infra/mirrors/schautrack"
  UPDATE_BASE_URL: "https://gitlab.example.com"
  LOGIN_CAPTCHA_GLOBAL_THRESHOLD: "25"
  ANDROID_PACKAGE_NAME: "to.schauer.schautrack"
---
```

### Case 5 — nil maps (the case #369 hit)

```
$ helm template test helm/schautrack --set config.updateCheck=null --set config.captcha=null --set config.rateLimit=null | sed -n '/^kind: ConfigMap$/,/^---$/p'
kind: ConfigMap
metadata:
  name: test-schautrack
  labels:
    helm.sh/chart: schautrack-0.4.0
    app.kubernetes.io/name: schautrack
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.1.9"
    app.kubernetes.io/managed-by: Helm
data:
  PORT: "3000"
  IMPRINT_URL: "/imprint"
  SMTP_PORT: "587"
  AI_DAILY_LIMIT: "10"
  ANDROID_PACKAGE_NAME: "to.schauer.schautrack"
---
EXIT=0
```

No render error, no keys. `{{- with }}` handles the nil map.

### Cases 6–9 — values file, `--set-string`, `0`

```
########## CASE 6: -f values file with YAML boolean false ##########
  UPDATE_CHECK_ENABLED: "false"
########## CASE 7: -f values file with YAML boolean true ##########
  UPDATE_CHECK_ENABLED: "true"
########## CASE 8: --set-string (string "false") ##########
  UPDATE_CHECK_ENABLED: "false"
########## CASE 9: globalThreshold=0 (app ignores <=0 -> must omit) ##########
0
(0 occurrences = correctly omitted)
```

Case 6 is the GitOps path (`enabled: false` in a values file) and matters as much as case 2.

### The rendered value is a string, not a YAML bool

```
$ helm template test helm/schautrack --set config.updateCheck.enabled=false | python3 -c "..."
UPDATE_CHECK_ENABLED value='false' type=str
OK: parses as the string "false" -> app sees os.Getenv=="false" -> check disabled
```

### End-to-end: rendered ConfigMap → real `config.Load()`

Rather than stop at "the template emits the right string", a throwaway test rendered the chart and fed the resulting value into the actual Go config loader (test file deleted afterwards; not part of this diff):

```
=== RUN   TestRenderedConfigMapDisablesUpdateCheck
    args=[]                                          rendered=""(found=false)  cfg.UpdateCheckEnabled=true   cfg.UpdateProvider="github" cfg.UpdateRepo="schaurian/schautrack"
    args=[--set config.updateCheck.enabled=false]     rendered="false"(found=true)  cfg.UpdateCheckEnabled=false  cfg.UpdateProvider="github" cfg.UpdateRepo="schaurian/schautrack"
    args=[--set config.updateCheck.enabled=true]      rendered="true"(found=true)   cfg.UpdateCheckEnabled=true   cfg.UpdateProvider="github" cfg.UpdateRepo="schaurian/schautrack"
--- PASS: TestRenderedConfigMapDisablesUpdateCheck (0.14s)
```

The chart value actually flips `UpdateCheckEnabled` in the running application, and `handler.LatestVersion` skips the outbound request when it is false.

## Env-var coverage audit

Re-ran #368's methodology: every env var the app reads (`os.Getenv`, `os.LookupEnv`, `envOr`, and the `Env:` field of the admin-settings spec table) diffed against everything the chart templates (`configmap.yaml` + `secret.yaml`).

**Before this PR** — 8 unreachable. **After** — 3, all correctly so:

| Env var | Status | Why |
|---|---|---|
| `BUILD_VERSION` | correctly unreachable | Baked into the image by the Dockerfile (`ENV BUILD_VERSION=$BUILD_VERSION`, `ldflags -X main.version`). A chart value would let a deployment misreport its own version. Should stay unreachable. |
| `CAPTCHA_BYPASS` | **intentionally** unreachable | Test-only; removes all brute-force protection. Now documented as such in `values.yaml` and the chart README. |
| `TEST_DATABASE_URL` | N/A | Only read by `pool_test.go` / `weightgoal_test.go` to opt into integration tests. |
| `LOGIN_CAPTCHA_GLOBAL_THRESHOLD` | **fixed here** | `config.captcha.globalThreshold` |
| `UPDATE_BASE_URL` | **fixed here** | `config.updateCheck.baseUrl` |
| `UPDATE_CHECK_ENABLED` | **fixed here** | `config.updateCheck.enabled` |
| `UPDATE_PROVIDER` | **fixed here** | `config.updateCheck.provider` |
| `UPDATE_REPO` | **fixed here** | `config.updateCheck.repo` |

```
$ comm -23 <app env vars> <chart-settable>
BUILD_VERSION
CAPTCHA_BYPASS
TEST_DATABASE_URL
```

Reverse direction (chart sets something the app never reads) — one entry, correct:

```
$ comm -13 <app env vars> <chart-settable>
POSTGRES_PASSWORD     # consumed by the bundled postgres container, not the app
```

**50 app env vars, 48 chart-settable.** With this PR the chart reaches every runtime-configurable variable the application has.

Also confirmed the other two self-host paths are already complete, so the chart was the only one with a gap: `compose.yml` uses `env_file: .env`, so every variable is reachable, and `.env.example:77-86` already documents the whole `UPDATE_*` group.

## Docs

- Chart README: new "Opting out of the update check" walkthrough (privacy/air-gap opt-out + the self-hosted-mirror alternative), a "CAPTCHA" parameter section carrying the `CAPTCHA_BYPASS` warning, an "Update check" parameter table, and a `0.4.0` upgrade note.
- `values.yaml`: every new key commented with its env var, the app default, and why the boolean is special.

## Chart version

`0.3.0` → **`0.4.0`**, matching the convention #369 established: new backwards-compatible values are a minor bump, with a matching `### <version>` section under "Upgrading". Every new value defaults to empty, so upgrading changes no running behaviour.

## Follow-ups filed

- #398 — the canonical env table in the root `README.md` documents `UPDATE_CHECK_ENABLED` but omits `UPDATE_PROVIDER` / `UPDATE_REPO` / `UPDATE_BASE_URL`, even though `.env.example` and now the chart both expose them. Left out of this PR for scope discipline (diff confined to `helm/`).
- #400 — the chart has no `values.schema.json`, so a mistyped key (`config.updateCheck.enable`) silently renders nothing. Exactly the silent-no-op failure mode this PR fixes, one level up.

Out of scope and untouched, as instructed: `RATE_LIMIT_BARCODE` (#366, follow-up after #330).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
