### PR TITLE
test(e2e): open the add-food sheet before reading the macro inputs

### DIFF
--- a/e2e/macros-settings.spec.ts
+++ b/e2e/macros-settings.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { psql, createIsolatedUser } from './fixtures/helpers';
+import { psql, createIsolatedUser, openAddFood } from './fixtures/helpers';
 
 const baseURL = process.env.E2E_BASE_URL || 'http://localhost:3001';
 let user: { email: string; password: string; id: string };
@@ -227,11 +227,19 @@ test.describe.serial('Macro Settings', () => {
     await page.goto(`${baseURL}/dashboard`);
     await page.waitForURL(/\/dashboard/);
 
-    // Macro inputs use inputmode="numeric"; calories auto-calc field is readonly with inputmode="tel"
-    const proteinInput = page.locator('label').filter({ hasText: 'Protein' }).locator('..').locator('input[inputmode="numeric"]');
-    const carbsInput = page.locator('label').filter({ hasText: 'Carbs' }).locator('..').locator('input[inputmode="numeric"]');
-    const fatInput = page.locator('label').filter({ hasText: 'Fat' }).locator('..').locator('input[inputmode="numeric"]');
-    const caloriesInput = page.locator('label').filter({ hasText: 'Calories' }).locator('..').locator('input[inputmode="tel"]');
+    // The entry form lives in the "Add food" sheet, not inline on the page.
+    // Desktop used to render an always-open inline form and this spec was
+    // written against that; the sheet is now the only way in on every
+    // viewport, so the form has to be opened before its fields exist at all.
+    const addFood = await openAddFood(page);
+
+    // Macro inputs use inputmode="numeric"; calories auto-calc field is readonly with inputmode="tel".
+    // Scoped to the dialog so these cannot accidentally match a label of the
+    // same name elsewhere on the dashboard behind the sheet.
+    const proteinInput = addFood.locator('label').filter({ hasText: 'Protein' }).locator('..').locator('input[inputmode="numeric"]');
+    const carbsInput = addFood.locator('label').filter({ hasText: 'Carbs' }).locator('..').locator('input[inputmode="numeric"]');
+    const fatInput = addFood.locator('label').filter({ hasText: 'Fat' }).locator('..').locator('input[inputmode="numeric"]');
+    const caloriesInput = addFood.locator('label').filter({ hasText: 'Calories' }).locator('..').locator('input[inputmode="tel"]');
 
     await expect(proteinInput).toBeVisible({ timeout: 10000 });
     await proteinInput.click();


### PR DESCRIPTION
## What

`macros-settings.spec.ts` "auto-calc calories computes value from macros in entry form" navigated to `/dashboard` and looked for the Protein input directly:

```ts
const proteinInput = page.locator('label').filter({ hasText: 'Protein' })
  .locator('..').locator('input[inputmode="numeric"]');
await expect(proteinInput).toBeVisible({ timeout: 10000 });
```

That worked when desktop rendered an always-open inline entry form. It no longer does: `Dashboard.tsx` mounts `EntryForm` inside `<Sheet open={addOpen}>` with `addOpen` defaulting to `false`, so on every viewport the fields do not exist until the "Add food" FAB is clicked. The spec failed on `toBeVisible` with `element(s) not found`, deterministically, on both attempts.

## Fix

Use the `openAddFood` helper the other specs already use, and scope the four field locators to the returned dialog so they cannot match a same-named label on the dashboard behind the sheet.

## Why it went unnoticed

This is test rot, not an app defect. The E2E suite has never run in CI (#313 / #312), so nothing caught the spec drifting away from the UI when the inline desktop form was removed. It surfaced as the single hard failure in #328, which is the PR that first runs the suite in CI.

## Verification

Run against the real stack (`compose.test.yml`), not just typechecked:

```
✓ [chromium] › e2e/macros-settings.spec.ts:181:7 › Macro Settings › auto-calc calories computes value from macros in entry form (5.0s)
2 passed (8.9s)
```

Unblocks the hard failure in #328.