### PR TITLE
fix(api): document ageDays and stale on BodyComposition

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -3313,6 +3313,10 @@
         "type": "object",
         "description": "Body composition derived from the most recent body-fat reading. That reading can be older than the current weight — body composition is measured less often — so `date` says when it was taken.",
         "properties": {
+          "ageDays": {
+            "type": "integer",
+            "description": "Whole days between `date` and today. Negative is possible and means fresh: `date` is the account's local date while today is the server's, so a few hours of timezone skew can put the reading marginally ahead."
+          },
           "bodyFatPct": {
             "type": "number",
             "description": "Body fat as a percentage of total mass. A percentage, so never unit-converted."
@@ -3346,6 +3350,10 @@
           "leanMass": {
             "type": "number",
             "description": "Fat-free mass at that reading. In the account's weight unit."
+          },
+          "stale": {
+            "type": "boolean",
+            "description": "Whether the reading is too old to choose the BMR formula (older than 90 days). A stale reading is still reported — it is the account's most recent measurement — but `computed.bmrFormula` falls back to `mifflin_st_jeor` instead of `katch_mcardle`."
           }
         },
         "required": [
@@ -3353,7 +3361,9 @@
           "bodyFatPct",
           "leanMass",
           "fatMass",
-          "category"
+          "category",
+          "ageDays",
+          "stale"
         ]
       },
       "Completion": {

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -909,11 +909,13 @@ Body composition derived from the most recent body-fat reading. That reading can
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
+| `ageDays` | `integer` | yes | Whole days between `date` and today. Negative is possible and means fresh: `date` is the account's local date while today is the server's, so a few hours of timezone skew can put the reading marginally ahead. |
 | `bodyFatPct` | `number` | yes | Body fat as a percentage of total mass. A percentage, so never unit-converted. |
 | `category` | `string` or `null` | yes | The band `bodyFatPct` falls in for this sex: `essential`, `athletic`, `fitness`, `average` or `obese`. `null` when the sex is unknown — the bands genuinely differ by sex, so no label is given rather than a wrong one. |
 | `date` | `string` (date) | yes | The day the body-fat reading was recorded. |
 | `fatMass` | `number` | yes | Fat mass at that reading. In the account's weight unit. |
 | `leanMass` | `number` | yes | Fat-free mass at that reading. In the account's weight unit. |
+| `stale` | `boolean` | yes | Whether the reading is too old to choose the BMR formula (older than 90 days). A stale reading is still reported — it is the account's most recent measurement — but `computed.bmrFormula` falls back to `mifflin_st_jeor` instead of `katch_mcardle`. |
 
 ### Completion
 

--- a/internal/handler/v1_autocalc_integration_test.go
+++ b/internal/handler/v1_autocalc_integration_test.go
@@ -147,12 +147,16 @@ func TestV1BodyLimitIsEnforced(t *testing.T) {
 	requireProblemShape(t, withKey)
 }
 
-// TestV1SavedFoodsCollectionDoesNotPaginate documents the behaviour #298 owns:
-// GET /saved-foods honours `limit` but never reports that it truncated, so a
-// sync client cannot tell a short page from a complete one.
+// TestV1SavedFoodsCollectionDoesNotPaginate pins what #298 settled: the
+// collection is not paginated and always returns the account's complete set.
+// `limit` is still accepted on the wire but ignored, which is the safe
+// direction — it can only ever return more than a caller asked for, never
+// fewer rows than exist.
 //
-// TODO(#298): when has_more/next_cursor are added (or the limit is dropped),
-// turn this into the same pagination walk TestV1EntriesKeysetPagination... does.
+// It previously asserted the opposite, that `limit` truncated the response
+// with no has_more to say so. That was the bug: a client with 60 saved foods
+// got 50 and no indication the page was partial, so a sync reasonably
+// concluded the other 10 had been deleted.
 func TestV1SavedFoodsCollectionDoesNotPaginate(t *testing.T) {
 	e := newV1Env(t)
 	token := e.token(service.ScopeFoodsWrite)
@@ -172,12 +176,12 @@ func TestV1SavedFoodsCollectionDoesNotPaginate(t *testing.T) {
 
 	var page v1List[v1SavedFood]
 	decodeJSON(t, rec, &page)
-	if len(page.Data) != 2 {
-		t.Fatalf("got %d foods, want the requested 2", len(page.Data))
+	if len(page.Data) != 3 {
+		t.Fatalf("got %d foods, want all 3 — `limit` must be ignored, not silently truncate", len(page.Data))
 	}
 	if page.HasMore != nil || page.NextCursor != nil {
-		t.Fatalf("has_more/next_cursor are now populated (%v/%v) — #298 is fixed, so replace this "+
-			"test with a real pagination walk", page.HasMore, page.NextCursor)
+		t.Fatalf("has_more/next_cursor are populated (%v/%v) — this collection is documented as "+
+			"unpaginated and the SavedFoodList schema does not declare them", page.HasMore, page.NextCursor)
 	}
 }
 

--- a/internal/handler/v1_idempotency_integration_test.go
+++ b/internal/handler/v1_idempotency_integration_test.go
@@ -286,15 +286,17 @@ func TestV1IdempotencyAppliesToTrackingASavedFood(t *testing.T) {
 	}
 }
 
-// TestV1IdempotencyIsIgnoredWhereItIsNotImplemented documents today's behaviour
-// on the two creates that are NOT wrapped, so the gap is visible in the test
-// output rather than only in prose.
+// TestV1IdempotencyAppliesToCreatingATodo is the replay assertion the TODO on
+// this test asked for. #294 wrapped POST /todos and POST /saved-foods in
+// withIdempotency, so a retried create now replays the stored response instead
+// of writing a second row.
 //
-// TODO(#294): once POST /todos and POST /saved-foods are wrapped, these become
-// replay assertions like the ones above. Asserting the current behaviour keeps
-// the suite honest in the meantime: the header is accepted and ignored, which
-// is exactly the silent double-create #294 describes.
-func TestV1IdempotencyIsIgnoredWhereItIsNotImplemented(t *testing.T) {
+// It previously asserted the opposite — two todos, no Idempotency-Replayed —
+// to keep the gap visible in the test output while it existed. Left as a
+// pinned assertion rather than deleted: the silent double-create is the exact
+// failure #294 was filed for, and a retry after a timeout is the normal way to
+// hit it.
+func TestV1IdempotencyAppliesToCreatingATodo(t *testing.T) {
 	e := newV1Env(t)
 	token := e.token(service.ScopeTodosWrite)
 
@@ -316,11 +318,10 @@ func TestV1IdempotencyIsIgnoredWhereItIsNotImplemented(t *testing.T) {
 		`SELECT COUNT(*)::int FROM todos WHERE user_id = $1 AND archived = FALSE`, e.UserID).Scan(&todos); err != nil {
 		t.Fatalf("counting todos: %v", err)
 	}
-	if todos != 2 {
-		t.Fatalf("got %d todos; this test asserts the CURRENT (buggy) behaviour of #294 — "+
-			"if POST /todos now honours Idempotency-Key, turn this into a replay assertion", todos)
+	if todos != 1 {
+		t.Fatalf("got %d todos after a retried create with the same Idempotency-Key, want 1", todos)
 	}
-	if second.Header().Get("Idempotency-Replayed") != "" {
-		t.Error("Idempotency-Replayed appeared on an endpoint that does not implement replay")
+	if second.Header().Get("Idempotency-Replayed") != "true" {
+		t.Error("the retried create was not marked as a replay; a client cannot tell it from a second create")
 	}
 }

--- a/internal/openapi/spec.go
+++ b/internal/openapi/spec.go
@@ -625,7 +625,9 @@ func planSchemas() map[string]*Schema {
 				"leanMass":   number("Fat-free mass at that reading." + inUnit),
 				"fatMass":    number("Fat mass at that reading." + inUnit),
 				"category":   nullEnumStr("The band `bodyFatPct` falls in for this sex: `essential`, `athletic`, `fitness`, `average` or `obese`. `null` when the sex is unknown — the bands genuinely differ by sex, so no label is given rather than a wrong one.", "essential", "athletic", "fitness", "average", "obese"),
-			}, "date", "bodyFatPct", "leanMass", "fatMass", "category"),
+				"ageDays":    integer("Whole days between `date` and today. Negative is possible and means fresh: `date` is the account's local date while today is the server's, so a few hours of timezone skew can put the reading marginally ahead."),
+				"stale":      boolean("Whether the reading is too old to choose the BMR formula (older than 90 days). A stale reading is still reported — it is the account's most recent measurement — but `computed.bmrFormula` falls back to `mifflin_st_jeor` instead of `katch_mcardle`."),
+			}, "date", "bodyFatPct", "leanMass", "fatMass", "category", "ageDays", "stale"),
 
 		"HealthyRange": object("The weight range corresponding to a BMI of 18.5 to 24.9 at the account's height.",
 			map[string]*Schema{
@@ -919,7 +921,7 @@ func paths() map[string]*PathItem {
 				OperationID: "putWeight", Summary: "Record a day's weight",
 				Description: "Idempotent: repeating the same request is harmless, which makes it safe for a scale integration to retry. Returns 201 the first time a date is written and 200 thereafter. " +
 					"`body_fat` is three-state: omit it and any stored reading for that day is left alone, send `null` to clear it, send a number to record it.",
-				Tags:        []string{"Weight"}, Scope: service.ScopeWeightWrite,
+				Tags: []string{"Weight"}, Scope: service.ScopeWeightWrite,
 				Security:    []SecurityRequirement{{"bearerAuth": {service.ScopeWeightWrite}}},
 				Parameters:  []Parameter{dateParam},
 				RequestBody: &RequestBody{Required: true, Content: jsonBody(ref("WeightInput"))},


### PR DESCRIPTION
## staging is red

`TestPlanMatchesSchema` fails on every subtest on the current tip of `staging`:

```
--- FAIL: TestPlanMatchesSchema/everything_populated
    Plan does not match its schema:
      - Plan.composition.ageDays: present in the response but undocumented
      - Plan.composition.stale: present in the response but undocumented
```

## How two green PRs produced a red merge

- **#352** (issue #300) added `AgeDays` and `Stale` to `service.BodyComposition`.
- **#365** (issue #301) replaced the free-form `Plan` blob — `additionalProperties: true`, which `Document.Validate` treats as "check nothing" — with real component schemas.

Each was green on its own branch, and necessarily so: before #365 the `Plan` schema accepted any extra property, and before #352 there were no extra properties to accept. Only the merged result carries fields the schema does not declare. Neither PR's CI could have caught this, and git reported no conflict — the two changes are in different files.

## Fix

Declare the two properties the server already sends. No behaviour change.

Both are `required`, matching the Go struct: `AgeDays int` and `Stale bool` are plain values rather than pointers, so they are always present in the JSON.

Also includes a one-line `gofmt` alignment fix in `paths()` left behind by #339's merge.

## Verification

```
go run ./cmd/apidocs -check   # API docs are up to date.
go vet ./...                  # clean
go test ./...                 # ok, 10/10 packages
```