### PR TITLE
fix: reject a bare `null` v1 request body instead of treating it as `{}`

### DIFF
--- a/internal/handler/v1_common.go
+++ b/internal/handler/v1_common.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -104,59 +105,100 @@ func (o Optional[T]) MarshalJSON() ([]byte, error) {
 // a payload remotely that size, so it gets a tighter bound of its own.
 const maxV1Body = 1 << 20
 
-// decodeV1 reads a JSON body into dst, rejecting unknown fields.
+// decodeV1 reads a JSON body into dst, requiring it to be a single JSON object
+// and rejecting unknown fields.
 //
 // DisallowUnknownFields is the deliberate choice here. A public API that
 // silently ignores `{"calorie": 500}` (note the typo) hands the caller a
 // success response and drops their data. Failing with a message naming the
 // unknown field turns a silent data-loss bug into an obvious 400.
+//
+// It decodes in two passes, which looks redundant and is not. Decoding the
+// body straight into dst cannot distinguish a bare `null` from `{}`:
+// encoding/json treats a top-level null literal as "leave the destination
+// alone", so Decode returns no error, dst stays zero-valued, and the handler
+// runs as though the caller had sent an empty object. On the PUT-replace
+// endpoints a zero-valued struct is a destructive instruction — `Content: ""`
+// on PUT /notes/{date} means "delete this note" — so a body carrying no
+// instruction at all deleted a note and returned 200. That is the same silent
+// data loss DisallowUnknownFields exists to prevent, so a top-level value that
+// is not an object is refused before dst is ever touched.
 func decodeV1(w http.ResponseWriter, r *http.Request, dst any) *apierr.Problem {
 	if r.Body == nil {
 		return apierr.BadRequest("A JSON request body is required.")
 	}
 	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxV1Body))
-	dec.DisallowUnknownFields()
 
-	if err := dec.Decode(dst); err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			return apierr.New(http.StatusRequestEntityTooLarge, "body-too-large",
-				"Request body too large",
-				fmt.Sprintf("The request body exceeds the %d byte limit.", maxV1Body))
-		}
-		var typeErr *json.UnmarshalTypeError
-		if errors.As(err, &typeErr) {
-			// Field is empty when the mismatch is the body itself rather than
-			// one of its fields — a bare array, string or number where an
-			// object belongs. There is nothing to put in invalid_params[].name
-			// then, and typeErr.Type is the destination *Go* type, so the old
-			// 422 answered `{"name": "", "reason": "expected handler.v1EntryInput"}`:
-			// useless to the caller and a leak of an internal type name into a
-			// public response. That is a malformed body, exactly like the
-			// multi-value case below, so it gets the same 400.
-			if typeErr.Field == "" {
-				return apierr.BadRequest("The request body must be a JSON object.")
-			}
-			return apierr.Unprocessable("A field has the wrong type.",
-				apierr.InvalidParam{
-					Name:   typeErr.Field,
-					Reason: fmt.Sprintf("expected %s", typeErr.Type.String()),
-				})
-		}
-		// json's unknown-field error is only available as a string; converting
-		// it here is what lets the caller see WHICH field they misspelled.
-		if field, ok := strings.CutPrefix(err.Error(), "json: unknown field "); ok {
-			return apierr.BadRequest("Unknown field " + field + ".")
-		}
-		return apierr.BadRequest("The request body is not valid JSON.")
+	// Pass 1 reads the body as an uninterpreted value. This is where the size
+	// limit and JSON syntax are enforced — both have to win over the shape
+	// check below, because a body that cannot be read has no shape to report.
+	var raw json.RawMessage
+	if err := dec.Decode(&raw); err != nil {
+		return decodeV1Problem(err)
 	}
 
-	// A second Decode must hit EOF; anything else means the caller sent more
-	// than one JSON value and half of it would be ignored.
+	// Decode strips leading whitespace, so raw starts at the value itself. An
+	// array, string, number, boolean or null gets the same 400 as the
+	// multi-value case below: the caller sent something that is not a request
+	// body for this endpoint, and saying which shape was expected is the only
+	// actionable thing to tell them.
+	if len(raw) == 0 || raw[0] != '{' {
+		return apierr.BadRequest("The request body must be a JSON object.")
+	}
+
+	// Pass 2 fills dst from the object. It runs over the bytes pass 1 already
+	// read, so the body is never read twice.
+	obj := json.NewDecoder(bytes.NewReader(raw))
+	obj.DisallowUnknownFields()
+	if err := obj.Decode(dst); err != nil {
+		return decodeV1Problem(err)
+	}
+
+	// A second Decode on the *body* must hit EOF; anything else means the
+	// caller sent more than one JSON value and half of it would be ignored.
+	// Checked last so that a malformed first object is reported as the field
+	// error it is rather than as a multi-value body.
 	if dec.More() {
 		return apierr.BadRequest("The request body must contain exactly one JSON object.")
 	}
 	return nil
