### PR TITLE
docs(api): derive the 413 response and the Idempotency-Replayed header

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -504,6 +504,12 @@
               }
             },
             "headers": {
+              "Idempotency-Replayed": {
+                "description": "Present and `true` only on a replayed response — the request matched a stored Idempotency-Key and nothing new was created. Absent on the first request. This is the only way to distinguish a replay from a fresh create, since a replay repeats the original status code.",
+                "schema": {
+                  "type": "boolean"
+                }
+              },
               "Location": {
                 "description": "URL of the created entry.",
                 "schema": {
@@ -544,6 +550,16 @@
           },
           "409": {
             "description": "The request collides with existing state — a duplicate name, a limit already reached, or a feature not enabled.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -786,6 +802,16 @@
           },
           "404": {
             "description": "No such resource, or it belongs to another account.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1144,6 +1170,16 @@
               }
             }
           },
+          "413": {
+            "description": "The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
           "422": {
             "description": "The request is well-formed but its values are rejected. `invalid_params` lists the offending fields.",
             "content": {
@@ -1384,6 +1420,16 @@
           },
           "409": {
             "description": "The request collides with existing state — a duplicate name, a limit already reached, or a feature not enabled.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1656,6 +1702,12 @@
               }
             },
             "headers": {
+              "Idempotency-Replayed": {
+                "description": "Present and `true` only on a replayed response — the request matched a stored Idempotency-Key and nothing new was created. Absent on the first request. This is the only way to distinguish a replay from a fresh create, since a replay repeats the original status code.",
+                "schema": {
+                  "type": "boolean"
+                }
+              },
               "Location": {
                 "description": "URL of the created food.",
                 "schema": {
@@ -1696,6 +1748,16 @@
           },
           "409": {
             "description": "The request collides with existing state — a duplicate name, a limit already reached, or a feature not enabled.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1833,6 +1895,16 @@
           },
           "409": {
             "description": "The request collides with existing state — a duplicate name, a limit already reached, or a feature not enabled.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2034,6 +2106,12 @@
               }
             },
             "headers": {
+              "Idempotency-Replayed": {
+                "description": "Present and `true` only on a replayed response — the request matched a stored Idempotency-Key and nothing new was created. Absent on the first request. This is the only way to distinguish a replay from a fresh create, since a replay repeats the original status code.",
+                "schema": {
+                  "type": "boolean"
+                }
+              },
               "Location": {
                 "description": "URL of the created entry.",
                 "schema": {
@@ -2084,6 +2162,16 @@
           },
           "409": {
             "description": "The request collides with existing state — a duplicate name, a limit already reached, or a feature not enabled.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2273,6 +2361,12 @@
               }
             },
             "headers": {
+              "Idempotency-Replayed": {
+                "description": "Present and `true` only on a replayed response — the request matched a stored Idempotency-Key and nothing new was created. Absent on the first request. This is the only way to distinguish a replay from a fresh create, since a replay repeats the original status code.",
+                "schema": {
+                  "type": "boolean"
+                }
+              },
               "Location": {
                 "description": "URL of the created todo.",
                 "schema": {
@@ -2313,6 +2407,16 @@
           },
           "409": {
             "description": "The request collides with existing state — a duplicate name, a limit already reached, or a feature not enabled.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2557,6 +2661,16 @@
               }
             }
           },
+          "413": {
+            "description": "The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
           "422": {
             "description": "The request is well-formed but its values are rejected. `invalid_params` lists the offending fields.",
             "content": {
@@ -2788,6 +2902,16 @@
           },
           "404": {
             "description": "No such resource, or it belongs to another account.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -3182,6 +3306,16 @@
           },
           "403": {
             "description": "The token is valid but lacks the scope this endpoint requires. The `required_scope` field names it.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5176,6 +5310,16 @@
       },
       "NotFound": {
         "description": "No such resource, or it belongs to another account.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "PayloadTooLarge": {
+        "description": "The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint.",
         "content": {
           "application/problem+json": {
             "schema": {

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -215,6 +215,7 @@ Only settings that affect how the rest of the API behaves are writable. Authenti
 | `400` | [`Problem`](#problem) — The request is malformed — unparseable JSON, an unknown field, or a bad query parameter. |
 | `401` | [`Problem`](#problem) — No token, or the token is unknown, revoked, or expired. |
 | `403` | [`Problem`](#problem) — The token is valid but lacks the scope this endpoint requires. The `required_scope` field names it. |
+| `413` | [`Problem`](#problem) — The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint. |
 | `422` | [`Problem`](#problem) — The request is well-formed but its values are rejected. `invalid_params` lists the offending fields. |
 | `429` | [`Problem`](#problem) — Too many requests. The `Retry-After` header gives the number of seconds until the window reopens. |
 | `500` | [`Problem`](#problem) — An unexpected server-side failure. |
@@ -275,6 +276,7 @@ Needs `calories`, at least one macro, or both. When the account computes calorie
 | `401` | [`Problem`](#problem) — No token, or the token is unknown, revoked, or expired. |
 | `403` | [`Problem`](#problem) — The token is valid but lacks the scope this endpoint requires. The `required_scope` field names it. |
 | `409` | [`Problem`](#problem) — The request collides with existing state — a duplicate name, a limit already reached, or a feature not enabled. |
+| `413` | [`Problem`](#problem) — The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint. |
 | `422` | [`Problem`](#problem) — The request is well-formed but its values are rejected. `invalid_params` lists the offending fields. |
 | `429` | [`Problem`](#problem) — Too many requests. The `Retry-After` header gives the number of seconds until the window reopens. |
 | `500` | [`Problem`](#problem) — An unexpected server-side failure. |
@@ -327,6 +329,7 @@ Only the fields present in the body are changed. Send `null` to clear the name o
 | `401` | [`Problem`](#problem) — No token, or the token is unknown, revoked, or expired. |
 | `403` | [`Problem`](#problem) — The token is valid but lacks the scope this endpoint requires. The `required_scope` field names it. |
 | `404` | [`Problem`](#problem) — No such resource, or it belongs to another account. |
+| `413` | [`Problem`](#problem) — The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint. |
 | `422` | [`Problem`](#problem) — The request is well-formed but its values are rejected. `invalid_params` lists the offending fields. |
 | `429` | [`Problem`](#problem) — Too many requests. The `Retry-After` header gives the number of seconds until the window reopens. |
 | `500` | [`Problem`](#problem) — An unexpected server-side failure. |
@@ -433,6 +436,7 @@ Idempotent: repeating the same request is harmless, which makes it safe for a sc
 | `400` | [`Problem`](#problem) — The request is malformed — unparseable JSON, an unknown field, or a bad query parameter. |
 | `401` | [`Problem`](#problem) — No token, or the token is unknown, revoked, or expired. |
 | `403` | [`Problem`](#problem) — The token is valid but lacks the scope this endpoint requires. The `required_scope` field names it. |
+| `413` | [`Problem`](#problem) — The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint. |
 | `422` | [`Problem`](#problem) — The request is well-formed but its values are rejected. `invalid_params` lists the offending fields. |
 | `429` | [`Problem`](#problem) — Too many requests. The `Retry-After` header gives the number of seconds until the window reopens. |
 | `500` | [`Problem`](#problem) — An unexpected server-side failure. |
@@ -507,6 +511,7 @@ POST /api/v1/todos
 | `401` | [`Problem`](#problem) — No token, or the token is unknown, revoked, or expired. |
 | `403` | [`Problem`](#problem) — The token is valid but lacks the scope this endpoint requires. The `required_scope` field names it. |
 | `409` | [`Problem`](#problem) — The request collides with existing state — a duplicate name, a limit already reached, or a feature not enabled. |
+| `413` | [`Problem`](#problem) — The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint. |
 | `422` | [`Problem`](#problem) — The request is well-formed but its values are rejected. `invalid_params` lists the offending fields. |
 | `429` | [`Problem`](#problem) — Too many requests. The `Retry-After` header gives the number of seconds until the window reopens. |
 | `500` | [`Problem`](#problem) — An unexpected server-side failure. |
@@ -556,6 +561,7 @@ PATCH /api/v1/todos/{id}
 | `401` | [`Problem`](#problem) — No token, or the token is unknown, revoked, or expired. |
 | `403` | [`Problem`](#problem) — The token is valid but lacks the scope this endpoint requires. The `required_scope` field names it. |
 | `404` | [`Problem`](#problem) — No such resource, or it belongs to another account. |
+| `413` | [`Problem`](#problem) — The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint. |
 | `422` | [`Problem`](#problem) — The request is well-formed but its values are rejected. `invalid_params` lists the offending fields. |
 | `429` | [`Problem`](#problem) — Too many requests. The `Retry-After` header gives the number of seconds until the window reopens. |
 | `500` | [`Problem`](#problem) — An unexpected server-side failure. |
@@ -608,6 +614,7 @@ States the desired result rather than toggling, so a retried request cannot sile
 | `401` | [`Problem`](#problem) — No token, or the token is unknown, revoked, or expired. |
 | `403` | [`Problem`](#problem) — The token is valid but lacks the scope this endpoint requires. The `required_scope` field names it. |
 | `404` | [`Problem`](#problem) — No such resource, or it belongs to another account. |
+| `413` | [`Problem`](#problem) — The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint. |
 | `429` | [`Problem`](#problem) — Too many requests. The `Retry-After` header gives the number of seconds until the window reopens. |
 | `500` | [`Problem`](#problem) — An unexpected server-side failure. |
 
@@ -682,6 +689,7 @@ POST /api/v1/saved-foods
 | `401` | [`Problem`](#problem) — No token, or the token is unknown, revoked, or expired. |
 | `403` | [`Problem`](#problem) — The token is valid but lacks the scope this endpoint requires. The `required_scope` field names it. |
 | `409` | [`Problem`](#problem) — The request collides with existing state — a duplicate name, a limit already reached, or a feature not enabled. |
+| `413` | [`Problem`](#problem) — The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint. |
 | `422` | [`Problem`](#problem) — The request is well-formed but its values are rejected. `invalid_params` lists the offending fields. |
 | `429` | [`Problem`](#problem) — Too many requests. The `Retry-After` header gives the number of seconds until the window reopens. |
 | `500` | [`Problem`](#problem) — An unexpected server-side failure. |
@@ -708,6 +716,7 @@ PATCH /api/v1/saved-foods/{id}
 | `403` | [`Problem`](#problem) — The token is valid but lacks the scope this endpoint requires. The `required_scope` field names it. |
 | `404` | [`Problem`](#problem) — No such resource, or it belongs to another account. |
 | `409` | [`Problem`](#problem) — The request collides with existing state — a duplicate name, a limit already reached, or a feature not enabled. |
+| `413` | [`Problem`](#problem) — The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint. |
 | `422` | [`Problem`](#problem) — The request is well-formed but its values are rejected. `invalid_params` lists the offending fields. |
 | `429` | [`Problem`](#problem) — Too many requests. The `Retry-After` header gives the number of seconds until the window reopens. |
 | `500` | [`Problem`](#problem) — An unexpected server-side failure. |
@@ -759,6 +768,7 @@ Creates a calorie entry from the saved food and returns it. Requires `entries:wr
 | `403` | [`Problem`](#problem) — The token is valid but lacks the scope this endpoint requires. The `required_scope` field names it. |
 | `404` | [`Problem`](#problem) — No such resource, or it belongs to another account. |
 | `409` | [`Problem`](#problem) — The request collides with existing state — a duplicate name, a limit already reached, or a feature not enabled. |
+| `413` | [`Problem`](#problem) — The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint. |
 | `422` | [`Problem`](#problem) — The request is well-formed but its values are rejected. `invalid_params` lists the offending fields. |
 | `429` | [`Problem`](#problem) — Too many requests. The `Retry-After` header gives the number of seconds until the window reopens. |
 | `500` | [`Problem`](#problem) — An unexpected server-side failure. |
@@ -815,6 +825,7 @@ Replaces the whole note. Writing an empty string deletes it. Returns 409 when da
 | `401` | [`Problem`](#problem) — No token, or the token is unknown, revoked, or expired. |
 | `403` | [`Problem`](#problem) — The token is valid but lacks the scope this endpoint requires. The `required_scope` field names it. |
 | `409` | [`Problem`](#problem) — The request collides with existing state — a duplicate name, a limit already reached, or a feature not enabled. |
+| `413` | [`Problem`](#problem) — The request body exceeds the 1 MB limit. Attached to every operation that takes a body — the cap is enforced in the decoder, not per endpoint. |
 | `422` | [`Problem`](#problem) — The request is well-formed but its values are rejected. `invalid_params` lists the offending fields. |
 | `429` | [`Problem`](#problem) — Too many requests. The `Retry-After` header gives the number of seconds until the window reopens. |
 | `500` | [`Problem`](#problem) — An unexpected server-side failure. |

--- a/internal/openapi/derived_responses_test.go
+++ b/internal/openapi/derived_responses_test.go
@@ -1,0 +1,102 @@
+package openapi
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEveryBodyOperationDeclares413 pins #349. decodeV1 caps every v1 request
+// body and answers 413, so the response belongs to "this operation takes a
+// body" rather than to any individual endpoint. Before this was derived, only
+// the AI image upload declared it and a generated client had no 413 branch for
+// the other thirteen.
+func TestEveryBodyOperationDeclares413(t *testing.T) {
+	doc := Build("", "")
+	for path, item := range doc.Paths {
+		for method, op := range item.Operations() {
+			if op.RequestBody == nil {
+				continue
+			}
+			if op.Responses["413"] == nil {
+				t.Errorf("%s %s takes a request body but declares no 413", method, path)
+			}
+		}
+	}
+}
+
+// TestNoBodylessOperationDeclares413 is the other half: a 413 on an operation
+// that takes no body would be a lie, and would train clients to handle a status
+// the server cannot produce there.
+func TestNoBodylessOperationDeclares413(t *testing.T) {
+	doc := Build("", "")
+	for path, item := range doc.Paths {
+		for method, op := range item.Operations() {
+			if op.RequestBody == nil && op.Responses["413"] != nil {
+				t.Errorf("%s %s declares 413 but accepts no request body", method, path)
+			}
+		}
+	}
+}
+
+// TestAIEstimateKeepsItsOwn413 checks the derived pass does not overwrite an
+// operation that documents a different limit. The image upload is 10 MB, not
+// the 1 MB decodeV1 cap.
+func TestAIEstimateKeepsItsOwn413(t *testing.T) {
+	doc := Build("", "")
+	op := doc.Paths["/ai/estimate"].Post
+	resp := op.Responses["413"]
+	if resp == nil {
+		t.Fatal("POST /ai/estimate lost its 413")
+	}
+	if want := "10 MB"; !strings.Contains(resp.Description, want) {
+		t.Errorf("POST /ai/estimate's 413 = %q, want it to still mention %q", resp.Description, want)
+	}
+}
+
+// TestIdempotentOperationsDeclareTheReplayHeader pins #360. A replay repeats
+// the original status code, so the header is the only way a client can tell one
+// from a fresh create — prose in the parameter description does not reach a
+// generated client.
+func TestIdempotentOperationsDeclareTheReplayHeader(t *testing.T) {
+	doc := Build("", "")
+	found := 0
+	for path, item := range doc.Paths {
+		for method, op := range item.Operations() {
+			if !acceptsIdempotencyKey(op) {
+				continue
+			}
+			found++
+			for code, resp := range op.Responses {
+				if code < "200" || code > "299" {
+					continue
+				}
+				if _, ok := resp.Headers["Idempotency-Replayed"]; !ok {
+					t.Errorf("%s %s accepts Idempotency-Key but its %s does not declare Idempotency-Replayed",
+						method, path, code)
+				}
+			}
+		}
+	}
+	if found == 0 {
+		t.Fatal("no operation accepts Idempotency-Key — the derivation is keyed off nothing")
+	}
+}
+
+// TestNonIdempotentOperationsOmitTheReplayHeader is the inverse: an endpoint
+// that ignores the key must not advertise a header it will never send.
+func TestNonIdempotentOperationsOmitTheReplayHeader(t *testing.T) {
+	doc := Build("", "")
+	for path, item := range doc.Paths {
+		for method, op := range item.Operations() {
+			if acceptsIdempotencyKey(op) {
+				continue
+			}
+			for code, resp := range op.Responses {
+				if _, ok := resp.Headers["Idempotency-Replayed"]; ok {
+					t.Errorf("%s %s does not accept Idempotency-Key but its %s declares Idempotency-Replayed",
+						method, path, code)
+				}
+			}
+		}
+	}
+}

--- a/internal/openapi/spec.go
+++ b/internal/openapi/spec.go
@@ -230,11 +230,87 @@ func Build(version, baseURL string) *Document {
 		Security: []SecurityRequirement{{"bearerAuth": {}}},
 	}
 	d.Paths = paths()
+	applyBodyLimitResponses(d)
+	applyIdempotencyReplayedHeader(d)
 	d.Info.Version = APIVersion
 	if version != "" {
 		d.Info.Description += "\n\n---\n\nServed by build `" + version + "`."
 	}
 	return d
+}
+
+// applyBodyLimitResponses declares 413 on every operation that accepts a
+// request body.
+//
+// Derived rather than written per operation on purpose. decodeV1 caps every v1
+// body at maxV1Body and answers 413 when it is exceeded, so the response is a
+// property of "this operation takes a body" — not of any individual endpoint.
+// Listing it by hand meant only the AI image upload documented it (#349), and
+// a client generated from the document had no 413 branch for the other
+// thirteen: an oversized payload surfaced as an unhandled status rather than
+// as the size error it is.
+//
+// An operation that already declares its own 413 keeps it — POST /ai/estimate
+// has a different limit and says so.
+func applyBodyLimitResponses(d *Document) {
+	for _, item := range d.Paths {
+		for _, op := range item.Operations() {
+			if op.RequestBody == nil || op.Responses["413"] != nil {
+				continue
+			}
+			op.Responses["413"] = respRef("PayloadTooLarge")
+		}
+	}
+}
+
+// applyIdempotencyReplayedHeader declares the Idempotency-Replayed response
+// header on the success responses of every operation that accepts an
+// Idempotency-Key.
+//
+// The header is how a caller tells a replay from a fresh create — the status
+// code cannot, because a replay deliberately repeats the original 201. It was
+// described in prose but never declared, so it did not exist for any generated
+// client (#360); code reading `response.headers["Idempotency-Replayed"]` had to
+// be written by hand against documentation.
+//
+// Keyed off the request parameter rather than a list of paths so the two cannot
+// disagree: an endpoint that starts honouring the key documents the header in
+// the same commit, and one that stops loses it.
+func applyIdempotencyReplayedHeader(d *Document) {
+	header := Header{
+		Description: "Present and `true` only on a replayed response — the request matched a stored " +
+			"Idempotency-Key and nothing new was created. Absent on the first request. This is the " +
+			"only way to distinguish a replay from a fresh create, since a replay repeats the " +
+			"original status code.",
+		Schema: boolean(""),
+	}
+	for _, item := range d.Paths {
+		for _, op := range item.Operations() {
+			if !acceptsIdempotencyKey(op) {
+				continue
+			}
+			for code, resp := range op.Responses {
+				if code < "200" || code > "299" || resp == nil {
+					continue
+				}
+				if resp.Headers == nil {
+					resp.Headers = map[string]Header{}
+				}
+				if _, ok := resp.Headers["Idempotency-Replayed"]; !ok {
+					resp.Headers["Idempotency-Replayed"] = header
+				}
+			}
+		}
+	}
+}
+
+func acceptsIdempotencyKey(op *Operation) bool {
+	for _, p := range op.Parameters {
+		if p.In == "header" && p.Name == "Idempotency-Key" {
+			return true
+		}
+	}
+	return false
 }
 
 func securitySchemes() map[string]*SecurityScheme {
@@ -268,6 +344,8 @@ func sharedResponses() map[string]*Response {
 			},
 		},
 		"ServerError": r("An unexpected server-side failure."),
+		"PayloadTooLarge": r("The request body exceeds the 1 MB limit. Attached to every operation " +
+			"that takes a body — the cap is enforced in the decoder, not per endpoint."),
 	}
 }
 


### PR DESCRIPTION
Closes #349
Closes #360

Both facts were true of the server and missing from the document, so neither reached a generated client.

**413** — `decodeV1` caps every v1 body at `maxV1Body` and answers 413. That makes the response a property of *"this operation takes a body"*, not of any individual endpoint. Written by hand, only the AI image upload declared it; the other eleven had no 413 branch. Now derived from `op.RequestBody`. `POST /ai/estimate` keeps its own, which documents a different 10 MB limit.

**Idempotency-Replayed** — a replay deliberately repeats the original status code, so this header is the *only* way a client can tell a replay from a fresh create. It was described in the `Idempotency-Key` parameter prose and declared nowhere. Now derived from the presence of that parameter, so the request and response sides cannot disagree.

Deriving rather than listing is the point: an endpoint that starts taking a body, or starts honouring the key, documents it in the same commit.

Result in the generated document: 12 of 12 body operations declare 413, and 4 success responses declare the header.

Tests pin both directions — no bodyless operation declares 413, and no non-idempotent operation advertises a header it will never send.