### PR TITLE
fix: reject malformed decimals and strip Unicode whitespace in both parseAmounts

### DIFF
--- a/client/src/lib/mathParser.test.ts
+++ b/client/src/lib/mathParser.test.ts
@@ -5,6 +5,13 @@ import { parseAmount } from './mathParser';
 // The safe-math parser is duplicated in Go and TS (CSP forbids eval in the
 // browser), so both implementations must agree on the same table of inputs.
 // Keep this file in sync with the Go tests when either parser changes.
+//
+// "Keep in sync" is now enforced rather than requested for the cases that must
+// hold on both sides: they live in testdata/parse_amount_cases.json and are run
+// by tests/mathParserParity.test.ts here and by TestParseAmountSharedCases in
+// Go. Two hand-maintained tables let #351 and #353 diverge silently; one table
+// with two runners cannot. Add cases there unless the expectation is specific
+// to this implementation.
 
 describe('parseAmount', () => {
   it('parses simple numbers', () => {
@@ -171,18 +178,21 @@ describe('parseAmount', () => {
       ['0 x 10', true, 0, 'spaced form is an explicit multiplication by zero'],
       ['1,0x2', true, 20, 'comma is stripped first, so this is 10*2'],
 
-      // Space stripping: ALL whitespace goes, so a space inside a number
-      // closes over silently.
+      // Whitespace stripping: ALL whitespace goes, so a space inside a
+      // number closes over silently.
       ['5 5', true, 55, 'digits concatenate: a typo becomes a plausible number'],
       ['1 000', true, 1000, 'space as a thousands separator, intended'],
       ['2 x 3', true, 6, 'spaces around operators, intended'],
       ['5 -', false, 0, 'trailing operator still fails the grammar'],
       [' 5 ', true, 5, 'surrounding spaces'],
       ['\t7\n', true, 7, 'tabs and newlines'],
-      // DIVERGENCE from Go: /\s+/ strips Unicode whitespace, Go strips only
-      // U+0020, so the server rejects what this accepts. Harmless for the SPA
-      // (this parser runs first and sends a number) but real for the v1 API.
-      ['5\u00a05', true, 55, 'NBSP stripped here, NOT in the Go parser'],
+      // No longer a divergence from Go: stripWhitespace there now drops the
+      // same set this does, so a NBSP thousands separator is accepted by the
+      // v1 API and the import path too (#351). The full whitespace class is
+      // pinned in the shared fixture; these are the cases the issue named.
+      ['5\u00a05', true, 55, 'NBSP is stripped, exactly as in the Go parser'],
+      ['1\u00a0000', true, 1000, 'NBSP thousands separator, what fr-FR and de-CH produce'],
+      ['5\u200b5', false, 0, 'U+200B ZWSP is not whitespace in either language: still rejected'],
 
       // Comma stripping: a comma is ALWAYS a thousands separator, never a
       // decimal point. In an expression parser it cannot be both.
@@ -199,15 +209,22 @@ describe('parseAmount', () => {
       ['5--3', true, 8, 'binary minus then unary minus'],
       ['5+-3', true, 2, 'binary plus then unary minus'],
 
-      // Decimal forms: parseNumber accepts any run of [0-9.] and hands it to
-      // parseFloat, so a malformed decimal truncates to its valid prefix.
-      // parseFactor needs a leading digit, hence the ".5" / "5." asymmetry.
-      ['5.', true, 5, 'trailing decimal point is tolerated'],
-      ['.5', false, 0, 'leading decimal point is NOT (asymmetric with "5.")'],
-      ['5..', true, 5, 'trailing dots tolerated'],
-      ['..5', false, 0, 'leading dots rejected'],
-      ['5.0.0', true, 5, 'malformed decimal truncates to its valid prefix'],
-      ['1.2.3', true, 1, 'same, and 1.2 rounds to 1'],
+      // Decimal forms: parseNumber still accepts any run of [0-9.], but it
+      // now shape-checks the run before handing it to parseFloat, which
+      // truncates to the longest valid prefix rather than returning NaN. A
+      // fat-fingered '1.2.3' used to be accepted as 1 (#353).
+      //
+      // parseFactor also admits a leading '.' now, so '.5' and '5.' are
+      // symmetric - matching Go, where ParseWeight already accepted '.5'.
+      ['5.', true, 5, 'trailing decimal point is a valid literal'],
+      ['.5', true, 1, 'leading decimal point too, symmetric with "5." (rounds to 1)'],
+      ['.4', true, 0, 'same, and it rounds to an honest zero'],
+      ['5..', false, 0, 'two decimal points is not a number: no longer tolerated as 5'],
+      ['..5', false, 0, 'leading dots still rejected, now by parseNumber rather than parseFactor'],
+      ['.', false, 0, 'a bare dot is not a number'],
+      ['5.0.0', false, 0, 'malformed decimal REJECTED, no longer truncated to 5'],
+      ['1.2.3', false, 0, 'same: no longer 1.2 rounded to 1'],
+      ['1.2.3+1', false, 0, 'a malformed literal fails the whole expression'],
 
       // Scientific notation: "e" is not an allowed character and the grammar
       // has no exponent operator.
@@ -223,6 +240,15 @@ describe('parseAmount', () => {
       ['½', false, 0, 'vulgar fraction'],
 
       ['', false, 0, 'empty input'],
+
+      // Known remaining divergence from the Go twin: Math.round rounds a half
+      // toward +Infinity, math.Round rounds it away from zero. They agree on
+      // every positive half ('123.5' -> 124 on both) and disagree on every
+      // negative one, so these rows are TS-only and are deliberately absent
+      // from testdata/parse_amount_cases.json. Filed as #408 rather than
+      // changed here: it is a rounding decision, not a parsing one.
+      ['-1.5', true, -1, 'Math.round(-1.5) = -1; Go math.Round(-1.5) = -2'],
+      ['10-11.5', true, -1, 'same, reached through an expression'],
     ];
     for (const [input, ok, value, why] of cases) {
       expect(parseAmount(input), `${JSON.stringify(input)} (${why})`).toEqual({ ok, value });

--- a/client/src/lib/mathParser.ts
+++ b/client/src/lib/mathParser.ts
@@ -1,3 +1,10 @@
+// The decimal literals parseNumber accepts: "5", "5.", "5.0", ".5". This is
+// exactly what strconv.ParseFloat accepts on the Go side once the input
+// alphabet is narrowed to digits and dots — no exponent, no sign, no hex
+// float, no underscores can reach it, because the run that is tested here is
+// built from /[0-9.]/ characters only.
+const NUMBER_RE = /^(?:\d+(?:\.\d*)?|\.\d+)$/;
+
 // Safe mathematical expression evaluator using recursive descent parser
 function safeMathEval(expr: string): number {
   let pos = 0;
@@ -5,12 +12,26 @@ function safeMathEval(expr: string): number {
   function peek() { return pos < expr.length ? expr[pos] : null; }
   function consume() { return pos < expr.length ? expr[pos++] : null; }
 
+  // Consumes a run of [0-9.] and converts it, failing the whole parse when
+  // that run is not a well-formed decimal.
+  //
+  // The run is greedy, so it can swallow more than one decimal point:
+  // "5.0.0", "1.2.3", "5..". parseFloat does not reject those, it *truncates*
+  // to the longest valid prefix — parseFloat("5.0.0") is 5 and
+  // parseFloat("1.2.3") is 1.2 — so a fat-fingered amount used to be accepted
+  // as a plausible different amount (#353). NUMBER_RE is the shape check that
+  // parseFloat does not do; it is the same literal grammar strconv.ParseFloat
+  // enforces on the Go side, restricted to the digits-and-dots alphabet this
+  // run can contain.
+  //
+  // Keep in sync with parseNumber in internal/service/mathparser.go.
   function parseNumber(): number {
     let num = '';
     while (pos < expr.length && /[0-9.]/.test(expr[pos])) {
       num += consume();
     }
-    if (num === '' || num === '.') throw new Error('Invalid number');
+    if (num === '') throw new Error('Invalid number');
+    if (!NUMBER_RE.test(num)) throw new Error('Malformed number: ' + num);
     const value = parseFloat(num);
     if (!Number.isFinite(value)) throw new Error('Number out of range');
     return value;
@@ -21,7 +42,10 @@ function safeMathEval(expr: string): number {
     if (ch === '(') { consume(); const result = parseExpression(); if (consume() !== ')') throw new Error('Missing )'); return result; }
     if (ch === '-') { consume(); return -parseFactor(); }
     if (ch === '+') { consume(); return parseFactor(); }
-    if (/[0-9]/.test(ch!)) return parseNumber();
+    // A leading "." starts a number too — see the matching comment in
+    // parseFactor in internal/service/mathparser.go. parseNumber rejects the
+    // runs that are not real numbers (".", "..5").
+    if (/[0-9.]/.test(ch!)) return parseNumber();
     throw new Error('Unexpected: ' + ch);
   }
 
@@ -59,6 +83,11 @@ function safeMathEval(expr: string): number {
 // normalization is there to support.
 const HEX_LITERAL_RE = /(^|[^0-9.])0[xX][0-9a-fA-F]/;
 
+// Every whitespace character, defined as the union of JavaScript's `\s` and
+// Go's unicode.IsSpace so both parsers strip the identical set. See the call
+// site in parseAmount and stripWhitespace in internal/service/mathparser.go.
+const WHITESPACE_RE = /[\s\u0085]/g;
+
 export function parseAmount(input: string | number | null | undefined, options: { maxAbs?: number } = {}): { ok: boolean; value: number } {
   const maxAbs = options.maxAbs ?? null;
   if (input === undefined || input === null) return { ok: false, value: 0 };
@@ -72,7 +101,16 @@ export function parseAmount(input: string | number | null | undefined, options: 
   if (HEX_LITERAL_RE.test(String(input).replace(/,/g, ''))) return { ok: false, value: 0 };
 
   const expr = String(input)
-    .replace(/\s+/g, '')
+    // Strip every whitespace character, not just U+0020: "1 000" with a NBSP
+    // or a narrow NBSP is what fr-FR / de-CH locales produce, and U+FEFF is
+    // what a BOM-prefixed CSV paste carries. `\s` covers all of those, and
+    // U+0085 NEXT LINE is added because Go's unicode.IsSpace counts it and
+    // `\s` does not — the two sides must strip the identical set or the
+    // server rejects what this accepts (#351). U+200B ZERO WIDTH SPACE is in
+    // neither set and stays rejected on both sides: it is not a space
+    // separator.
+    // Keep in sync with stripWhitespace in internal/service/mathparser.go.
+    .replace(WHITESPACE_RE, '')
     .replace(/,/g, '')
     .replace(/[–—−]/g, '-')
     .replace(/[x×]/gi, '*')

--- a/client/tests/mathParserParity.test.ts
+++ b/client/tests/mathParserParity.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseAmount } from '../src/lib/mathParser';
+
+/**
+ * Cross-language parity for parseAmount (issues #351 and #353).
+ *
+ * The safe-math parser exists twice — Go for the API, TypeScript because CSP
+ * forbids `eval()` in the browser (CLAUDE.md rule 12) — and the SPA parses the
+ * input box locally and POSTs the resulting *number*, so the two are not a
+ * primary/mirror pair: whichever one runs decides what gets stored. When they
+ * disagree, the app accepts an input in the browser and rejects the same input
+ * from the v1 API or an import file, and nothing tells anyone.
+ *
+ * They did disagree, twice, and both were found by reading the code rather
+ * than by a failing test:
+ *
+ *   - #351: Go stripped only U+0020, this file's parser stripped all of
+ *     Unicode whitespace, so a NBSP thousands separator ("1\u00a0000") worked
+ *     in the SPA and 400'd on the API — and vanished silently from an import.
+ *   - #353: both discarded their number-conversion error, in two different
+ *     ways (fmt.Sscanf vs parseFloat), so "1.2.3" became 1 in Go and 1.2 here.
+ *     Same class of bug, two different wrong answers.
+ *
+ * `mathParser.test.ts` pins this implementation's behaviour, and the Go suite
+ * pins that one's; neither forces the two to agree. This file does, by running
+ * the *same* table Go's TestParseAmountSharedCases runs:
+ * `testdata/parse_amount_cases.json` at the repository root. Add a case there
+ * rather than to either per-language table whenever the expectation is not
+ * language-specific.
+ *
+ * It lives in `tests/` rather than `src/` because it reads the fixture with
+ * `node:fs`, and `tsc -b` covers only `src` and has no `@types/node`.
+ */
+
+type SharedCase = { input: string; ok: boolean; value: number; why: string };
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturePath = resolve(here, '../../testdata/parse_amount_cases.json');
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf8')) as {
+  _readme: string[];
+  cases: SharedCase[];
+};
+
+describe('parseAmount cross-language parity', () => {
+  it('loads the shared fixture', () => {
+    expect(fixture.cases.length).toBeGreaterThan(50);
+  });
+
+  // `ok` and `value` are compared separately with `===` rather than with a
+  // single `toEqual({ ok, value })`. `toEqual` uses Object.is, which reports
+  // -0 !== 0, and JavaScript produces -0 where Go produces a plain 0 for
+  // inputs like "-0.4". Nothing observable distinguishes the two (-0 === 0,
+  // String(-0) is "0", JSON.stringify(-0) is "0", so the server can never
+  // receive one), so a shared table must not be able to fail on it. Such
+  // inputs are also kept out of the fixture — see its _readme.
+  it('agrees with the Go parser on every shared case', () => {
+    for (const { input, ok, value, why } of fixture.cases) {
+      const r = parseAmount(input);
+      const label = `${JSON.stringify(input)} (${why})`;
+      expect(r.ok, label).toBe(ok);
+      expect(r.value === value, `${label}: got ${r.value}, want ${value}`).toBe(true);
+    }
+  });
+});

--- a/internal/handler/entries_export.go
+++ b/internal/handler/entries_export.go
@@ -204,6 +204,14 @@ type importData struct {
 	weights         []importWeight
 	goalCandidate   *float64
 	hasUserSettings bool
+	// skippedEntries and skippedWeights count the rows that were present in
+	// the file but did not survive validation, including the ones dropped by
+	// the 10,000-row cap. Import reports the total so a partial import stops
+	// being indistinguishable from a complete one — a row with an amount the
+	// server could not parse used to just vanish, and the response still said
+	// the import succeeded (#351).
+	skippedEntries int
+	skippedWeights int
 }
 
 // isEmpty reports whether the import carries nothing worth writing. Import
@@ -218,7 +226,9 @@ func (d importData) isEmpty() bool {
 // no user) so the validation that guards the destructive import — the loop
 // that rejects bad dates, zero/oversized amounts, malformed timestamps and
 // out-of-range macros — can be table-tested directly. Invalid rows are
-// silently skipped; entries and weights are each capped at 10,000 rows.
+// skipped rather than failing the import, but they are counted into
+// skippedEntries/skippedWeights so Import can say so; entries and weights are
+// each capped at 10,000 rows, and the rows past the cap count as skipped too.
 func parseImportData(parsed map[string]any) importData {
 	// Extract calorie goal from various formats
 	var goalCandidate *float64
@@ -244,13 +254,16 @@ func parseImportData(parsed map[string]any) importData {
 
 	// Parse entries
 	var toInsert []importEntry
+	var skippedEntries int
 	if entries, ok := parsed["entries"].([]any); ok {
-		for _, e := range entries {
+		for i, e := range entries {
 			if len(toInsert) >= 10000 {
+				skippedEntries += len(entries) - i
 				break
 			}
 			entry, ok := e.(map[string]any)
 			if !ok {
+				skippedEntries++
 				continue
 			}
 			dateStr := ""
@@ -260,10 +273,12 @@ func parseImportData(parsed map[string]any) importData {
 				dateStr = v
 			}
 			if !isValidDate(dateStr) {
+				skippedEntries++
 				continue
 			}
 			amountResult := service.ParseAmount(fmt.Sprintf("%v", entry["amount"]), MaxEntryCalories)
 			if !amountResult.Ok || amountResult.Value == 0 {
+				skippedEntries++
 				continue
 			}
 			var name *string
@@ -296,13 +311,16 @@ func parseImportData(parsed map[string]any) importData {
 
 	// Parse weight entries
 	var weightToInsert []importWeight
+	var skippedWeights int
 	if weights, ok := parsed["weights"].([]any); ok {
-		for _, w := range weights {
+		for i, w := range weights {
 			if len(weightToInsert) >= 10000 {
+				skippedWeights += len(weights) - i
 				break
 			}
 			wEntry, ok := w.(map[string]any)
 			if !ok {
+				skippedWeights++
 				continue
 			}
 			dateStr := ""
@@ -312,10 +330,12 @@ func parseImportData(parsed map[string]any) importData {
 				dateStr = v
 			}
 			if !isValidDate(dateStr) {
+				skippedWeights++
 				continue
 			}
 			wr := service.ParseWeight(fmt.Sprintf("%v", wEntry["weight"]))
 			if !wr.Ok {
+				skippedWeights++
 				continue
 			}
 			// An unparseable body fat drops just that field — the weight is
@@ -344,7 +364,35 @@ func parseImportData(parsed map[string]any) importData {
 		weights:         weightToInsert,
 		goalCandidate:   goalCandidate,
 		hasUserSettings: hasUserSettings,
+		skippedEntries:  skippedEntries,
+		skippedWeights:  skippedWeights,
 	}
+}
+
+// importMessage renders the success text for a completed import.
+//
+// The skipped count is the point of it. parseImportData drops any row it
+// cannot read — an unparseable amount, a bad date, a row past the 10,000 cap —
+// and the response used to report an unqualified success, so a file whose
+// amounts the server could not parse imported as "Imported 3 entries." with no
+// hint that seven more rows were thrown away (#351). Saying how many were
+// dropped costs nothing and turns silent data loss into something the user can
+// act on.
+//
+// This stays inside the existing `message` string rather than adding a field
+// to the response: Account.tsx renders `message` verbatim, so it reaches the
+// user with no client, OpenAPI or i18n change. Per-row diagnostics (which rows,
+// and why) would need a real response-shape change and are filed as #409.
+func importMessage(parts []string, skipped int) string {
+	msg := fmt.Sprintf("Imported %s.", strings.Join(parts, " and "))
+	if skipped > 0 {
+		unit := "rows"
+		if skipped == 1 {
+			unit = "row"
+		}
+		msg += fmt.Sprintf(" Skipped %d %s that could not be read.", skipped, unit)
+	}
+	return msg
 }
 
 // Import handles POST /settings/import
@@ -511,5 +559,5 @@ func (h *EntriesHandler) Import(w http.ResponseWriter, r *http.Request) {
 		parts = append(parts, "user settings")
 	}
 
-	JSON(w, http.StatusOK, map[string]any{"ok": true, "message": fmt.Sprintf("Imported %s.", strings.Join(parts, " and "))})
+	JSON(w, http.StatusOK, map[string]any{"ok": true, "message": importMessage(parts, data.skippedEntries+data.skippedWeights)})
 }

--- a/internal/handler/entries_import_test.go
+++ b/internal/handler/entries_import_test.go
@@ -329,6 +329,112 @@ func TestParseImportData_CapsAtTenThousand(t *testing.T) {
 	}
 }
 
+// TestParseImportDataCountsSkippedRows pins the counters that make a partial
+// import visible.
+//
+// Every one of these rows used to be dropped with no trace: the response said
+// "Imported 1 entries." and the user had no way to know the file had held more
+// (#351). The NBSP row is the case the issue was actually filed about — the
+// browser parser accepted "1 000" with a NBSP, so the number reached an export
+// file, and re-importing it silently threw the row away because the Go parser
+// rejected the same string. It now imports, which is the real fix; the counter
+// is the belt to that braces, for every other row the server cannot read.
+func TestParseImportDataCountsSkippedRows(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantEntries  int
+		wantSkippedE int
+		wantWeights  int
+		wantSkippedW int
+	}{
+		{
+			name:         "unparseable amount is counted, not silently dropped",
+			input:        `{"entries":[{"date":"2025-01-15","amount":420},{"date":"2025-01-15","amount":"1.2.3"},{"date":"2025-01-15","amount":"abc"}]}`,
+			wantEntries:  1,
+			wantSkippedE: 2,
+		},
+		{
+			name:         "NBSP thousands separator now imports instead of vanishing",
+			input:        `{"entries":[{"date":"2025-01-15","amount":"1\u00a0000"}]}`,
+			wantEntries:  1,
+			wantSkippedE: 0,
+		},
+		{
+			name:         "bad date, non-object row and zero amount all count",
+			input:        `{"entries":[{"date":"bad","amount":100},"nope",{"date":"2025-01-15","amount":0},{"date":"2025-01-15","amount":50}]}`,
+			wantEntries:  1,
+			wantSkippedE: 3,
+		},
+		{
+			name:         "weights are counted separately",
+			input:        `{"weights":[{"date":"2025-01-15","weight":72.5},{"date":"2025-01-15","weight":"heavy"},{"date":"nope","weight":70}]}`,
+			wantWeights:  1,
+			wantSkippedW: 2,
+		},
+		{
+			name:        "a clean file reports nothing skipped",
+			input:       `{"entries":[{"date":"2025-01-15","amount":420}],"weights":[{"date":"2025-01-15","weight":72.5}]}`,
+			wantEntries: 1,
+			wantWeights: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := parseImportData(mustParseImportJSON(t, tt.input))
+			if len(d.entries) != tt.wantEntries || d.skippedEntries != tt.wantSkippedE {
+				t.Errorf("entries kept/skipped = %d/%d, want %d/%d",
+					len(d.entries), d.skippedEntries, tt.wantEntries, tt.wantSkippedE)
+			}
+			if len(d.weights) != tt.wantWeights || d.skippedWeights != tt.wantSkippedW {
+				t.Errorf("weights kept/skipped = %d/%d, want %d/%d",
+					len(d.weights), d.skippedWeights, tt.wantWeights, tt.wantSkippedW)
+			}
+		})
+	}
+}
+
+// TestParseImportDataCountsRowsPastTheCap verifies the 10,000-row cap is
+// reported too. Truncating a file is the same silent data loss as dropping a
+// bad row, it just happens to a valid one.
+func TestParseImportDataCountsRowsPastTheCap(t *testing.T) {
+	entries := make([]any, 10005)
+	for i := range entries {
+		entries[i] = map[string]any{"date": "2025-01-15", "amount": float64(100)}
+	}
+	d := parseImportData(map[string]any{"entries": entries})
+	if len(d.entries) != 10000 {
+		t.Fatalf("entries = %d, want 10000", len(d.entries))
+	}
+	if d.skippedEntries != 5 {
+		t.Errorf("skippedEntries = %d, want 5", d.skippedEntries)
+	}
+}
+
+// TestImportMessage pins the user-facing text, including the singular/plural
+// split and the fact that a clean import says nothing extra.
+func TestImportMessage(t *testing.T) {
+	tests := []struct {
+		parts   []string
+		skipped int
+		want    string
+	}{
+		{[]string{"3 entries"}, 0, "Imported 3 entries."},
+		{[]string{"3 entries"}, 1, "Imported 3 entries. Skipped 1 row that could not be read."},
+		{[]string{"3 entries"}, 7, "Imported 3 entries. Skipped 7 rows that could not be read."},
+		{
+			[]string{"3 entries", "2 weight records"}, 2,
+			"Imported 3 entries and 2 weight records. Skipped 2 rows that could not be read.",
+		},
+	}
+	for _, tt := range tests {
+		if got := importMessage(tt.parts, tt.skipped); got != tt.want {
+			t.Errorf("importMessage(%v, %d) = %q, want %q", tt.parts, tt.skipped, got, tt.want)
+		}
+	}
+}
+
 // buildImportRequest builds a POST /settings/import multipart request. When
 // fieldName is empty the file part is omitted entirely (to exercise the
 // "no file uploaded" path).

--- a/internal/service/mathparser.go
+++ b/internal/service/mathparser.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"strconv"
 	"strings"
+	"unicode"
 )
 
 type ParseAmountResult struct {
@@ -27,29 +29,62 @@ var validExprRe = regexp.MustCompile(`^[0-9+\-*/().]+$`)
 // happen to be used.
 var hexLiteralRe = regexp.MustCompile(`(^|[^0-9.])0[xX][0-9a-fA-F]`)
 
+// stripWhitespace removes every whitespace rune from s, not just U+0020.
+//
+// This exists because "1 000" with a NBSP (U+00A0) or a narrow NBSP (U+202F)
+// is what a fr-FR / de-CH locale actually produces — it is what a user gets
+// from pasting a number out of a spreadsheet or a nutrition label — and a
+// stray U+FEFF is what a user gets from pasting the first field of a
+// BOM-prefixed CSV. Stripping only U+0020 left those characters in the
+// expression, where they failed validExprRe and the whole input was rejected.
+//
+// The set matched here is deliberately the union of Go's unicode.IsSpace and
+// JavaScript's `\s`, so it is identical to the `/[\s\u0085]/g` replacement
+// used by parseAmount in client/src/lib/mathParser.ts. The two differ in
+// exactly two code points, and both are added rather than dropped:
+//
+//   - U+0085 NEXT LINE: unicode.IsSpace yes, JS `\s` no.
+//   - U+FEFF ZERO WIDTH NO-BREAK SPACE (the BOM): unicode.IsSpace no, JS `\s`
+//     yes.
+//
+// U+200B ZERO WIDTH SPACE is in neither and stays rejected on both sides: it
+// is not a space separator, and silently deleting invisible characters that
+// are not whitespace would widen what the app accepts for no reason.
+//
+// Keep in sync with client/src/lib/mathParser.ts (issue #351).
+func stripWhitespace(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) || r == '\uFEFF' {
+			return -1
+		}
+		return r
+	}, s)
+}
+
 func ParseAmount(input string, maxAbs int) ParseAmountResult {
 	input = strings.TrimSpace(input)
 	if input == "" {
 		return ParseAmountResult{Ok: false, Value: 0}
 	}
 
-	// Normalize input. Stripping spaces and commas are independent global
+	// Normalize input. Stripping whitespace and commas are independent global
 	// replacements of distinct characters, so their relative order does not
 	// matter; commas go first only so the hex check below can still see the
-	// spaces.
+	// whitespace.
 	expr := strings.ReplaceAll(input, ",", "")
 
 	// Reject hex-looking literals before "x" becomes "*". Without this,
 	// "0x10" normalizes to "0*10" and is *silently accepted as 0* — the
 	// callers read Value==0 as "no calorie entry", so a pasted hex value
-	// writes an empty entry and reports success. Checked before spaces are
-	// stripped so an explicitly spaced "0 x 10" is still the multiplication
-	// it looks like.
+	// writes an empty entry and reports success. Checked before whitespace
+	// is stripped so an explicitly spaced "0 x 10" is still the
+	// multiplication it looks like (that holds for a NBSP-spaced "0 x 10"
+	// too, now that stripWhitespace removes those as well).
 	if hexLiteralRe.MatchString(expr) {
 		return ParseAmountResult{Ok: false, Value: 0}
 	}
 
-	expr = strings.ReplaceAll(expr, " ", "")
+	expr = stripWhitespace(expr)
 	expr = strings.NewReplacer("–", "-", "—", "-", "−", "-").Replace(expr)
 	expr = strings.NewReplacer("x", "*", "X", "*", "×", "*").Replace(expr)
 	expr = strings.ReplaceAll(expr, "÷", "/")
@@ -112,6 +147,24 @@ func (p *parser) consume() byte {
 	return 0
 }
 
+// parseNumber consumes a run of [0-9.] and converts it, failing the whole
+// parse when that run is not a well-formed decimal.
+//
+// The run is greedy, so it can swallow more than one decimal point: "5.0.0",
+// "1.2.3", "5..". The previous implementation handed the run to fmt.Sscanf
+// and *discarded the error*, which made Sscanf's prefix-scanning semantics
+// the de facto grammar — "5.0.0" silently became 5 and "1.2.3" silently
+// became 1.2 (rounded to 1). A fat-fingered amount was accepted as a
+// plausible different amount instead of being reported as invalid (#353).
+//
+// strconv.ParseFloat has no prefix behaviour: it accepts the run only if the
+// *whole* slice is a decimal literal. Since the run contains nothing but
+// digits and dots, that is exactly "digits[.digits] | .digits" — no exponent,
+// no sign, no hex float, no underscores can reach it.
+//
+// Keep in sync with parseNumber in client/src/lib/mathParser.ts, where the
+// same run is shape-checked against /^(?:\d+(?:\.\d*)?|\.\d+)$/ because
+// parseFloat truncates rather than returning NaN.
 func (p *parser) parseNumber() float64 {
 	start := p.pos
 	for p.pos < len(p.expr) && (p.expr[p.pos] >= '0' && p.expr[p.pos] <= '9' || p.expr[p.pos] == '.') {
@@ -121,8 +174,12 @@ func (p *parser) parseNumber() float64 {
 		p.err = fmt.Errorf("invalid number")
 		return 0
 	}
-	var val float64
-	fmt.Sscanf(p.expr[start:p.pos], "%f", &val)
+	lit := p.expr[start:p.pos]
+	val, err := strconv.ParseFloat(lit, 64)
+	if err != nil {
+		p.err = fmt.Errorf("invalid number %q", lit)
+		return 0
+	}
 	return val
 }
 
@@ -147,7 +204,13 @@ func (p *parser) parseFactor() float64 {
 		p.consume()
 		return p.parseFactor()
 	}
-	if ch >= '0' && ch <= '9' {
+	// A leading "." starts a number too. Requiring a digit here made ".5"
+	// invalid while "5." was fine, and ParseWeight — the other number box in
+	// the app — accepts ".5" as 0.5, so the two disagreed on the same
+	// keystroke for no reason beyond this check (#353). "." is not an
+	// operator in this grammar, so admitting it introduces no ambiguity, and
+	// parseNumber rejects the runs that are not real numbers (".", "..5").
+	if ch >= '0' && ch <= '9' || ch == '.' {
 		return p.parseNumber()
 	}
 	p.err = fmt.Errorf("unexpected character: %c", ch)

--- a/internal/service/mathparser_test.go
+++ b/internal/service/mathparser_test.go
@@ -1,6 +1,9 @@
 package service
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -193,6 +196,11 @@ func TestParseAmountMaxAbs(t *testing.T) {
 // what this table records. Nothing here is incidental: if a case below starts
 // failing, the normalization order changed and the set of strings the app
 // accepts changed with it. Decide again, then update the table.
+//
+// Cases that must hold in *both* parsers live in testdata/parse_amount_cases.json
+// instead, run from here by TestParseAmountSharedCases and from the client by
+// tests/mathParserParity.test.ts. This table is for what is specific to the Go
+// side; prefer the shared fixture for anything else.
 func TestParseAmountNormalizationEdges(t *testing.T) {
 	tests := []struct {
 		input string
@@ -224,18 +232,24 @@ func TestParseAmountNormalizationEdges(t *testing.T) {
 		{"0 x 10", true, 0, "spaced form is an explicit multiplication by zero"},
 		{"1,0x2", true, 20, "comma is stripped first, so this is 10*2"},
 
-		// --- Space stripping ---------------------------------------------
-		// ALL spaces go, so a space inside a number closes over silently.
+		// --- Whitespace stripping ----------------------------------------
+		// ALL whitespace goes, so a space inside a number closes over
+		// silently.
 		{"5 5", true, 55, "digits concatenate: a typo becomes a plausible number"},
 		{"1 000", true, 1000, "space as a thousands separator, intended"},
 		{"2 x 3", true, 6, "spaces around operators, intended"},
 		{"5 -", false, 0, "trailing operator still fails the grammar"},
 		{" 5 ", true, 5, "surrounding spaces"},
 		{"\t7\n", true, 7, "TrimSpace handles tabs/newlines at the ends"},
-		// Only U+0020 is stripped, not Unicode whitespace. NBSP survives
-		// into the expression and fails validExprRe.
-		{"5\u00a05", false, 0, "non-breaking space is not stripped"},
-		{"1\u00a0000", false, 0, "NBSP thousands separator is rejected, unlike a plain space"},
+		// stripWhitespace drops every whitespace rune, not just U+0020, so a
+		// NBSP thousands separator is accepted exactly like a plain space
+		// (#351). It used to survive into the expression and fail
+		// validExprRe, which meant the server 400'd inputs the browser
+		// parser accepted. The full whitespace class is pinned in the shared
+		// fixture; these two are the cases the issue was filed about.
+		{"5\u00a05", true, 55, "NBSP is stripped, so digits concatenate like they do around U+0020"},
+		{"1\u00a0000", true, 1000, "NBSP thousands separator, what fr-FR and de-CH produce"},
+		{"5\u200b5", false, 0, "U+200B ZWSP is not whitespace in either language: still rejected"},
 
 		// --- Comma stripping ----------------------------------------------
 		{"1,000", true, 1000, "comma as a thousands separator, intended"},
@@ -258,17 +272,28 @@ func TestParseAmountNormalizationEdges(t *testing.T) {
 		{"5+-3", true, 2, "binary plus then unary minus"},
 
 		// --- Decimal forms ---------------------------------------------------
-		// parseNumber accepts any run of [0-9.] and hands it to Sscanf, whose
-		// error is ignored — so a malformed decimal truncates at the first
-		// valid prefix rather than failing. parseFactor, however, requires a
-		// digit to start a number, which is why ".5" is rejected while "5."
-		// is not.
-		{"5.", true, 5, "trailing decimal point is tolerated"},
-		{".5", false, 0, "leading decimal point is NOT (asymmetric with \"5.\")"},
-		{"5..", true, 5, "trailing dots tolerated"},
-		{"..5", false, 0, "leading dots rejected"},
-		{"5.0.0", true, 5, "malformed decimal truncates to its valid prefix"},
-		{"1.2.3", true, 1, "same, and 1.2 rounds to 1"},
+		// parseNumber still accepts any run of [0-9.], but it now converts it
+		// with strconv.ParseFloat and fails the parse when the run is not a
+		// whole decimal literal. Previously the run went to fmt.Sscanf with
+		// the error discarded, so "1.2.3" was silently accepted as its
+		// longest valid prefix — a fat-fingered amount became a plausible
+		// different amount instead of a validation error (#353).
+		//
+		// parseFactor also admits a leading "." now, so ".5" and "5." are
+		// symmetric. That was the other half of #353: ParseWeight accepts
+		// ".5" as 0.5, and the two number boxes disagreeing on the same
+		// keystroke bought nothing — see
+		// TestParseAmountVsParseWeightSyntaxDivergence, where that row is now
+		// an agreement rather than a divergence.
+		{"5.", true, 5, "trailing decimal point is a valid literal"},
+		{".5", true, 1, "leading decimal point too, symmetric with \"5.\" (rounds to 1)"},
+		{".4", true, 0, "same, and it rounds to an honest zero"},
+		{"5..", false, 0, "two decimal points is not a number: no longer tolerated as 5"},
+		{"..5", false, 0, "leading dots still rejected, now by parseNumber rather than parseFactor"},
+		{".", false, 0, "a bare dot is not a number"},
+		{"5.0.0", false, 0, "malformed decimal REJECTED, no longer truncated to 5"},
+		{"1.2.3", false, 0, "same: no longer 1.2 rounded to 1"},
+		{"1.2.3+1", false, 0, "a malformed literal fails the whole expression"},
 
 		// --- Scientific notation ---------------------------------------------
 		// "e" is not in validExprRe and the grammar has no exponent operator.
@@ -296,6 +321,16 @@ func TestParseAmountNormalizationEdges(t *testing.T) {
 		// so a missing key arrives as this literal string.
 		{"<nil>", false, 0, "stringified nil from an absent JSON key"},
 		{"", false, 0, "empty input"},
+
+		// --- Known remaining divergence from the TS twin --------------------
+		// math.Round rounds a half away from zero; JavaScript's Math.round
+		// rounds it toward +Inf. They agree on every positive half ("123.5" ->
+		// 124 in both) and disagree on every negative one, so these two rows
+		// are Go-only and are deliberately absent from
+		// testdata/parse_amount_cases.json. Filed as #408 rather than changed
+		// here: it is a rounding decision, not a parsing one.
+		{"-1.5", true, -2, "math.Round(-1.5) = -2; JS Math.round(-1.5) = -1"},
+		{"10-11.5", true, -2, "same, reached through an expression"},
 	}
 
 	for _, tt := range tests {
@@ -350,6 +385,12 @@ func TestParseAmountAcceptedZeros(t *testing.T) {
 //     European decimal point a scale displays. It also inherits ParseFloat's
 //     exponent syntax for free.
 //
+// One row that used to be here is gone: ".5" was rejected by ParseAmount and
+// accepted by ParseWeight, but that followed from nothing except parseFactor
+// requiring a leading digit. It was not a consequence of one parser being a
+// calculator and the other a scalar, so it was not worth keeping — see #353.
+// The rows below are the ones that do follow from the difference in kind.
+//
 // The divergence is therefore kept, not removed: collapsing it in either
 // direction would either take the calculator away from calories or the comma
 // decimal away from weights. This test is the record of that decision, so a
@@ -366,10 +407,11 @@ func TestParseAmountVsParseWeightSyntaxDivergence(t *testing.T) {
 		{"1,5", true, 15, true, 1.5, "comma: thousands separator vs decimal point"},
 		{"1,000", true, 1000, true, 1.0, "the same string means 1000 kcal or 1.0 kg"},
 		{"1e1", false, 0, true, 10, "exponent syntax: grammar has none, ParseFloat does"},
-		{".5", false, 0, true, 0.5, "leading decimal point: grammar needs a leading digit"},
+		{".5", true, 1, true, 0.5, "leading decimal point: both accept it; the amount then rounds to 1"},
 		{"2x3", true, 6, false, 0, "expression syntax exists only for amounts"},
 		{"100+50", true, 150, false, 0, "same"},
 		{"5.", true, 5, true, 5, "trailing decimal point: both accept it"},
+		{"1.2.3", false, 0, false, 0, "malformed decimal: both reject it (#353)"},
 	}
 	for _, tt := range tests {
 		a := ParseAmount(tt.input, 0)
@@ -383,6 +425,70 @@ func TestParseAmountVsParseWeightSyntaxDivergence(t *testing.T) {
 				tt.input, w.Ok, w.Value, tt.weightOk, tt.weightValue, tt.why)
 		}
 	}
+}
+
+// sharedParseAmountCase is one row of testdata/parse_amount_cases.json.
+type sharedParseAmountCase struct {
+	Input string `json:"input"`
+	Ok    bool   `json:"ok"`
+	Value int    `json:"value"`
+	Why   string `json:"why"`
+}
+
+// TestParseAmountSharedCases runs the cross-language pin table that
+// client/tests/mathParserParity.test.ts runs against the TypeScript twin.
+//
+// The safe-math parser exists twice — Go for the API, TypeScript because CSP
+// forbids eval() in the browser — and the SPA parses the input box locally and
+// POSTs the resulting *number*, so the two are not a primary/mirror pair:
+// whichever one runs decides what gets stored. When they disagree, the app
+// accepts an input in the browser and rejects the same input from the v1 API
+// or an import file, and nothing tells anyone.
+//
+// They did disagree, twice, and both were found by reading the code rather
+// than by a failing test:
+//
+//   - #351: Go stripped only U+0020, TS stripped all of Unicode whitespace, so
+//     a NBSP thousands separator ("1\u00a0000") worked in the SPA and 400'd on
+//     the API — and vanished silently from an import.
+//   - #353: both discarded their number-conversion error, in two different
+//     ways (fmt.Sscanf vs parseFloat), so "1.2.3" became 1 in Go and 1.2 in TS.
+//     Same class of bug, two different wrong answers.
+//
+// Two tables maintained side by side would not have caught either: nothing
+// forces a change to one to be applied to the other. One table, loaded by both
+// runners, does. Add cases here rather than to the per-language tables
+// whenever the expectation is not language-specific.
+//
+// Two classes are deliberately excluded and pinned per-language instead,
+// documented in the fixture's _readme: negative half-values (math.Round rounds
+// half away from zero, Math.round rounds half toward +Inf, tracked as #408) and
+// inputs that evaluate to a negative zero. See the "known remaining divergence"
+// note in TestParseAmountNormalizationEdges.
+func TestParseAmountSharedCases(t *testing.T) {
+	path := filepath.Join("..", "..", "testdata", "parse_amount_cases.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read shared fixture: %v", err)
+	}
+	var doc struct {
+		Cases []sharedParseAmountCase `json:"cases"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse shared fixture: %v", err)
+	}
+	if len(doc.Cases) == 0 {
+		t.Fatal("shared fixture is empty")
+	}
+
+	for _, tt := range doc.Cases {
+		r := ParseAmount(tt.Input, 0)
+		if r.Ok != tt.Ok || r.Value != tt.Value {
+			t.Errorf("ParseAmount(%q) = {%v, %d}, want {%v, %d} (%s)",
+				tt.Input, r.Ok, r.Value, tt.Ok, tt.Value, tt.Why)
+		}
+	}
+	t.Logf("%d shared cases", len(doc.Cases))
 }
 
 func TestSafeMathEvalPrecedence(t *testing.T) {

--- a/testdata/parse_amount_cases.json
+++ b/testdata/parse_amount_cases.json
@@ -1,0 +1,690 @@
+{
+  "_readme": [
+    "Cross-language pin table for parseAmount, shared by both implementations:",
+    "  Go  - TestParseAmountSharedCases in internal/service/mathparser_test.go",
+    "  TS  - client/tests/mathParserParity.test.ts",
+    "",
+    "The safe-math parser is duplicated in Go and TypeScript because CSP forbids",
+    "eval() in the browser (CLAUDE.md rule 12). Two hand-written implementations",
+    "of the same grammar drift, and they drifted silently: issue #351 (Go stripped",
+    "only U+0020 where TS stripped all of Unicode whitespace) and issue #353 (both",
+    "discarded their number-conversion error, in two different ways) were both",
+    "found by reading the code, not by a failing test.",
+    "",
+    "Every case here is evaluated with NO maxAbs cap and must produce an identical",
+    "{ok, value} on both sides. A case that only one language can express does not",
+    "belong here - it belongs in that language's own test file.",
+    "",
+    "Deliberately NOT in this table:",
+    "  - Negative half-values ('-1.5', '10-11.5'). Go's math.Round rounds half away",
+    "    from zero (-2); JavaScript's Math.round rounds half toward +Inf (-1). That",
+    "    is a real divergence, tracked separately in issue #408.",
+    "  - Inputs that evaluate to a negative zero ('-0', '-0.4'). JavaScript yields",
+    "    -0, Go yields a plain 0. Nothing observable distinguishes them (-0 === 0,",
+    "    String(-0) is '0', JSON.stringify(-0) is '0'), but a deep-equal assertion",
+    "    does. Pinned per-language instead.",
+    "  - maxAbs behaviour, which each side pins in its own table."
+  ],
+  "cases": [
+    {
+      "input": "1 000",
+      "ok": true,
+      "value": 1000,
+      "why": "U+0020 as a thousands separator, intended"
+    },
+    {
+      "input": "1\u00a0000",
+      "ok": true,
+      "value": 1000,
+      "why": "NBSP thousands separator (fr-FR, de-CH copy-paste)"
+    },
+    {
+      "input": "1\u202f000",
+      "ok": true,
+      "value": 1000,
+      "why": "narrow NBSP thousands separator (fr-FR)"
+    },
+    {
+      "input": "1\u2009000",
+      "ok": true,
+      "value": 1000,
+      "why": "thin space thousands separator"
+    },
+    {
+      "input": "1\u2007000",
+      "ok": true,
+      "value": 1000,
+      "why": "figure space thousands separator"
+    },
+    {
+      "input": "1\u3000000",
+      "ok": true,
+      "value": 1000,
+      "why": "ideographic space (CJK full-width)"
+    },
+    {
+      "input": "1\u1680000",
+      "ok": true,
+      "value": 1000,
+      "why": "ogham space mark, still a space separator"
+    },
+    {
+      "input": "5\u00855",
+      "ok": true,
+      "value": 55,
+      "why": "U+0085 NEL: unicode.IsSpace yes, JS \\s no - stripped on both"
+    },
+    {
+      "input": "5\ufeff5",
+      "ok": true,
+      "value": 55,
+      "why": "U+FEFF BOM: JS \\s yes, unicode.IsSpace no - stripped on both"
+    },
+    {
+      "input": "\u00a05\u00a0",
+      "ok": true,
+      "value": 5,
+      "why": "surrounding NBSP"
+    },
+    {
+      "input": "\t7\n",
+      "ok": true,
+      "value": 7,
+      "why": "tab and newline"
+    },
+    {
+      "input": "\u000b7\f\r",
+      "ok": true,
+      "value": 7,
+      "why": "vertical tab, form feed, carriage return"
+    },
+    {
+      "input": "2\u00a0x\u00a03",
+      "ok": true,
+      "value": 6,
+      "why": "NBSP around the multiplication shorthand"
+    },
+    {
+      "input": "5 5",
+      "ok": true,
+      "value": 55,
+      "why": "digits concatenate: a typo becomes a plausible number"
+    },
+    {
+      "input": "5\u200b5",
+      "ok": false,
+      "value": 0,
+      "why": "U+200B ZWSP is in neither whitespace set - not stripped, rejected"
+    },
+    {
+      "input": "5\u20605",
+      "ok": false,
+      "value": 0,
+      "why": "U+2060 WORD JOINER is not whitespace either"
+    },
+    {
+      "input": "5.",
+      "ok": true,
+      "value": 5,
+      "why": "trailing decimal point is a valid literal in both"
+    },
+    {
+      "input": ".5",
+      "ok": true,
+      "value": 1,
+      "why": "leading decimal point now accepted, symmetric with \"5.\""
+    },
+    {
+      "input": ".4",
+      "ok": true,
+      "value": 0,
+      "why": "same, and it rounds to an honest zero"
+    },
+    {
+      "input": ".75",
+      "ok": true,
+      "value": 1,
+      "why": "same, rounds up"
+    },
+    {
+      "input": ".5+.5",
+      "ok": true,
+      "value": 1,
+      "why": "leading-dot literals compose"
+    },
+    {
+      "input": "5.*2",
+      "ok": true,
+      "value": 10,
+      "why": "trailing-dot literal composes"
+    },
+    {
+      "input": "0.5+0.5",
+      "ok": true,
+      "value": 1,
+      "why": "the ordinary spelling of the same thing"
+    },
+    {
+      "input": "007",
+      "ok": true,
+      "value": 7,
+      "why": "leading zeros are not an octal prefix"
+    },
+    {
+      "input": "5.0.0",
+      "ok": false,
+      "value": 0,
+      "why": "two decimal points is not a number - no longer truncates to 5"
+    },
+    {
+      "input": "1.2.3",
+      "ok": false,
+      "value": 0,
+      "why": "same - no longer truncates to 1.2 and rounds to 1"
+    },
+    {
+      "input": "5..",
+      "ok": false,
+      "value": 0,
+      "why": "trailing dots are not a number"
+    },
+    {
+      "input": "..5",
+      "ok": false,
+      "value": 0,
+      "why": "leading dots are not a number"
+    },
+    {
+      "input": ".",
+      "ok": false,
+      "value": 0,
+      "why": "a bare dot is not a number"
+    },
+    {
+      "input": "..",
+      "ok": false,
+      "value": 0,
+      "why": "nor are two"
+    },
+    {
+      "input": "1.2.3+1",
+      "ok": false,
+      "value": 0,
+      "why": "a malformed literal fails the whole expression"
+    },
+    {
+      "input": "(5.0.0)",
+      "ok": false,
+      "value": 0,
+      "why": "same, inside parentheses"
+    },
+    {
+      "input": "1,2.3.4",
+      "ok": false,
+      "value": 0,
+      "why": "comma stripped first, then the literal is still malformed"
+    },
+    {
+      "input": "0x10",
+      "ok": false,
+      "value": 0,
+      "why": "hex literal rejected, not silently 0"
+    },
+    {
+      "input": "0X10",
+      "ok": false,
+      "value": 0,
+      "why": "uppercase hex literal rejected"
+    },
+    {
+      "input": "0xff",
+      "ok": false,
+      "value": 0,
+      "why": "hex letters were never valid expression characters"
+    },
+    {
+      "input": "0xFF",
+      "ok": false,
+      "value": 0,
+      "why": "same, uppercase"
+    },
+    {
+      "input": "0x",
+      "ok": false,
+      "value": 0,
+      "why": "trailing operator after x->*"
+    },
+    {
+      "input": "0x0",
+      "ok": false,
+      "value": 0,
+      "why": "hex literal even when the value would be 0 anyway"
+    },
+    {
+      "input": "(0x10)",
+      "ok": false,
+      "value": 0,
+      "why": "hex literal rejected inside parentheses"
+    },
+    {
+      "input": "5+0x10",
+      "ok": false,
+      "value": 0,
+      "why": "hex literal rejected as a sub-expression"
+    },
+    {
+      "input": "2x3",
+      "ok": true,
+      "value": 6,
+      "why": "the multiplication shorthand the rewrite exists for"
+    },
+    {
+      "input": "10x16",
+      "ok": true,
+      "value": 160,
+      "why": "left operand ends in 0, still multiplication"
+    },
+    {
+      "input": "100x2",
+      "ok": true,
+      "value": 200,
+      "why": "left operand ends in 00, still multiplication"
+    },
+    {
+      "input": "1.0x2",
+      "ok": true,
+      "value": 2,
+      "why": "0 after a decimal point is not a hex prefix"
+    },
+    {
+      "input": "0 x 10",
+      "ok": true,
+      "value": 0,
+      "why": "spaced form is an explicit multiplication by zero"
+    },
+    {
+      "input": "0\u00a0x\u00a010",
+      "ok": true,
+      "value": 0,
+      "why": "NBSP-spaced form matches the U+0020-spaced form: the hex check runs before whitespace is stripped"
+    },
+    {
+      "input": "1,0x2",
+      "ok": true,
+      "value": 20,
+      "why": "comma is stripped first, so this is 10*2"
+    },
+    {
+      "input": "10 \u00d7 5",
+      "ok": true,
+      "value": 50,
+      "why": "multiplication sign"
+    },
+    {
+      "input": "10 x 5",
+      "ok": true,
+      "value": 50,
+      "why": "ASCII x"
+    },
+    {
+      "input": "10 X 5",
+      "ok": true,
+      "value": 50,
+      "why": "uppercase ASCII X"
+    },
+    {
+      "input": "100 \u00f7 4",
+      "ok": true,
+      "value": 25,
+      "why": "division sign"
+    },
+    {
+      "input": "10 \u2013 5",
+      "ok": true,
+      "value": 5,
+      "why": "en dash as minus"
+    },
+    {
+      "input": "10 \u2014 5",
+      "ok": true,
+      "value": 5,
+      "why": "em dash as minus"
+    },
+    {
+      "input": "10 \u2212 5",
+      "ok": true,
+      "value": 5,
+      "why": "minus sign as minus"
+    },
+    {
+      "input": "1,000",
+      "ok": true,
+      "value": 1000,
+      "why": "comma as a thousands separator, intended"
+    },
+    {
+      "input": "1,234 + 500",
+      "ok": true,
+      "value": 1734,
+      "why": "thousands separator inside an expression"
+    },
+    {
+      "input": "1,5",
+      "ok": true,
+      "value": 15,
+      "why": "European decimal becomes 15, NOT 1.5"
+    },
+    {
+      "input": "1,50",
+      "ok": true,
+      "value": 150,
+      "why": "same, two decimal places"
+    },
+    {
+      "input": "0,4",
+      "ok": true,
+      "value": 4,
+      "why": "same, leading zero"
+    },
+    {
+      "input": "123",
+      "ok": true,
+      "value": 123,
+      "why": "plain number"
+    },
+    {
+      "input": "123.7",
+      "ok": true,
+      "value": 124,
+      "why": "rounds up"
+    },
+    {
+      "input": "123.2",
+      "ok": true,
+      "value": 123,
+      "why": "rounds down"
+    },
+    {
+      "input": "123.5",
+      "ok": true,
+      "value": 124,
+      "why": "a positive half rounds away from zero on both sides"
+    },
+    {
+      "input": "100 + 50",
+      "ok": true,
+      "value": 150,
+      "why": "addition"
+    },
+    {
+      "input": "200 - 30",
+      "ok": true,
+      "value": 170,
+      "why": "subtraction"
+    },
+    {
+      "input": "10 * 5",
+      "ok": true,
+      "value": 50,
+      "why": "multiplication"
+    },
+    {
+      "input": "100 / 4",
+      "ok": true,
+      "value": 25,
+      "why": "division"
+    },
+    {
+      "input": "(10 + 20) * 3",
+      "ok": true,
+      "value": 90,
+      "why": "parentheses"
+    },
+    {
+      "input": "100 + 50 * 2 - 10",
+      "ok": true,
+      "value": 190,
+      "why": "precedence"
+    },
+    {
+      "input": "100 / (2 + 3) * 4",
+      "ok": true,
+      "value": 80,
+      "why": "precedence with parentheses"
+    },
+    {
+      "input": "-10",
+      "ok": true,
+      "value": -10,
+      "why": "negative"
+    },
+    {
+      "input": "+5",
+      "ok": true,
+      "value": 5,
+      "why": "leading unary plus"
+    },
+    {
+      "input": "--5",
+      "ok": true,
+      "value": 5,
+      "why": "double negation"
+    },
+    {
+      "input": "-+5",
+      "ok": true,
+      "value": -5,
+      "why": "mixed unary signs"
+    },
+    {
+      "input": "5--3",
+      "ok": true,
+      "value": 8,
+      "why": "binary minus then unary minus"
+    },
+    {
+      "input": "5+-3",
+      "ok": true,
+      "value": 2,
+      "why": "binary plus then unary minus"
+    },
+    {
+      "input": "-(10 + 5)",
+      "ok": true,
+      "value": -15,
+      "why": "unary minus on a parenthesized expression"
+    },
+    {
+      "input": "0",
+      "ok": true,
+      "value": 0,
+      "why": "honest zero"
+    },
+    {
+      "input": "0.0",
+      "ok": true,
+      "value": 0,
+      "why": "honest zero"
+    },
+    {
+      "input": "(0)",
+      "ok": true,
+      "value": 0,
+      "why": "honest zero"
+    },
+    {
+      "input": "10-10",
+      "ok": true,
+      "value": 0,
+      "why": "honest zero from arithmetic"
+    },
+    {
+      "input": "0*5",
+      "ok": true,
+      "value": 0,
+      "why": "honest zero from arithmetic"
+    },
+    {
+      "input": "0/1",
+      "ok": true,
+      "value": 0,
+      "why": "honest zero from arithmetic"
+    },
+    {
+      "input": "0.4",
+      "ok": true,
+      "value": 0,
+      "why": "rounds to an honest zero"
+    },
+    {
+      "input": "",
+      "ok": false,
+      "value": 0,
+      "why": "empty input"
+    },
+    {
+      "input": "abc",
+      "ok": false,
+      "value": 0,
+      "why": "not arithmetic"
+    },
+    {
+      "input": "10 + abc",
+      "ok": false,
+      "value": 0,
+      "why": "not arithmetic"
+    },
+    {
+      "input": "10 +",
+      "ok": false,
+      "value": 0,
+      "why": "trailing operator"
+    },
+    {
+      "input": "5 -",
+      "ok": false,
+      "value": 0,
+      "why": "trailing operator"
+    },
+    {
+      "input": "10 / 0",
+      "ok": false,
+      "value": 0,
+      "why": "division by zero"
+    },
+    {
+      "input": "100 / (5 - 5)",
+      "ok": false,
+      "value": 0,
+      "why": "division by zero via an expression"
+    },
+    {
+      "input": "(10 + 20",
+      "ok": false,
+      "value": 0,
+      "why": "unclosed parenthesis"
+    },
+    {
+      "input": "10 + 20)",
+      "ok": false,
+      "value": 0,
+      "why": "unopened parenthesis"
+    },
+    {
+      "input": "eval(1)",
+      "ok": false,
+      "value": 0,
+      "why": "not arithmetic"
+    },
+    {
+      "input": "10; alert(1)",
+      "ok": false,
+      "value": 0,
+      "why": "not arithmetic"
+    },
+    {
+      "input": "10 & 20",
+      "ok": false,
+      "value": 0,
+      "why": "bitwise operators are not in the grammar"
+    },
+    {
+      "input": "10 | 20",
+      "ok": false,
+      "value": 0,
+      "why": "same"
+    },
+    {
+      "input": "10 ^ 20",
+      "ok": false,
+      "value": 0,
+      "why": "same"
+    },
+    {
+      "input": "10 << 2",
+      "ok": false,
+      "value": 0,
+      "why": "same"
+    },
+    {
+      "input": "1e1",
+      "ok": false,
+      "value": 0,
+      "why": "no exponent operator in the grammar"
+    },
+    {
+      "input": "1E1",
+      "ok": false,
+      "value": 0,
+      "why": "same, uppercase"
+    },
+    {
+      "input": "1e+06",
+      "ok": false,
+      "value": 0,
+      "why": "what a stringified 1000000 looks like"
+    },
+    {
+      "input": "1.234567e+06",
+      "ok": false,
+      "value": 0,
+      "why": "what a stringified 1234567 looks like"
+    },
+    {
+      "input": "\uff10",
+      "ok": false,
+      "value": 0,
+      "why": "fullwidth zero"
+    },
+    {
+      "input": "\uff11\uff12\uff13",
+      "ok": false,
+      "value": 0,
+      "why": "fullwidth digits"
+    },
+    {
+      "input": "\u0661\u0662\u0663",
+      "ok": false,
+      "value": 0,
+      "why": "Arabic-Indic digits"
+    },
+    {
+      "input": "\u00bd",
+      "ok": false,
+      "value": 0,
+      "why": "vulgar fraction"
+    },
+    {
+      "input": "\u2153",
+      "ok": false,
+      "value": 0,
+      "why": "vulgar fraction"
+    },
+    {
+      "input": "<nil>",
+      "ok": false,
+      "value": 0,
+      "why": "stringified nil from an absent JSON key"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #351
Closes #353

> **Stacked on #356.** Base is `parse-amount-normalization-tests`; GitHub will retarget this to `staging` automatically once #356 merges. The diff shown against `staging` before then will include #356's commit.

## Why these are one PR

Both live in `internal/service/mathparser.go` **and** `client/src/lib/mathParser.ts`, both have to change in lockstep, and both rewrite the same two pinning tables that #356 just wrote. Splitting them guarantees a conflict in four files and buys nothing.

They also share a root cause worth naming: the safe-math parser exists twice — Go for the API, TypeScript because CSP forbids `eval()` in the browser (CLAUDE.md rule 12) — and nothing forced the two to agree. #353 is the *same* bug written twice with two different wrong answers; #351 is the two halves having drifted apart. So this PR ends with one shared table both implementations run (see below).

**Both parsers are fixed identically.** As #356's body argued: `EntryForm` parses the input box locally and POSTs the resulting *number*, so a Go-only fix leaves the SPA's behaviour unchanged, and a TS-only fix leaves the v1 API and the import path wrong.

---

## #353 — `parseNumber` discarded its conversion error

`parseNumber` consumes any run of `[0-9.]`, which is greedy enough to swallow more than one decimal point. Go then handed the run to `fmt.Sscanf` and **threw the error away**, which quietly made Sscanf's prefix-scanning semantics the real grammar. TS had the identical bug via `parseFloat`, which truncates rather than returning `NaN`.

| input | before (Go / TS) | after (both) |
|---|---|---|
| `5.0.0` | `Ok=true 5` | **rejected** |
| `1.2.3` | `Ok=true 1` (Go: 1.2 rounded; TS: 1.2 rounded) | **rejected** |
| `5..` | `Ok=true 5` | **rejected** |
| `1.2.3+1` | `Ok=true 2` | **rejected** |
| `(5.0.0)` | `Ok=true 5` | **rejected** |

Go now uses `strconv.ParseFloat`, which has no prefix behaviour, and sets `p.err` when it fails. TS shape-checks the run against `/^(?:\d+(?:\.\d*)?|\.\d+)$/` before calling `parseFloat`. Those two accept **exactly** the same set: the run can only contain digits and dots, so no exponent, sign, hex float or underscore can reach either.

A user who fat-fingers `1.2.3` now gets a validation error instead of a silently accepted 1 kcal.

### The `.5` / `5.` asymmetry: made symmetric, in the *accepting* direction

`parseFactor` required a digit to start a number, so `5.` was accepted and `.5` was not. **Both are accepted now.** Reasoning:

1. **It was not a considered decision, it was a side effect of that one `if`.** #356 pinned it as a divergence from `ParseWeight`, but the rationale it recorded for the `ParseAmount`/`ParseWeight` split is *calculator vs. scalar* — commas can't be both a thousands separator and a decimal point in an expression, and `ParseFloat` gets exponents for free. `.5` follows from none of that. `ParseWeight(".5")` is `0.5`; the two number boxes in the app disagreed on the same keystroke for no reason.
2. **Accepting is unambiguous.** `.` is not an operator in this grammar, so admitting it as a number start introduces no parse ambiguity, and `parseNumber` still rejects the runs that are not numbers (`.`, `..`, `..5`).
3. **Accepting only widens; rejecting `5.` would narrow.** `.5` and `5.` are both valid float literals in Go *and* JavaScript. Converging by rejecting `5.` would break an input that works today and that people type; converging by accepting `.5` breaks nothing.

That row in `TestParseAmountVsParseWeightSyntaxDivergence` is now an *agreement* row rather than a divergence row, and the test's doc comment says why it left.

---

## #351 — whitespace stripping diverged

Go stripped `strings.ReplaceAll(input, " ", "")` — U+0020 only. TS stripped `/\s+/g` — all of Unicode whitespace. So `1 000` with a NBSP (what `fr-FR` and `de-CH` produce, and what you get pasting out of a spreadsheet or a nutrition label) worked in the browser and 400'd on the API.

Go now strips via `strings.Map` over `unicode.IsSpace`. The two definitions differ in exactly two code points, and **both are added rather than dropped** so the sets are identical:

| code point | `unicode.IsSpace` | JS `\s` | now |
|---|---|---|---|
| U+0085 NEXT LINE | yes | no | added to the TS regex |
| U+FEFF BOM / ZWNBSP | no | yes | added to the Go predicate |
| U+200B ZERO WIDTH SPACE | no | no | **still rejected on both** — not a space separator |

`0 x 10` spelled with NBSPs behaves exactly like the U+0020 form (`Ok=true, Value=0`), because the hex check still runs *before* whitespace is stripped on both sides — #356's carve-out is preserved verbatim.

### The import path, which is the worse half

`POST /settings/import` `continue`d an unparseable row with **no error at all**: the row vanished and the response still said the import succeeded. And the import is destructive — it `DELETE`s the user's existing entries first — so there is no second chance to compare.

The NBSP fix removes the specific cause (an amount the browser wrote into an export file now re-imports), but the silent-skip remains for every other unreadable row. `parseImportData` now **counts** every row it drops — bad amount, bad date, non-object element, and rows past the 10,000 cap — and `Import` appends one sentence to the message it already returns:

```
Imported 3 entries. Skipped 7 rows that could not be read.
```

This was the small version: it fits inside the existing `{"ok": true, "message": "..."}` response, which `Account.tsx` already renders verbatim, so **no response-shape, OpenAPI or i18n change**. Per-row diagnostics (*which* rows, and why) do need a shape change, so they are filed as **#409**, along with a dry-run mode — the thing that actually makes a destructive import safe.

---

## The cross-language parity table (new)

`testdata/parse_amount_cases.json` — **110 cases**, each with a `why`, run by:

- `TestParseAmountSharedCases` in `internal/service/mathparser_test.go`
- `client/tests/mathParserParity.test.ts`

Two hand-maintained tables are what let #351 and #353 hide: nothing forced a change in one to be applied to the other, and both issues were found by reading the code, not by a failing test. One table with two runners cannot drift. It covers the classes where the two implementations use *different primitives* and are therefore at risk — whitespace, number literals, rounding, the hex carve-out, operator/comma rewrites, and the reject list.

It lives in `client/tests/` rather than `client/src/` because it reads the fixture with `node:fs`, and `tsc -b` covers only `src` and has no `@types/node` — the same reason `tests/barcodeDeps.test.ts` lives there. Nothing copies `testdata/` into the Docker image (the Dockerfile copies `cmd/` and `internal/` explicitly).

Two divergences are **deliberately excluded** and pinned per-language instead, documented in the fixture's `_readme`:

- **Negative half-rounding.** `math.Round(-1.5)` is `-2`; `Math.round(-1.5)` is `-1`. Go rounds a half away from zero, JS rounds it toward +∞. They agree on every positive half. Filed as **#408** — it is a rounding decision, not a parsing one, and fixing it in this PR would have been scope creep with a behaviour change attached.
- **Negative zero.** JS yields `-0` for `"-0"`/`"-0.4"` where Go yields `0`. Nothing observable distinguishes them, so it needs no fix, only the note #356 already wrote.

---

## Every pinned expectation that changed

`TestParseAmountNormalizationEdges` (Go) and `pins the consequences of the normalization pass` (TS), both updated in #356's `why`-annotation style:

| input | #356 pinned | now | why |
|---|---|---|---|
| `5\u00a05` (NBSP) | Go `false` / TS `true, 55` | **`true, 55` both** | NBSP is stripped on both sides (#351) |
| `1\u00a0000` (NBSP) | Go `false` (TS untested) | **`true, 1000` both** | the case #351 was filed about |
| `.5` | `false, 0` | **`true, 1`** | leading dot accepted; symmetric with `5.` |
| `5..` | `true, 5` | **`false, 0`** | two decimal points is not a number |
| `5.0.0` | `true, 5` | **`false, 0`** | no longer truncated to its valid prefix |
| `1.2.3` | `true, 1` | **`false, 0`** | same |
| `.5` in `…VsParseWeightSyntaxDivergence` | `ParseAmount` rejects, `ParseWeight` `0.5` | **both accept** | no longer a divergence; row reframed |

New rows added to both tables: `.4`→0, `.`→rejected, `1.2.3+1`→rejected, `5\u200b5`→rejected (ZWSP is not whitespace in either language), `1.2.3` to the `ParseWeight` comparison (both reject), and the `-1.5` / `10-11.5` per-language rounding rows for #408.

**Nothing #356 fixed regressed.** `2x3`=6, `10x16`=160, `100x2`=200, `1.0x2`=2, `1,0x2`=20, `0 x 10`=0, all hex forms rejected — all re-run, and all now also in the shared fixture so both languages enforce them.

---

## Verification

```
$ export GOFLAGS=-p=2 GOMAXPROCS=2
$ git fetch origin && git -c rebase.autoStash=false rebase origin/parse-amount-normalization-tests
Successfully rebased and updated refs/heads/mathparser-number-parsing.

$ go build ./... && go vet ./... && go test ./...
?   	schautrack/cmd/apidocs	[no test files]
ok  	schautrack/cmd/server	0.009s
?   	schautrack/internal/apierr	[no test files]
ok  	schautrack/internal/clientip	(cached)
?   	schautrack/internal/config	[no test files]
ok  	schautrack/internal/database	0.003s
ok  	schautrack/internal/handler	0.922s
ok  	schautrack/internal/middleware	0.067s
?   	schautrack/internal/model	[no test files]
ok  	schautrack/internal/openapi	0.022s
ok  	schautrack/internal/release	(cached)
ok  	schautrack/internal/service	0.214s
ok  	schautrack/internal/session	0.004s
ok  	schautrack/internal/sse	(cached)
```

```
$ go test ./internal/service/ -run 'ParseAmount|MathParser' -v
=== RUN   TestParseAmountSimpleNumbers
--- PASS: TestParseAmountSimpleNumbers (0.00s)
=== RUN   TestParseAmountDecimalRounding
--- PASS: TestParseAmountDecimalRounding (0.00s)
=== RUN   TestParseAmountArithmetic
--- PASS: TestParseAmountArithmetic (0.00s)
=== RUN   TestParseAmountParentheses
--- PASS: TestParseAmountParentheses (0.00s)
=== RUN   TestParseAmountAlternativeSymbols
--- PASS: TestParseAmountAlternativeSymbols (0.00s)
=== RUN   TestParseAmountCommas
--- PASS: TestParseAmountCommas (0.00s)
=== RUN   TestParseAmountInvalid
--- PASS: TestParseAmountInvalid (0.00s)
=== RUN   TestParseAmountDangerous
--- PASS: TestParseAmountDangerous (0.00s)
=== RUN   TestParseAmountTooLong
--- PASS: TestParseAmountTooLong (0.00s)
=== RUN   TestParseAmountMalformedParentheses
--- PASS: TestParseAmountMalformedParentheses (0.00s)
=== RUN   TestParseAmountDivisionByZero
--- PASS: TestParseAmountDivisionByZero (0.00s)
=== RUN   TestParseAmountNegative
--- PASS: TestParseAmountNegative (0.00s)
=== RUN   TestParseAmountComplex
--- PASS: TestParseAmountComplex (0.00s)
=== RUN   TestParseAmountMaxAbs
--- PASS: TestParseAmountMaxAbs (0.00s)
=== RUN   TestParseAmountNormalizationEdges
--- PASS: TestParseAmountNormalizationEdges (0.00s)
=== RUN   TestParseAmountAcceptedZeros
--- PASS: TestParseAmountAcceptedZeros (0.00s)
=== RUN   TestParseAmountVsParseWeightSyntaxDivergence
--- PASS: TestParseAmountVsParseWeightSyntaxDivergence (0.00s)
=== RUN   TestParseAmountSharedCases
    mathparser_test.go:491: 110 shared cases
--- PASS: TestParseAmountSharedCases (0.00s)
PASS
ok  	schautrack/internal/service	0.003s
```

```
$ go test ./internal/handler/ -run 'ParseImportData|ImportMessage' -v
=== RUN   TestParseImportDataCountsSkippedRows
=== RUN   TestParseImportDataCountsSkippedRows/unparseable_amount_is_counted,_not_silently_dropped
=== RUN   TestParseImportDataCountsSkippedRows/NBSP_thousands_separator_now_imports_instead_of_vanishing
=== RUN   TestParseImportDataCountsSkippedRows/bad_date,_non-object_row_and_zero_amount_all_count
=== RUN   TestParseImportDataCountsSkippedRows/weights_are_counted_separately
=== RUN   TestParseImportDataCountsSkippedRows/a_clean_file_reports_nothing_skipped
--- PASS: TestParseImportDataCountsSkippedRows (0.00s)
=== RUN   TestParseImportDataCountsRowsPastTheCap
--- PASS: TestParseImportDataCountsRowsPastTheCap (0.03s)
=== RUN   TestImportMessage
--- PASS: TestImportMessage (0.00s)
PASS
ok  	schautrack/internal/handler	0.079s
```

```
$ cd client && npm ci && npm run typecheck && npm test
> typecheck
> tsc -b --force

> test
> vitest run
 RUN  v4.1.10

 Test Files  13 passed (13)
      Tests  144 passed (144)
   Duration  1.90s
```

```
$ npm run i18n:drift
> i18next-cli extract --ci
- Running i18next key extractor...
✔ Extraction complete!
✅ No files were updated.

$ npm run i18n:check
> node scripts/i18n-parity.mjs
✓ de: 820 keys (parity with en: 818)
✓ es: 820 keys (parity with en: 818)
✓ fr: 820 keys (parity with en: 818)
✓ it: 820 keys (parity with en: 818)
✓ nl: 820 keys (parity with en: 818)
✓ pl: 844 keys (parity with en: 818)
✓ pt: 820 keys (parity with en: 818)

i18n parity check passed.
```

`gofmt -l` reports nothing for the files touched here. It does flag `internal/service/mathparser_test.go`, but that is pre-existing at the parent commit (the one-line `struct{ input string; ok bool; value int }` style, 15 files in `internal/` are in the same state) and is not touched by this change.

`npm run test:e2e` and `docker compose --build` were not run.

## Follow-ups filed

- **#408** (bug) — `parseAmount` rounds a negative half differently in Go and TS: `10-11.5` is `-2` on the server, `-1` in the browser. Pinned per-language and excluded from the shared fixture, with pointers to every row to move when it is fixed.
- **#409** (enhancement) — Import now says *how many* rows it skipped but not *which* or *why*; that needs a response-shape + OpenAPI + i18n change. Includes a dry-run proposal, since `parseImportData` is already a pure function.

## Scope

`ParseWeight` / `ParseBodyFat` are untouched (#302 owns them; the only change near them is the `.5` row in the comparison test flipping to an agreement). No fuzz targets (#315 owns those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