+}
+
+// decodeV1Problem maps an encoding/json failure onto a problem detail. Shared
+// by both decodeV1 passes: the size and syntax errors can only come from the
+// first, the field-level ones only from the second, and keeping one mapping
+// means the two passes cannot drift into reporting the same fault differently.
+func decodeV1Problem(err error) *apierr.Problem {
+	var maxErr *http.MaxBytesError
+	if errors.As(err, &maxErr) {
+		return apierr.New(http.StatusRequestEntityTooLarge, "body-too-large",
+			"Request body too large",
+			fmt.Sprintf("The request body exceeds the %d byte limit.", maxV1Body))
+	}
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		// Field is empty when the mismatch is the body itself rather than one
+		// of its fields. decodeV1's own shape check now catches that case
+		// first, so this branch is a backstop for a dst that is not a struct;
+		// it stays because typeErr.Type is the destination *Go* type, and
+		// answering `{"name": "", "reason": "expected handler.v1EntryInput"}`
+		// is both useless to the caller and a leak of an internal type name
+		// into a public response.
+		if typeErr.Field == "" {
+			return apierr.BadRequest("The request body must be a JSON object.")
+		}
+		return apierr.Unprocessable("A field has the wrong type.",
+			apierr.InvalidParam{
+				Name:   typeErr.Field,
+				Reason: fmt.Sprintf("expected %s", typeErr.Type.String()),
+			})
+	}
+	// json's unknown-field error is only available as a string; converting it
+	// here is what lets the caller see WHICH field they misspelled.
+	if field, ok := strings.CutPrefix(err.Error(), "json: unknown field "); ok {
+		return apierr.BadRequest("Unknown field " + field + ".")
+	}
+	return apierr.BadRequest("The request body is not valid JSON.")
 }
 
 // pathDate reads and validates a YYYY-MM-DD path parameter.

--- a/internal/handler/v1_common_test.go
+++ b/internal/handler/v1_common_test.go
@@ -193,15 +193,25 @@ func TestDecodeV1(t *testing.T) {
 			wantDetail: "The request body must be a JSON object.",
 		},
 		{
-			// KNOWN GAP, pinned rather than fixed here: encoding/json treats a
-			// null literal as "leave the destination alone", so decodeV1
-			// accepts it and the handler proceeds with a zero-valued struct —
-			// indistinguishable from `{}`. On PUT /api/v1/notes/{date} that
-			// means a body of `null` deletes the note. Tracked separately; if
-			// this case starts failing because null is now rejected, that is
-			// the fix landing and this expectation should flip.
-			name:    "bare JSON null is accepted as an empty object",
-			body:    `null`,
+			// Was accepted, and that was the data-loss bug in #347:
+			// encoding/json treats a null literal as "leave the destination
+			// alone", so Decode returned no error and the handler ran on a
+			// zero-valued struct — indistinguishable from `{}`. On
+			// PUT /api/v1/notes/{date} that deleted the note and answered 200.
+			// A null is not an object, so it lands in the same bucket as a
+			// bare array. See TestPutNoteV1RejectsNullBody.
+			name:       "bare JSON null",
+			body:       `null`,
+			wantStatus: http.StatusBadRequest,
+			wantSlug:   "bad-request",
+			wantDetail: "The request body must be a JSON object.",
+		},
+		{
+			// Not a special case of the above: `null` inside a field is a
+			// perfectly good instruction ("this field has no value") and must
+			// keep working. Only the top-level literal is refused.
+			name:    "null in a field is not a null body",
+			body:    `{"name":null,"calories":null}`,
 			wantDst: v1CommonTestBody{},
 		},
 	}
@@ -283,6 +293,35 @@ func paramReasons(p *apierr.Problem) []string {
 	return out
 }
 
+// TestDecodeV1EmptyObjectIsNotRejected pins the deliberate line drawn in #347.
+//
+// `{}` and `null` both leave dst zero-valued, so it is tempting to reject both
+// together. They are not the same request:
+//
+//   - `{}` IS a JSON object. It says "here is the resource, with every field at
+//     its default" — a complete, well-formed statement. On a PUT whole-content
+//     replace, `PUT /notes/{date}` with `{}` meaning "this note has no content"
+//     is a defensible reading, and it is the same one `{"content":""}` gets.
+//   - `null` is not an object at all. It carries no statement about the
+//     resource, which is exactly why acting on it is wrong.
+//
+// Rejecting `{}` as well would be a second behavioural change, would break
+// every caller that sends `{}` to a PATCH to mean "no-op" (they get the
+// existing 400 "contained no updatable fields", which already tells them so),
+// and belongs in the individual handlers — a note whose `content` key must be
+// present is a v1NoteInput decision, not a decodeV1 one. Tracked separately.
+func TestDecodeV1EmptyObjectIsNotRejected(t *testing.T) {
+	var dst v1CommonTestBody
+	got := decodeV1(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPut, "/", strings.NewReader(`{}`)), &dst)
+	if got != nil {
+		t.Fatalf("decodeV1(`{}`) = %d %q, want success — #347 fixed null only", got.Status, got.Detail)
+	}
+	if dst != (v1CommonTestBody{}) {
+		t.Errorf("dst = %+v, want the zero value", dst)
+	}
+}
+
 // TestDecodeV1UnknownFieldBeatsOtherErrors pins the ordering inside decodeV1:
 // the unknown-field string match runs after the typed checks, so a body that
 // is both oversize and wrong-typed reports the size first. Ordering matters
