### PR TITLE
ci: give every pushed commit its own concurrency group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,13 +36,31 @@ on:
       - 'cliff.toml'
       - '.github/workflows/build.yml'
 
-# Serialize runs per ref so two quick merges to the same branch cannot race:
-# without this, both runs compute the same next version from the same latest
-# tag and clobber each other's image/tag. Queue rather than cancel so an
-# in-flight image push is never interrupted.
+# One concurrency group per COMMIT, not per ref.
+#
+# GitHub keeps at most one *pending* run per concurrency group: "By default, any
+# existing `pending` job or workflow in the same concurrency group will be
+# canceled and the new queued job or workflow will take its place."
+# `cancel-in-progress: false` only protects the run that is already executing —
+# it does not queue the rest, which is what the previous version of this comment
+# claimed. So `group: build-${{ github.ref }}` silently threw CI away for every
+# merge in a burst except the first and the last: on 2026-08-08 four consecutive
+# `staging` merge commits ran ZERO jobs, and the resulting tip of `staging` was
+# never tested (issue #377). A test job that never runs protects nothing.
+#
+# Keying on the commit gives every pushed commit its own run, which can never be
+# evicted. The serialisation the old group was reaching for now lives on the
+# individual jobs that mutate shared state — see the `concurrency:` blocks on
+# create-tag (git tags), publish-helm (gh-pages) and notify-argocd (the deploy
+# nudge). test / compute-version / build-and-push / create-manifest are
+# deliberately NOT serialised; each of those explains why at the job.
+#
+# Pull requests keep one group per PR and DO cancel in progress: a superseded PR
+# run is wasted work whose result is about to be replaced anyway, and cancelling
+# it frees the runner.
 concurrency:
-  group: build-${{ github.ref }}
-  cancel-in-progress: false
+  group: build-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   REGISTRY: ghcr.io
@@ -131,6 +149,12 @@ jobs:
   compute-version:
     runs-on: ${{ github.ref == 'refs/heads/staging' && 'arc-runner' || 'ubuntu-latest' }}
     needs: test
+    # Deliberately not serialised: this job only *reads* git state. A group here
+    # would be theatre — it is released the moment the job ends, several jobs
+    # before create-tag writes anything, so two `main` runs would still derive
+    # the same version. Job-level concurrency cannot span a multi-job critical
+    # section; closing that gap needs the derivation moved into create-tag
+    # (issue #402).
     outputs:
       version: ${{ steps.version.outputs.version }}
       should_tag: ${{ steps.version.outputs.should_tag }}
@@ -210,6 +234,17 @@ jobs:
     # leaves a dangling version tag with no corresponding image or release.
     needs: [compute-version, create-manifest]
     if: needs.compute-version.outputs.should_tag == 'true'
+    # The git tag namespace is repository-wide and the workflow-level group is
+    # now per-commit, so two `main` runs can reach this job at the same time.
+    # Serialise the tag writes repo-wide (not per-ref: tags are not scoped to a
+    # branch).
+    # This orders the writes; it does NOT make version derivation atomic —
+    # compute-version read `git describe` several jobs earlier. Two `main`
+    # pushes inside one run window still derive the same version, and the second
+    # tag push then fails loudly instead of clobbering. Tracked in issue #402.
+    concurrency:
+      group: build-git-tags
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -229,6 +264,15 @@ jobs:
   build-and-push:
     runs-on: ${{ github.ref == 'refs/heads/staging' && 'arc-runner' || 'ubuntu-latest' }}
     needs: compute-version
+    # Deliberately not serialised. Two reasons:
+    #   1. This is a matrix job, and one job-level concurrency group is shared by
+    #      every matrix leg unless `matrix.platform` is part of the key — so a
+    #      naive group here would queue linux/arm64 behind linux/amd64 and, since
+    #      only one job may be pending per group, cancel one of them outright.
+    #   2. It needs no lock anyway: the image is pushed by digest
+    #      (push-by-digest=true, i.e. content-addressed), so overlapping pushes
+    #      are idempotent, and the human-readable tag is applied later by
+    #      create-manifest from this run's own digest artifacts.
     permissions:
       contents: read
       packages: write
@@ -302,6 +346,9 @@ jobs:
     # Only assemble/push the multi-arch manifest for push events — PR builds
     # do not push images, so there are no digests to reference.
     if: github.event_name == 'push'
+    # Deliberately not serialised: on staging the tag it writes is unique per run
+    # (staging-<run_number>), and the digests it consumes are this run's own
+    # upload-artifact output, so concurrent runs have nothing to contend over.
     permissions:
       contents: read
       packages: write
@@ -362,6 +409,10 @@ jobs:
     # manifest, so this transitively runs after create-manifest too).
     needs: [compute-version, create-tag]
     if: needs.compute-version.outputs.should_tag == 'true'
