### PR TITLE
fix(api): surface an oversized trailing value, and stop hardcoding the weight cap

### DIFF
--- a/internal/handler/v1_common.go
+++ b/internal/handler/v1_common.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -154,14 +155,47 @@ func decodeV1(w http.ResponseWriter, r *http.Request, dst any) *apierr.Problem {
 		return decodeV1Problem(err)
 	}
 
-	// A second Decode on the *body* must hit EOF; anything else means the
+	// A second Decode on the *body* must hit io.EOF; anything else means the
 	// caller sent more than one JSON value and half of it would be ignored.
 	// Checked last so that a malformed first object is reported as the field
 	// error it is rather than as a multi-value body.
-	if dec.More() {
+	//
+	// Decode, not More(). More() reports whether another value is *in the
+	// current array or object*, and it answers false on any read error —
+	// including the MaxBytesError raised when the reader hits maxV1Body while
+	// looking ahead. A body whose first object is valid, followed by padding
+	// past the limit and a second value, therefore sailed through: More()
+	// swallowed the size error, decodeV1 returned nil, and the trailing value
+	// was silently dropped from a request the caller was told had succeeded
+	// (#411). Decoding into a discard target surfaces both faults instead.
+	var trailing json.RawMessage
+	err := dec.Decode(&trailing)
+	switch {
+	case errors.Is(err, io.EOF):
+		return nil // exactly one value, which is the contract
+
+	case isMaxBytes(err):
+		// The only fault that gets its own answer. "Your request is too big"
+		// and "send exactly one object" are different instructions, and a
+		// caller who padded past 1 MB cannot act on the second one.
+		return decodeV1Problem(err)
+
+	default:
+		// Anything else past the first object — a second value, or trailing
+		// garbage that does not parse — is the same mistake from the caller's
+		// side: the body is not one JSON object. Kept as one message because
+		// naming the structural rule is more actionable than reporting a
+		// syntax error in bytes the server was never going to use.
 		return apierr.BadRequest("The request body must contain exactly one JSON object.")
 	}
-	return nil
+}
+
+// isMaxBytes reports whether err is the size-limit failure raised by
+// http.MaxBytesReader. Split out because decodeV1 has to distinguish it from
+// every other trailing-read failure, while decodeV1Problem only has to map it.
+func isMaxBytes(err error) bool {
+	var maxErr *http.MaxBytesError
+	return errors.As(err, &maxErr)
 }
 
 // decodeV1Problem maps an encoding/json failure onto a problem detail. Shared

--- a/internal/handler/v1_common_test.go
+++ b/internal/handler/v1_common_test.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
 
 	"schautrack/internal/apierr"
+	"schautrack/internal/service"
 )
 
 // Characterization tests for the v1 request-parsing helpers in v1_common.go.