@@ -306,6 +345,55 @@ func TestDecodeV1ErrorPrecedence(t *testing.T) {
 	}
 	if got.Detail != `Unknown field "nope".` {
 		t.Errorf("detail = %q, want the unknown field named", got.Detail)
+	}
+
+	// --- ordering around the top-level "must be an object" check ------------
+	//
+	// #347 split decodeV1 into two parses: the body is read as a raw value and
+	// checked for being an object before the fields are decoded into dst. That
+	// moves the top-level shape check ahead of the unknown-field and
+	// wrong-type checks, so the cases below pin where it sits relative to each
+	// of the other four.
+
+	// Size still wins: an oversize body is refused before anyone asks what
+	// shape it is, because the shape cannot be known without reading it all.
+	got = decodeV1(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/",
+			strings.NewReader(`["`+strings.Repeat("x", maxV1Body)+`"]`)), &dst)
+	if got == nil || got.Status != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversize bare array = %v, want 413", got)
+	}
+
+	// A syntax error wins for the same reason — there is no value to inspect.
+	got = decodeV1(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`[1,`)), &dst)
+	if got == nil || got.Detail != "The request body is not valid JSON." {
+		t.Fatalf("truncated bare array = %v, want the not-valid-JSON detail", got)
+	}
+
+	// The shape check wins over the multi-value check. Both are 400s and both
+	// say the body is malformed; naming the shape is the more useful of the
+	// two, and this is the pre-#347 answer for a bare array followed by
+	// garbage, kept unchanged.
+	for _, body := range []string{`[1,2]{}`, `null{}`, `42 42`} {
+		got = decodeV1(httptest.NewRecorder(),
+			httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), &dst)
+		if got == nil || got.Status != http.StatusBadRequest {
+			t.Fatalf("decodeV1(%q) = %v, want 400", body, got)
+		}
+		if got.Detail != "The request body must be a JSON object." {
+			t.Errorf("decodeV1(%q) detail = %q, want the must-be-an-object detail", body, got.Detail)
+		}
+	}
+
+	// ...but the multi-value check still wins over the field-level checks, so
+	// an object with a bad field followed by a second object reports the field.
+	// Pinned because the two parses could easily have been ordered the other
+	// way round, which would have changed this answer.
+	got = decodeV1(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"nope":1}{}`)), &dst)
+	if got == nil || got.Detail != `Unknown field "nope".` {
+		t.Fatalf("unknown field in the first of two objects = %v, want the field named", got)
 	}
 }
 

--- a/internal/handler/v1_common_test.go
+++ b/internal/handler/v1_common_test.go
@@ -70,6 +70,17 @@ func TestDecodeV1(t *testing.T) {
 			wantDst: v1CommonTestBody{},
 		},
 		{
+			// Load-bearing for the shape check added in #347, which tests the
+			// FIRST byte of the decoded raw value. json.Decoder.Decode skips
+			// leading whitespace, so that byte is the '{' and not a space —
+			// but if it ever did not, every pretty-printed or newline-prefixed
+			// body would be wrongly refused as "not a JSON object". Pinned
+			// because a client that indents its payload is entirely ordinary.
+			name:    "leading whitespace before the object is fine",
+			body:    "\n\t  {\"name\":\"apple\",\"calories\":95}\n",
+			wantDst: v1CommonTestBody{Name: "apple", Calories: 95},
+		},
+		{
 			// The whole point of the manual strings.CutPrefix: a typo'd field
 			// must come back named, not as a generic parse failure.
 			name:       "unknown field is a 400 that names the field",

--- a/internal/handler/v1_null_body_test.go
+++ b/internal/handler/v1_null_body_test.go
@@ -1,0 +1,292 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"schautrack/internal/apierr"
+	"schautrack/internal/database"
+	"schautrack/internal/middleware"
+	"schautrack/internal/model"
+)
+
+// Regression tests for #347, at the level where the bug actually cost data.
+//
+// The unit-level pin lives in v1_common_test.go ("bare JSON null"), but a
+// parser test cannot show that the parser was destroying rows. These drive the
+// two v1 handlers where a zero-valued input is read as a *destructive
+// instruction* — PUT /notes/{date} and PUT /todos/{id}/completions/{date} —
+// against a real database, and assert the row is still there afterwards.
+//
+// Both also assert the intended delete still works, so a fix that turns
+// decodeV1 into a blanket rejection of empty-ish bodies fails here rather than
+// shipping a second regression.
+//
+// Skipped unless TEST_DATABASE_URL is set, matching internal/database's
+// integration tests. CI sets it.
+
+// v1TestDB opens the integration pool and runs the migrations, or skips.
+func v1TestDB(t *testing.T) (context.Context, *pgxpool.Pool) {
+	t.Helper()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	t.Cleanup(cancel)
+
+	// database.NewPool, not a bare pgxpool.New: the production pool registers a
+	// codec that scans DATE columns straight into string (see
+	// database.dateStringCodec), and several v1 handlers scan into a string
+	// date field. A plain pool makes those handlers fail with a scan error that
+	// cannot happen in the running app — a test harness that manufactures its
+	// own bugs is worse than no test.
+	pool, err := database.NewPool(ctx, url)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	if err := database.InitSchemaWithRetry(ctx, pool, 1); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+	return ctx, pool
+}
+
+// v1TestUser seeds a user with notes enabled and removes it afterwards.
+func v1TestUser(t *testing.T, ctx context.Context, pool *pgxpool.Pool, email string) *model.User {
+	t.Helper()
+	cleanup := func() { pool.Exec(ctx, `DELETE FROM users WHERE email = $1`, email) }
+	cleanup()
+	t.Cleanup(cleanup)
+
+	var id int
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email, password_hash, email_verified, notes_enabled, timezone)
+		 VALUES ($1, 'x', true, true, 'UTC') RETURNING id`, email).Scan(&id); err != nil {
+		t.Fatalf("seeding the user failed: %v", err)
+	}
+	tz := "UTC"
+	return &model.User{ID: id, Email: email, Timezone: &tz}
+}
+
+// v1PutJSON drives a v1 handler with a raw body and the given path params.
+func v1PutJSON(ctx context.Context, h http.HandlerFunc, u *model.User, path, body string,
+	params map[string]string) *httptest.ResponseRecorder {
+	rctx := chi.NewRouteContext()
+	for k, v := range params {
+		rctx.URLParams.Add(k, v)
+	}
+	c := context.WithValue(middleware.WithTestUser(ctx, u), chi.RouteCtxKey, rctx)
+
+	r := httptest.NewRequest(http.MethodPut, path, strings.NewReader(body)).WithContext(c)
+	rec := httptest.NewRecorder()
+	h(rec, r)
+	return rec
+}
+
+// assertProblem decodes a problem+json body and checks the status and detail.
+func assertProblem(t *testing.T, rec *httptest.ResponseRecorder, wantStatus int, wantDetail string) {
+	t.Helper()
+	if rec.Code != wantStatus {
+		t.Fatalf("status = %d, want %d (body %s)", rec.Code, wantStatus, rec.Body.String())
+	}
+	// Invariant #3: every v1 error is problem+json, including this new one.
+	if ct := rec.Header().Get("Content-Type"); ct != apierr.ContentType {
+		t.Errorf("Content-Type = %q, want %q", ct, apierr.ContentType)
+	}
+	var p apierr.Problem
+	if err := json.Unmarshal(rec.Body.Bytes(), &p); err != nil {
+		t.Fatalf("response is not JSON: %v (body %s)", err, rec.Body.String())
+	}
+	if p.Detail != wantDetail {
+		t.Errorf("detail = %q, want %q", p.Detail, wantDetail)
+	}
+	if p.Status != wantStatus {
+		t.Errorf("problem.status = %d, want %d", p.Status, wantStatus)
+	}
+}
+
+// TestPutNoteV1RejectsNullBody is the data-loss case from #347.
+//
+// A client wrapper that serialises "no payload" as `json.dumps(None)` sends the
+// four bytes `null`. Before the fix decodeV1 accepted them, PutNoteV1 saw
+// Content == "" and ran DELETE FROM daily_notes, and the caller got a 200 —
+// the note was gone and nothing in the exchange said so.
+func TestPutNoteV1RejectsNullBody(t *testing.T) {
+	ctx, pool := v1TestDB(t)
+	user := v1TestUser(t, ctx, pool, "v1-null-note@handler.test")
+	h := &V1Handler{Pool: pool}
+
+	const date = "2026-08-08"
+	const content = "buy oat milk"
+	seed := func() {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO daily_notes (user_id, note_date, content) VALUES ($1, $2, $3)
+			 ON CONFLICT (user_id, note_date) DO UPDATE SET content = EXCLUDED.content`,
+			user.ID, date, content); err != nil {
+			t.Fatalf("seeding the note failed: %v", err)
+		}
+	}
+	read := func() (string, bool) {
+		var got string
+		err := pool.QueryRow(ctx,
+			`SELECT content FROM daily_notes WHERE user_id = $1 AND note_date = $2`,
+			user.ID, date).Scan(&got)
+		if err != nil {
+			return "", false
+		}
+		return got, true
+	}
+	put := func(body string) *httptest.ResponseRecorder {
+		return v1PutJSON(ctx, h.PutNoteV1, user, "/api/v1/notes/"+date, body,
+			map[string]string{"date": date})
+	}
+
+	t.Run("null body leaves the note intact", func(t *testing.T) {
+		seed()
+		rec := put(`null`)
+		assertProblem(t, rec, http.StatusBadRequest, "The request body must be a JSON object.")
+
+		got, ok := read()
+		if !ok {
+			t.Fatal("a body of `null` deleted the note — #347 has regressed")
+		}
+		if got != content {
+			t.Errorf("content = %q, want %q unchanged", got, content)
+		}
+	})
+
+	t.Run("null body with whitespace is still rejected", func(t *testing.T) {
+		seed()
+		rec := put("  \n null \n ")
+		assertProblem(t, rec, http.StatusBadRequest, "The request body must be a JSON object.")
+		if _, ok := read(); !ok {
+			t.Fatal("a whitespace-padded `null` deleted the note")
+		}
+	})
+
+	t.Run("a real note still saves", func(t *testing.T) {
+		seed()
+		rec := put(`{"content":"eggs"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+		}
+		got, ok := read()
+		if !ok || got != "eggs" {
+			t.Errorf("note = %q, %v; want %q saved", got, ok, "eggs")
+		}
+	})
+
+	t.Run("an explicit empty content still deletes", func(t *testing.T) {
+		// The intended delete path. A fix that made decodeV1 refuse anything
+		// yielding a zero-valued struct would break this.
+		seed()
+		rec := put(`{"content":""}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+		}
+		if got, ok := read(); ok {
+			t.Errorf("note still present with content %q, want it deleted", got)
+		}
+	})
+
+	t.Run("an empty object still deletes", func(t *testing.T) {
+		// The deliberate line from #347, pinned here as well as in
+		// TestDecodeV1EmptyObjectIsNotRejected: `{}` is an object and keeps its
+		// pre-fix meaning on this whole-content-replace PUT. Only `null` — not
+		// an object, and carrying no statement about the note — changed. If
+		// this endpoint should instead require the `content` key, that is a
+		// v1NoteInput change and its own reviewed decision.
+		seed()
+		rec := put(`{}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+		}
+		if got, ok := read(); ok {
+			t.Errorf("note still present with content %q; `{}` behaviour changed as a side effect", got)
+		}
+	})
+}
+
+// TestSetTodoCompletionV1RejectsNullBody is the second destructive endpoint
+// #347 reaches: a zero-valued v1CompletionInput is Completed:false, which is
+// "un-complete this todo" — it deletes the completion row and breaks the
+// streak the user was keeping.
+func TestSetTodoCompletionV1RejectsNullBody(t *testing.T) {
+	ctx, pool := v1TestDB(t)
+	user := v1TestUser(t, ctx, pool, "v1-null-todo@handler.test")
+	h := &V1Handler{Pool: pool}
+
+	const date = "2026-08-08"
+	var todoID int
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO todos (user_id, name, schedule) VALUES ($1, 'stretch', '{"type":"daily"}')
+		 RETURNING id`, user.ID).Scan(&todoID); err != nil {
+		t.Fatalf("seeding the todo failed: %v", err)
+	}
+
+	seed := func() {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO todo_completions (todo_id, user_id, completion_date) VALUES ($1, $2, $3)
+			 ON CONFLICT DO NOTHING`, todoID, user.ID, date); err != nil {
+			t.Fatalf("seeding the completion failed: %v", err)
+		}
+	}
+	completed := func() bool {
+		var ok bool
+		if err := pool.QueryRow(ctx,
+			`SELECT EXISTS(SELECT 1 FROM todo_completions
+			  WHERE todo_id = $1 AND user_id = $2 AND completion_date = $3)`,
+			todoID, user.ID, date).Scan(&ok); err != nil {
+			t.Fatalf("reading the completion back failed: %v", err)
+		}
+		return ok
+	}
+	put := func(body string) *httptest.ResponseRecorder {
+		return v1PutJSON(ctx, h.SetTodoCompletionV1, user,
+			"/api/v1/todos/x/completions/"+date, body,
+			map[string]string{"id": strconv.Itoa(todoID), "date": date})
+	}
+
+	t.Run("null body leaves the completion intact", func(t *testing.T) {
+		seed()
+		rec := put(`null`)
+		assertProblem(t, rec, http.StatusBadRequest, "The request body must be a JSON object.")
+		if !completed() {
+			t.Fatal("a body of `null` cleared the completion — #347 has regressed")
+		}
+	})
+
+	t.Run("an explicit false still un-completes", func(t *testing.T) {
+		seed()
+		rec := put(`{"completed":false}`)
+		if rec.Code != http.StatusOK && rec.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want 2xx (body %s)", rec.Code, rec.Body.String())
+		}
+		if completed() {
+			t.Error("completion still present after an explicit completed:false")
+		}
+	})
+
+	t.Run("an explicit true still completes", func(t *testing.T) {
+		rec := put(`{"completed":true}`)
+		if rec.Code != http.StatusOK && rec.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want 2xx (body %s)", rec.Code, rec.Body.String())
+		}
+		if !completed() {
+			t.Error("completion missing after an explicit completed:true")
+		}
+	})
+}