+    # Deliberately NOT put in the build-git-tags group: it is already ordered
+    # behind create-tag by `needs`, and sharing that group would let a later
+    # run's create-tag cancel this run's pending create-release, leaving a
+    # pushed tag with no GitHub release attached.
     permissions:
       contents: write
     steps:
@@ -438,6 +489,22 @@ jobs:
     # emits an 8-char SHA that is not valid semver (helm package would reject it),
     # and gh-pages must only be written by push events on main/staging.
     if: github.event_name == 'push'
+    # gh-pages is a single branch mutated by a plain `git push` with no rebase or
+    # retry, so two concurrent publishes mean one push is rejected
+    # non-fast-forward and that chart is lost. The group is repository-wide, not
+    # per-ref, because `main` and `staging` write different directories of the
+    # SAME branch — a collision the old per-ref workflow-level group never
+    # covered.
+    # Left on the default `queue: single`, so at most one publish is pending and
+    # a merge burst collapses to the newest chart. That is deliberate: the steps
+    # below `rm -f *.tgz` and re-index (last writer wins) while ArgoCD resolves
+    # `>=0.0.1` to the highest version, so publishing every chart in a burst
+    # would risk leaving the highest index entry pointing at a deleted file —
+    # GitHub does not guarantee queue ordering. Fix issue #405 before switching
+    # this to `queue: max`.
+    concurrency:
+      group: build-gh-pages
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -529,6 +596,15 @@ jobs:
     runs-on: ${{ github.ref == 'refs/heads/staging' && 'arc-runner' || 'ubuntu-latest' }}
     needs: [compute-version, publish-helm]
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'
+    # One deploy nudge per ref is enough. This job waits up to 15 minutes for
+    # GitHub Pages and then refreshes a single ArgoCD application; in a merge
+    # burst only the newest chart is worth deploying, and serialising per ref
+    # also stops several 15-minute waits from parking on the single self-hosted
+    # runner (issue #406). Dropping a superseded nudge is safe: every step here
+    # is already best-effort and ArgoCD polls the Helm repo every ~3 minutes.
+    concurrency:
+      group: build-argocd-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       contents: write # push an empty gh-pages commit when a Pages deployment fails
     steps:


### PR DESCRIPTION
Closes #377

## The bug

```yaml
concurrency:
  group: build-${{ github.ref }}
  cancel-in-progress: false
```

with the comment *"Queue rather than cancel so an in-flight image push is never interrupted."*

It does not queue. From the Actions docs (`concurrency` and `jobs.<job_id>.concurrency`, identical wording in both):

> When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be `pending`. **By default, any existing `pending` job or workflow in the same concurrency group will be canceled and the new queued job or workflow will take its place.**

`cancel-in-progress: false` only protects the run that is already *executing*. It says nothing about the pending slot, of which there is exactly one. So the third run in a burst evicts the second, the fourth evicts the third, and so on.

### Evidence, `staging`, 2026-08-08 06:45–06:52 UTC

| Commit | Result | Jobs run |
|---|---|---|
| `ef9aca83` | success | 8 |
| `454c041e` | **cancelled** | **0** |
| `fe3e1f0a` | **cancelled** | **0** |
| `4e3e182e` | **cancelled** | **0** |
| `a3209c23` | **cancelled** | **0** |
| `5aaf0e21` | success | 8 |

Four consecutive merge commits got zero CI, and `a3209c23` — the tip of `staging` after the burst — was never tested. The same pattern is visible at 05:54 (`cbbbc069`, `5c52a1bd`), at 06:56/07:00 (`436f4978`, `63698cbe`, `b066322e`), and on `main` at 15:06 on 2026-04-11 (run `24285184869`, `jobs_run=0`). This is not rare and it is not staging-only.

This defeats the real Postgres service just merged in #325, and it would defeat the `e2e` job in #328 the same way: a test job that never runs on the merge commit protects nothing.

## The design

**Workflow level — one group per commit for pushes, one group per PR for pull requests.**