@@ -878,5 +880,73 @@ func assertBadRequest(t *testing.T, p *apierr.Problem, wantDetail string) {
 	}
 	if p.Detail != wantDetail {
 		t.Errorf("detail = %q, want %q", p.Detail, wantDetail)
+	}
+}
+
+// TestDecodeV1TrailingValuePastTheSizeLimit is the regression pin for #411.
+//
+// The trailing-value check used to be `if dec.More()`. More() answers false on
+// *any* read error, and the reader here is a MaxBytesReader — so a body whose
+// first object is valid, followed by enough padding to cross maxV1Body and
+// then a second value, produced: pass 1 fine, pass 2 fine, More() false
+// (because looking ahead tripped the size limit), and decodeV1 returned nil.
+// The caller got a 2xx for a request the server had only half read, with the
+// trailing value silently discarded — the same silent-data-loss shape
+// DisallowUnknownFields and the null-body check exist to prevent.
+//
+// Both faults in that body must surface, and the size one is the more useful
+// answer: it tells the caller their request was too big, not that they wrote
+// it wrong.
+func TestDecodeV1TrailingValuePastTheSizeLimit(t *testing.T) {
+	var dst v1CommonTestBody
+
+	// A valid first object, then padding past the cap, then a second value.
+	body := `{"calories":1}` + strings.Repeat(" ", maxV1Body) + `{"calories":2}`
+	got := decodeV1(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), &dst)
+	if got == nil {
+		t.Fatal("decodeV1 accepted a body that runs past the size limit and drops a trailing value")
+	}
+	if got.Status != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413 (got %+v)", got.Status, got)
+	}
+
+	// The ordinary multi-value body, well under the cap, still gets its own
+	// 400 — the fix must not turn every trailing value into a size error.
+	got = decodeV1(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"calories":1}{"calories":2}`)), &dst)
+	if got == nil || got.Status != http.StatusBadRequest {
+		t.Fatalf("multi-value body = %v, want 400", got)
+	}
+	if got.Detail != "The request body must contain exactly one JSON object." {
+		t.Errorf("detail = %q, want the exactly-one-object detail", got.Detail)
+	}
+
+	// And a single object followed only by whitespace is still valid: the
+	// trailing Decode must read io.EOF, not treat the padding as a value.
+	got = decodeV1(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"calories":1}   `+"\n\t")), &dst)
+	if got != nil {
+		t.Errorf("object followed by whitespace = %v, want accepted", got)
+	}
+}
+
+// TestV1WeightErrorStatesTheRealCap is the pin for #318. The PUT /weight/{date}
+// rejection used to spell the bound out as the literal 1500, so raising
+// service.MaxWeight would have left the API telling clients a limit its own
+// parser no longer enforced. A wrong limit in an error message is worse than
+// no limit: it is the number a client will code against.
+func TestV1WeightErrorStatesTheRealCap(t *testing.T) {
+	src, err := os.ReadFile("v1_weight.go")
+	if err != nil {
+		t.Fatalf("reading v1_weight.go: %v", err)
+	}
+	if strings.Contains(string(src), "at most 1500") {
+		t.Error("v1_weight.go hardcodes the weight cap in its error string; " +
+			"interpolate service.MaxWeight so the two cannot drift")
+	}
+	want := fmt.Sprintf("at most %g", service.MaxWeight)
+	if want != "at most 1500" {
+		t.Fatalf("this test assumes service.MaxWeight formats as 1500, got %q", want)
 	}
 }

--- a/internal/handler/v1_weight.go
+++ b/internal/handler/v1_weight.go
@@ -244,11 +244,21 @@ func (h *V1Handler) PutWeightV1(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Reuse the app's own parser so the API accepts exactly the values the UI
-	// does, including its rounding to two decimals and its 0 < w <= 1500 bound.
+	// does, including its rounding to two decimals and its
+	// 0 < w <= service.MaxWeight bound.
+	//
+	// The bound is interpolated from service.MaxWeight rather than written out,
+	// so raising the cap cannot leave this endpoint telling clients a number
+	// the parser no longer enforces — the comment and the error string are the
+	// only places the API states the limit, and a stale limit in an error
+	// message is worse than none.
 	parsed := service.ParseWeight(fmt.Sprintf("%v", in.Weight))
 	if !parsed.Ok {
 		apierr.Write(w, r, apierr.Unprocessable("The weight value is not usable.",
-			apierr.InvalidParam{Name: "weight", Reason: "must be a number greater than 0 and at most 1500"}))
+			apierr.InvalidParam{
+				Name:   "weight",
+				Reason: fmt.Sprintf("must be a number greater than 0 and at most %g", service.MaxWeight),
+			}))
 		return
 	}
 


### PR DESCRIPTION
Closes #411
Closes #318

## #411 — `dec.More()` swallowed a MaxBytesError

`json.Decoder.More()` returns false on *any* read error. The reader is a `MaxBytesReader`, so this body:

```
{"calories":1}<1 MB of padding>{"calories":2}
```

decoded fine in both passes, then `More()` tripped the size limit while looking ahead, returned false, and `decodeV1` returned `nil`. The caller got a 2xx for a request the server had only half read, with the trailing value discarded — the same silent-data-loss shape `DisallowUnknownFields` and the null-body check exist to prevent.

Now decodes into a discard target. A MaxBytesError becomes a 413; every other trailing fault keeps the existing "exactly one JSON object" 400, since "too big" and "send one object" are different instructions and a padded body cannot act on the second.

## #318 — hardcoded 1500

The `PUT /weight/{date}` rejection stated the bound as a literal in both a comment and the 422 `reason`. Raising `service.MaxWeight` would have left the API advertising a limit its parser no longer enforced — and that string is the number a client codes against. Interpolated, with a test that fails if the literal returns.

## Verification

Against a real Postgres 18, since a plain `go test ./...` silently skips every DB-backed test:
```
go vet ./...   # clean
go test ./...  # ok, 10/10 packages
```