### PR DESCRIPTION
Closes #347

## The bug

`decodeV1` decoded straight into the destination struct. `encoding/json` treats a top-level
`null` literal as "leave the destination alone": `Decode` returns no error, `dec.More()` is
false, and the handler proceeds on a zero-valued input. On the PUT-replace endpoints a
zero-valued input is not "nothing to do" — it is a *destructive instruction*:

```
PUT /api/v1/notes/{date}                     body `null` -> DELETE FROM daily_notes, 200 OK
PUT /api/v1/todos/{id}/completions/{date}    body `null` -> completion cleared,       200 OK
```

A note the user typed was destroyed by a body carrying no instruction to destroy it, and
nothing in the exchange said so. The realistic trigger is not malice, it is `json.dumps(None)`
or `JSON.stringify(undefined ?? null)` in a client wrapper that means "no payload".

This is the same silent data loss `DisallowUnknownFields` exists to prevent — argued in
`decodeV1`'s own doc comment ("hands the caller a success response and drops their data") —
and it applies with more force to a body that carries no instruction at all.

## The fix

`decodeV1` now reads the body as a raw value first and requires the top-level value to be a
JSON object. `null` lands in the **same bucket as a bare array/string/number**: the existing
400 `"The request body must be a JSON object."` I kept it in that bucket rather than giving
`null` a message of its own — it is the same class of fault (the top-level value is not an
object), the string is already documented and already emitted, and a fourth phrasing for the
same category helps nobody.