```yaml
concurrency:
  group: build-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.sha }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

A per-commit group has exactly one member, so eviction becomes structurally impossible: every pushed commit gets its run. PRs keep a stable per-PR group and now *do* cancel in progress, because a superseded PR run is wasted work whose verdict is about to be replaced — and cancelling it frees the runner. `cancel-in-progress` as an expression is documented ("you can specify `cancel-in-progress` as an expression with any of the allowed expression contexts").

**Job level — one group per shared mutable resource, on the three jobs that actually write one.**

| Job | Group | Resource it protects |
|---|---|---|
| `create-tag` | `build-git-tags` | the repository-wide git tag namespace |
| `publish-helm` | `build-gh-pages` | the `gh-pages` branch |
| `notify-argocd` | `build-argocd-${{ github.ref }}` | the ArgoCD application for that ref |

Note `build-gh-pages` is deliberately **not** ref-scoped. `main` writes `/` and `staging` writes `/staging/` of the *same branch*, so they collide — a collision the old per-ref workflow group never covered, since different refs are different groups. This is a strict improvement over both the old config and no config.

### Why not the alternatives

**Why not just fix the comment and accept it?** (Option 1 in the issue.) Because #325 and #328 are spending real CI time on tests that the merge commit never runs. Documenting that away would make the tests decorative.

**Why not `queue: max` at the workflow level?** It is real and documented (`single` is the default; `max` allows up to 100 pending) and it would make the original comment literally true. Two reasons against it here:
- It cannot coexist with the PR-cancellation half of this fix: *"The combination of `queue: max` and `cancel-in-progress: true` is not allowed and will result in a workflow validation error."* One `concurrency:` block takes one `queue` value, so keeping PR cancellation rules it out.
- It serialises whole runs. A staging run occupies the runner for ~7 minutes end to end; 20 merges in a day would put the tip hours behind.

**Why not `queue: max` on `publish-helm`, where it would fit?** Because the job is not order-safe. It does `rm -f "$CHANNEL_PATH"/*.tgz` and then `helm repo index --merge`, so only one `.tgz` ever exists while the index keeps every historical entry — it works solely because the highest version is always the last published. The docs are explicit that the queue does not guarantee that:

> Jobs or workflow runs in the same concurrency group are processed in first-in-first-out (FIFO) order according to the time each one started waiting on the concurrency group, not the time each workflow was dispatched. **Since the actual start time of a job or run may vary, ordering is not guaranteed.**

Publishing every chart in a burst out of order would leave the highest index entry pointing at a deleted file and ArgoCD would 404. The default `queue: single` approximates "newest wins", which matches both the step's last-writer-wins design and ArgoCD's `>=0.0.1` → highest-version resolution. #405 tracks making the job order-safe; after that it can move to `queue: max` and every commit gets its chart.

**Why not a group on `build-and-push`,** which the issue and the brief both suggested? Two reasons, both recorded at the job:
1. It is a matrix job. A job-level group is shared by every matrix leg unless `matrix.platform` is part of the key, so a naive group would queue `linux/arm64` behind `linux/amd64` and — one pending per group — cancel one of the two platforms outright.
2. It needs no lock. The image is pushed with `push-by-digest=true`, i.e. content-addressed, so overlapping pushes are idempotent; the human-readable tag is applied later by `create-manifest` from this run's own digest artifacts.

**Why not a group on `compute-version`?** It would be theatre. A job-level group is acquired and released *per job*, so it cannot span a multi-job critical section: run B's `compute-version` still slots into the gap between run A's `compute-version` and run A's `create-tag`, several jobs later, and still reads the same `git describe`. See "known gap" below.

**Why is `create-release` not in `build-git-tags`?** Sharing the group would let a later run's `create-tag` cancel this run's *pending* `create-release`, leaving a pushed tag with no GitHub release. It is already ordered behind `create-tag` by `needs`.

**Why is `notify-argocd` grouped but allowed to drop work?** It waits up to 15 minutes for GitHub Pages and then refreshes one ArgoCD app. In a burst only the newest chart is worth deploying, and every step in it is already explicitly best-effort with ArgoCD polling the Helm repo every ~3 minutes regardless. Grouping it also keeps five 15-minute sleep loops from parking on the single self-hosted runner.

## The three scenarios

**1. Five merges to `staging` in two minutes.** Five distinct groups (`build-refs/heads/staging-<sha>`), so nothing is evicted and all five runs execute `test` — including the burst's tip, which today runs nothing. The five `publish-helm` jobs contend for `build-gh-pages`: one runs, one pends, and later arrivals evict the pending one, so an intermediate chart can still be dropped. That is no worse than today (today those runs are cancelled outright, chart included) and it is the behaviour the current `publish-helm` implementation actually wants until #405 lands. Same for `notify-argocd`. A run whose `publish-helm` is evicted ends as *cancelled* — but with its `test`/`build-and-push` jobs green and visible, which is exactly the signal #377 says is missing. `create-tag`/`create-release` do not run on staging at all (`should_tag=false`).

Practical caveat: this converts cancelled work into queued work on a scale set with `maxRunners: 1` (#406). Nothing is lost — queued self-hosted jobs wait, they are not cancelled — but a 5-merge burst becomes ~35 minutes of serial runner time instead of ~14. Measured occupancy per staging run is ~7 minutes (`test` ~1m45, `build-and-push` ~3m, remainder ~1m, plus ~18s runner spin-up between jobs).

**2. A PR receiving three pushes in a minute.** All three share `build-refs/pull/N/merge-pr`. Push 2 queues, evicting nothing (nothing was pending), and `cancel-in-progress: true` cancels push 1's in-flight run; push 3 does the same to push 2. Only the newest merge commit is tested, which is the correct verdict for a PR and is a genuine improvement — today `cancel-in-progress: false` leaves superseded PR runs burning a runner to completion. Nothing release-critical runs on PRs (`publish-helm` and `create-manifest` are gated on `github.event_name == 'push'`, `create-tag` on `should_tag`).

**3. Two merges whose `build-and-push` jobs would otherwise overlap.** They do overlap, by design. Both push by digest to GHCR, which is content-addressed, so concurrent pushes of the same digest are idempotent and of different digests are distinct blobs; neither can clobber the other. Each run's `create-manifest` reads only its own `digests-*` artifacts and, on staging, writes a tag unique to its run (`staging-<run_number>`). The one place two overlapping runs would genuinely collide, the `gh-pages` push in `publish-helm`, is now serialised repository-wide — including the `main`-versus-`staging` case the old per-ref group never covered.

## Verification

```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/build.yml')); ..."
jobs: ['test', 'compute-version', 'create-tag', 'build-and-push', 'create-manifest', 'create-release', 'publish-helm', 'notify-argocd']
top concurrency: {'group': "build-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.sha }}",
                  'cancel-in-progress': "${{ github.event_name == 'pull_request' }}"}
  create-tag     -> {'group': 'build-git-tags', 'cancel-in-progress': False}
  publish-helm   -> {'group': 'build-gh-pages', 'cancel-in-progress': False}
  notify-argocd  -> {'group': 'build-argocd-${{ github.ref }}', 'cancel-in-progress': False}

$ actionlint .github/workflows/build.yml     # v1.7.12
exit=0

$ export GOFLAGS=-p=2 GOMAXPROCS=2 && go build ./... && go test ./...
go build OK
ok schautrack/cmd/server, internal/{clientip,database,handler,middleware,openapi,release,service,session,sse}
go test exit=0
```

`actionlint` reports two pre-existing `label "arc-runner" is unknown` errors in `cleanup.yml` and `renovate.yml`. Confirmed identical against `origin/staging` before this change; `build.yml` escapes them only because its `runs-on` is an expression. Not touched here.

Expression evaluation traced by hand: on `push`, `false && 'pr'` → `false`, `false || github.sha` → the SHA; on `pull_request`, `true && 'pr'` → `'pr'` (non-empty, so the `||` short-circuit idiom is safe), giving a group stable across pushes to the PR.

## What is NOT verified

**The runtime behaviour is unproven until this actually runs.** I cannot make GitHub schedule a burst, so scenarios 1–3 are reasoned from the documented semantics quoted above, not observed. Specifically unproven: that a per-commit group really is never evicted, that `cancel-in-progress` as an expression evaluates per-event the way the docs describe, and that job-level eviction on `publish-helm` behaves as the shared workflow/job group model implies.

The syntax half *is* self-verifying: `.github/workflows/build.yml` is in this workflow's own `paths:` filter, so opening this PR triggers a run against the new file, and an invalid `concurrency:` key or expression would fail workflow validation immediately and visibly. **Please confirm this PR's own check ran before merging** — and the real proof is the next merge burst on `staging`: every commit should show a `test` job, with at most the `publish-helm`/`notify-argocd` tail collapsed.

Also unverified: the `TestIntegrationTestsRunInCI` tripwire from #325 passes locally only because `CI` is unset; its real assertion (that `TEST_DATABASE_URL` is set) is exercised for the first time by this PR's own run.

## Known gaps, filed separately

- **#402** — `compute-version` reads `git describe` and `create-tag` writes the tag in *different jobs*, so the critical section spans the whole run and job-level concurrency cannot make it atomic. Whole-run serialisation used to hide this; per-commit groups expose it, so two `main` pushes inside one run window now both derive the same version and the second tag push fails loudly (git refuses a conflicting tag — noisy, not corrupting). `main` pushes do cluster: 2026-04-11 ×5, 2026-07-03 ×2, 2026-02-17 ×2. Fix is to derive the version inside `create-tag` after `git fetch --tags` and retry on collision.
- **#405** — `publish-helm`'s `gh-pages` push has no rebase/retry, and `rm -f *.tgz` + `--merge` makes chart publishing order-dependent. Blocks `queue: max` here.
- **#406** — the `arc-runner` scale set is `maxRunners: 1`, so all staging CI is serialised on one runner. Correctness does not depend on this value — that is why the job-level groups above are explicit rather than implied by runner capacity — but it sets the wall-clock cost of per-commit CI.

## Scope

Only the `concurrency` configuration and its comments. No steps, jobs, or dependencies changed. #328 adds an `e2e` job to this file: it needs **no** job-level `concurrency` — it is a test job, and per-commit grouping at the workflow level is exactly what makes it run on every merge commit. Nothing in #328 or #379 is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