The field-level decode is a second pass over the bytes the first pass already read, so the
body is never read twice. The error mapping is factored into `decodeV1Problem` and shared by
both passes, so they cannot drift into reporting the same fault differently.

**No OpenAPI change.** 400 is already documented on every v1 endpoint that takes a body;
`go run ./cmd/apidocs` regenerates `api/openapi.json` and `docs/api-v1.md` with a zero diff
(confirmed — `git status` clean after running it).

## The `{}` decision: deliberately unchanged

`{}` and `null` both leave the struct zero-valued, so it is tempting to reject them together.
They are not the same request:

- **`{}` IS a JSON object.** It says "here is the resource, with every field at its default" —
  a complete, well-formed statement. On a PUT whole-content replace, `PUT /notes/{date}` with
  `{}` meaning "this note has no content" is a defensible reading, and it is the same one
  `{"content":""}` already gets.
- **`null` is not an object at all.** It states nothing about the resource, which is exactly
  why acting on it is wrong.

So `{}` keeps its pre-fix behaviour on every endpoint, including still deleting the note.
Changing it would have been a second, unreviewed behaviour change; it would break callers who
send `{}` to a PATCH to mean "no-op" (they get the existing 400 "contained no updatable
fields", which already tells them so); and "a note must carry an explicit `content` key" is a
`v1NoteInput` decision, not a `decodeV1` one.

Pinned in both directions so neither can drift silently:
`TestDecodeV1EmptyObjectIsNotRejected` (unit) and
`TestPutNoteV1RejectsNullBody/an_empty_object_still_deletes` (DB-backed).

## #358's pinned precedence: preserved

The restructure into two parses is exactly the risk #358 was written to catch, so the whole
table was re-run. Size > syntax > unknown field > wrong type all hold, and the multi-value
check still runs *after* the field decode (so `{"nope":1}{}` still reports the unknown field,
not the second object).

The one new question is where the top-level shape check sits. It is **after** size/syntax
(a body that cannot be read has no shape to report) and **before** the multi-value check
(`[1,2]{}` keeps its pre-fix answer, "must be a JSON object"). That ordering is now pinned
too, in `TestDecodeV1ErrorPrecedence`. The only behaviour change beyond `null` itself is
`null{}`, which moves from "must contain exactly one JSON object" to "must be a JSON object"
— the more useful of two 400s for a body that was never valid.

## Red then green

`TestPutNoteV1RejectsNullBody` and `TestSetTodoCompletionV1RejectsNullBody` run against a real
Postgres 18. **Before the fix** — note the 200s and the deleted rows:

```
=== RUN   TestDecodeV1/bare_JSON_null
    v1_common_test.go:238: decodeV1 accepted "null", want 400
--- FAIL: TestDecodeV1 (0.01s)
    --- FAIL: TestDecodeV1/bare_JSON_null (0.00s)

=== RUN   TestDecodeV1ErrorPrecedence
    v1_common_test.go:385: decodeV1("null{}") detail = "The request body must contain exactly one JSON object.", want the must-be-an-object detail
--- FAIL: TestDecodeV1ErrorPrecedence (0.01s)

=== RUN   TestPutNoteV1RejectsNullBody/null_body_leaves_the_note_intact
    v1_null_body_test.go:154: status = 200, want 400 (body {"date":"2026-08-08","content":"","updated_at":null})
=== RUN   TestPutNoteV1RejectsNullBody/null_body_with_whitespace_is_still_rejected
    v1_null_body_test.go:168: status = 200, want 400 (body {"date":"2026-08-08","content":"","updated_at":null})
--- FAIL: TestPutNoteV1RejectsNullBody (0.13s)
    --- FAIL: TestPutNoteV1RejectsNullBody/null_body_leaves_the_note_intact (0.00s)
    --- FAIL: TestPutNoteV1RejectsNullBody/null_body_with_whitespace_is_still_rejected (0.00s)
    --- PASS: TestPutNoteV1RejectsNullBody/a_real_note_still_saves (0.00s)
    --- PASS: TestPutNoteV1RejectsNullBody/an_explicit_empty_content_still_deletes (0.00s)
    --- PASS: TestPutNoteV1RejectsNullBody/an_empty_object_still_deletes (0.00s)

=== RUN   TestSetTodoCompletionV1RejectsNullBody/null_body_leaves_the_completion_intact
    v1_null_body_test.go:260: status = 200, want 400 (body {"completed":false,"date":"2026-08-08","todo_id":1})
--- FAIL: TestSetTodoCompletionV1RejectsNullBody (0.06s)
    --- FAIL: TestSetTodoCompletionV1RejectsNullBody/null_body_leaves_the_completion_intact (0.00s)
    --- PASS: TestSetTodoCompletionV1RejectsNullBody/an_explicit_false_still_un-completes (0.00s)
    --- PASS: TestSetTodoCompletionV1RejectsNullBody/an_explicit_true_still_completes (0.00s)
FAIL	schautrack/internal/handler	0.207s
```

The three sub-tests that pass in the red run are the ones asserting the *intended* behaviour
still works — they are there so a fix that over-rejects fails here instead of shipping.

**After the fix**, whole `TestDecodeV1|Note` selection, nothing skipped:

```
--- PASS: TestDecodeV1 (0.01s)
    --- PASS: TestDecodeV1/valid_body_decodes (0.00s)
    --- PASS: TestDecodeV1/absent_fields_keep_their_zero_value (0.00s)
    --- PASS: TestDecodeV1/unknown_field_is_a_400_that_names_the_field (0.00s)
    --- PASS: TestDecodeV1/unknown_field_named_even_when_other_fields_are_valid (0.00s)
    --- PASS: TestDecodeV1/wrong_field_type_is_a_422_naming_the_field_and_the_expected_type (0.00s)
    --- PASS: TestDecodeV1/wrong_field_type_reports_the_JSON_name,_not_the_Go_name (0.00s)
    --- PASS: TestDecodeV1/malformed_JSON (0.00s)
    --- PASS: TestDecodeV1/empty_body (0.00s)
    --- PASS: TestDecodeV1/whitespace-only_body (0.00s)
    --- PASS: TestDecodeV1/http.NoBody_is_an_empty_body,_not_an_absent_one (0.00s)
    --- PASS: TestDecodeV1/nil_body (0.00s)
    --- PASS: TestDecodeV1/body_over_maxV1Body_is_413,_not_400 (0.01s)
    --- PASS: TestDecodeV1/two_concatenated_objects (0.00s)
    --- PASS: TestDecodeV1/object_followed_by_garbage (0.00s)
    --- PASS: TestDecodeV1/bare_JSON_array (0.00s)
    --- PASS: TestDecodeV1/bare_JSON_string (0.00s)
    --- PASS: TestDecodeV1/bare_JSON_number (0.00s)
    --- PASS: TestDecodeV1/bare_JSON_null (0.00s)
    --- PASS: TestDecodeV1/null_in_a_field_is_not_a_null_body (0.00s)
--- PASS: TestDecodeV1EmptyObjectIsNotRejected (0.00s)
--- PASS: TestDecodeV1ErrorPrecedence (0.02s)
--- PASS: TestDecodeV1OptionalTypeErrorNamesTheField (0.00s)
--- PASS: TestNoteMatchesSchema (0.00s)
--- PASS: TestPutNoteV1RejectsNullBody (0.09s)
    --- PASS: TestPutNoteV1RejectsNullBody/null_body_leaves_the_note_intact (0.00s)
    --- PASS: TestPutNoteV1RejectsNullBody/null_body_with_whitespace_is_still_rejected (0.00s)
    --- PASS: TestPutNoteV1RejectsNullBody/a_real_note_still_saves (0.00s)
    --- PASS: TestPutNoteV1RejectsNullBody/an_explicit_empty_content_still_deletes (0.00s)
    --- PASS: TestPutNoteV1RejectsNullBody/an_empty_object_still_deletes (0.00s)
ok  	schautrack/internal/handler	0.121s
```

Full suite on the rebased branch, with `TEST_DATABASE_URL` pointed at the same Postgres:

```
ok  	schautrack/cmd/server	0.022s
ok  	schautrack/internal/clientip	0.010s
ok  	schautrack/internal/database	0.891s
ok  	schautrack/internal/handler	4.258s
ok  	schautrack/internal/middleware	2.031s
ok  	schautrack/internal/openapi	0.085s
ok  	schautrack/internal/release	0.007s
ok  	schautrack/internal/service	0.749s
ok  	schautrack/internal/session	0.018s
ok  	schautrack/internal/sse	0.055s
```

`go build ./...` and `go vet ./...` clean. Also verified the suite still passes with
`TEST_DATABASE_URL` unset (the new tests skip rather than fail).

## Blast-radius audit

Measured, not read: every v1 handler that takes a body was driven with an input struct left at
its zero value — byte-for-byte what a `null` body produced before this fix — against a real
Postgres, with row counts taken either side. (Throwaway probe, not committed.)

| Endpoint | Result | Rows |
|---|---|---|
| **`PUT /notes/{date}`** | **200** | **notes 1 → 0 — deletes the note** |
| **`PUT /todos/{id}/completions/{date}`** | **200** | **completions 1 → 0 — clears the completion** |
| **`POST /saved-foods/{id}/track`** | **201** | **entries 1 → 2 — creates a calorie entry** |
| `POST /entries` | 422 | no write |
| `PATCH /entries/{id}` | 400 | no write |
| `POST /todos` | 422 | no write |
| `PATCH /todos/{id}` | 400 | no write |
| `POST /saved-foods` | 422 | no write |
| `PATCH /saved-foods/{id}` | 400 | no write |
| `PATCH /me` | 400 | no write |
| `PUT /weight/{date}` | 422 | no write |

Three writes, and **notes is the worst of them** — it destroys free-text the user typed, which
exists nowhere else. The todo completion is genuine data loss too (it breaks a streak) but is
recoverable by re-completing. `saved-foods/{id}/track` is a *surprising* write rather than a
destructive one: a `null` body silently logs a real calorie entry, visible and deletable, and
the endpoint is `Idempotency-Key`-wrapped (though the key is optional). Nothing else writes:
the eight safe endpoints are saved by their own validators — the creates require a name or a
calorie value, the PATCHes return the existing 400 "contained no updatable fields", and
`PUT /weight` rejects a weight of 0.

All three are fixed by this change, since the fix is in `decodeV1` rather than in any one
handler.

## Stacking note

This was branched to stack on #358 (`v1-common-helper-tests`), but **#358 merged into
`staging` at 07:00 UTC today**, before I made a commit. So this is rebased directly onto
`origin/staging` and targets `staging` — no stacked-PR retarget needed. #358's
`v1_common_test.go` table is fully preserved; the only edit to it is flipping the case it
explicitly marked as a KNOWN GAP to be flipped when this fix landed, plus new pins.

## Issues filed while working

- #411 — `dec.More()` swallows a `MaxBytesError`, so a multi-value body padded past 1 MB is
  accepted with the extra value silently dropped, and the 413 never fires. Pre-existing;
  verified against a verbatim copy of the pre-#347 `decodeV1`, which behaves identically. Not
  fixed here to keep this diff to the one defect.
- #412 — DB-backed handler tests built on a bare `pgxpool.New` miss the production pool's
  `DATE`→`string` codec and produce scan-error 500s the running app cannot produce. Cost me a
  detour chasing a "500 on saved-food tracking" that did not exist. `v1TestDB` in this PR uses
  `database.NewPool` for that reason; `onboarding_test.go` is still on the bare form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
