### PR TITLE
ci: gate on gofmt and go vet, and format the 15 files that were drifting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,29 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # Ahead of the tests on purpose: both are fast, and a vet failure is
+      # usually the honest explanation for a confusing test failure below.
+      #
+      # gofmt is enforced because "formatted by whatever the author's editor
+      # did" produces diffs where a real change hides among reflowed lines —
+      # exactly the reviewing cost this repo's commit style exists to avoid.
+      # `gofmt -l` prints offending files and exits 0, so the file list has to
+      # be turned into the failure itself.
+      #
+      # go vet catches the class this repo keeps hitting: a helper redeclared
+      # in a package after two branches merge cleanly, a Printf verb that does
+      # not match its argument, a lock copied by value. None of those are
+      # compile errors, and none produce a conflict marker.
+      - name: Check gofmt and go vet
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::These files are not gofmt-formatted. Run 'gofmt -w .' and commit:"
+            echo "$unformatted" | while read -r f; do echo "::error file=$f::not gofmt-formatted"; done
+            exit 1
+          fi
+          go vet ./...
+
       - name: Run Go tests
         run: go test ./...
         env:

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -31,6 +31,7 @@ type AdminHandler struct {
 //   - the key must be in the allowlist
 //   - the env var must not override the setting
 //   - the value must pass the per-key validator (if any)
+//
 // All checks run before any write, so a batch save is all-or-nothing.
 func (h *AdminHandler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 	var body struct {

--- a/internal/handler/admin_settings.go
+++ b/internal/handler/admin_settings.go
@@ -20,14 +20,14 @@ import (
 // (then also wire it through SettingsCache.GetEffectiveSetting in the
 // relevant handler).
 type AdminSetting struct {
-	Key      string                  // DB key in admin_settings + JSON key
-	Env      string                  // matching environment variable name
-	Section  string                  // grouping for the UI ("general", "ai", …)
-	Tier     string                  // "hot" = takes effect next request; "restart" = needs server restart
-	Secret   bool                    // mask the value in the UI; don't include the value in audit logs
-	Dangerous bool                   // shows a typed-confirmation dialog before save
-	Help     string                  // short help text shown under the field
-	Validate func(value string) error // optional value validator; called server-side on every save
+	Key       string                   // DB key in admin_settings + JSON key
+	Env       string                   // matching environment variable name
+	Section   string                   // grouping for the UI ("general", "ai", …)
+	Tier      string                   // "hot" = takes effect next request; "restart" = needs server restart
+	Secret    bool                     // mask the value in the UI; don't include the value in audit logs
+	Dangerous bool                     // shows a typed-confirmation dialog before save
+	Help      string                   // short help text shown under the field
+	Validate  func(value string) error // optional value validator; called server-side on every save
 }
 
 // adminSettings is the canonical ordered list. Order is the display order
@@ -47,7 +47,7 @@ var adminSettings = []AdminSetting{
 	// AI Features
 	// =========================================================================
 	{Key: "ai_provider", Env: "AI_PROVIDER", Section: "ai", Tier: "hot",
-		Help: `One of: openai, claude, ollama.`,
+		Help:     `One of: openai, claude, ollama.`,
 		Validate: oneOf("openai", "claude", "ollama", "")},
 	{Key: "ai_key", Env: "AI_KEY", Section: "ai", Tier: "hot", Secret: true,
 		Help: "Global API key (fallback when users don't have their own)."},
@@ -67,7 +67,7 @@ var adminSettings = []AdminSetting{
 	// OIDC / SSO
 	// =========================================================================
 	{Key: "oidc_issuer", Env: "OIDC_ISSUER", Section: "oidc", Tier: "restart",
-		Help: "OIDC issuer URL. Setting this enables OIDC sign-in.",
+		Help:     "OIDC issuer URL. Setting this enables OIDC sign-in.",
 		Validate: validURL},
 	{Key: "oidc_client_id", Env: "OIDC_CLIENT_ID", Section: "oidc", Tier: "restart",
 		Help: "OAuth2 client ID from your provider."},

--- a/internal/handler/ai_test.go
+++ b/internal/handler/ai_test.go
@@ -89,9 +89,9 @@ func TestResolveAIConfig(t *testing.T) {
 // internal) endpoint URL.
 func TestAIClientErrorMessage(t *testing.T) {
 	tests := []struct {
-		name       string
-		err        error
-		want       string
+		name        string
+		err         error
+		want        string
 		mustNotHold []string
 	}{
 		{

--- a/internal/handler/passkeys.go
+++ b/internal/handler/passkeys.go
@@ -36,8 +36,8 @@ func (u *webauthnUser) WebAuthnID() []byte {
 	return b
 }
 
-func (u *webauthnUser) WebAuthnName() string        { return u.email }
-func (u *webauthnUser) WebAuthnDisplayName() string  { return u.email }
+func (u *webauthnUser) WebAuthnName() string                       { return u.email }
+func (u *webauthnUser) WebAuthnDisplayName() string                { return u.email }
 func (u *webauthnUser) WebAuthnCredentials() []webauthn.Credential { return u.credentials }
 
 func passkeysToCredentials(records []service.PasskeyRecord) []webauthn.Credential {
@@ -91,9 +91,9 @@ func (h *PasskeyHandler) RegisterBegin(w http.ResponseWriter, r *http.Request) {
 	excludeList := make([]protocol.CredentialDescriptor, len(wUser.credentials))
 	for i, c := range wUser.credentials {
 		excludeList[i] = protocol.CredentialDescriptor{
-			Type:            protocol.PublicKeyCredentialType,
-			CredentialID:    c.ID,
-			Transport:       c.Transport,
+			Type:         protocol.PublicKeyCredentialType,
+			CredentialID: c.ID,
+			Transport:    c.Transport,
 		}
 	}
 

--- a/internal/handler/saved_foods.go
+++ b/internal/handler/saved_foods.go
@@ -93,13 +93,13 @@ func (h *SavedFoodsHandler) List(w http.ResponseWriter, r *http.Request) {
 // JSON body. Returns the parsed values or an error message + status code.
 // Used by both Create and Update; pass forCreate=true to require a non-empty name.
 type savedFoodInput struct {
-	hasName    bool
-	name       string
-	hasEmoji   bool
-	emoji      *string
-	hasAmount  bool
-	amount     *int
-	macros     map[string]*int // only keys present in body are populated
+	hasName   bool
+	name      string
+	hasEmoji  bool
+	emoji     *string
+	hasAmount bool
+	amount    *int
+	macros    map[string]*int // only keys present in body are populated
 }
 
 // Every field below reads through optionalString (entries_helpers.go), which
@@ -578,4 +578,3 @@ func hasKey(m map[string]any, k string) bool {
 	_, ok := m[k]
 	return ok
 }
-

--- a/internal/handler/saved_foods_test.go
+++ b/internal/handler/saved_foods_test.go
@@ -204,8 +204,8 @@ func TestParseSavedFoodPayload(t *testing.T) {
 			},
 		},
 		{
-			name: "name is trimmed then truncated to MaxSavedFoodName",
-			body: map[string]any{"name": "  " + strings.Repeat("a", 100) + "  "},
+			name:      "name is trimmed then truncated to MaxSavedFoodName",
+			body:      map[string]any{"name": "  " + strings.Repeat("a", 100) + "  "},
 			forCreate: true, wantStatus: 0,
 			check: func(t *testing.T, in *savedFoodInput) {
 				if len(in.name) != MaxSavedFoodName {
@@ -232,8 +232,8 @@ func TestParseSavedFoodPayload(t *testing.T) {
 			},
 		},
 		{
-			name: "amount arithmetic expression evaluated",
-			body: map[string]any{"name": "x", "amount": "2*3"},
+			name:      "amount arithmetic expression evaluated",
+			body:      map[string]any{"name": "x", "amount": "2*3"},
 			forCreate: true, wantStatus: 0,
 			check: func(t *testing.T, in *savedFoodInput) {
 				if !in.hasAmount || in.amount == nil || *in.amount != 6 {
@@ -242,18 +242,18 @@ func TestParseSavedFoodPayload(t *testing.T) {
 			},
 		},
 		{
-			name: "amount unparseable rejected",
-			body: map[string]any{"name": "x", "amount": "abc"},
+			name:      "amount unparseable rejected",
+			body:      map[string]any{"name": "x", "amount": "abc"},
 			forCreate: true, wantStatus: 400,
 		},
 		{
-			name: "amount over MaxEntryCalories rejected",
-			body: map[string]any{"name": "x", "amount": "99999"},
+			name:      "amount over MaxEntryCalories rejected",
+			body:      map[string]any{"name": "x", "amount": "99999"},
 			forCreate: true, wantStatus: 400,
 		},
 		{
-			name: "explicit nil amount leaves hasAmount false",
-			body: map[string]any{"name": "x", "amount": nil},
+			name:      "explicit nil amount leaves hasAmount false",
+			body:      map[string]any{"name": "x", "amount": nil},
 			forCreate: true, wantStatus: 0,
 			check: func(t *testing.T, in *savedFoodInput) {
 				if in.hasAmount {
@@ -262,8 +262,8 @@ func TestParseSavedFoodPayload(t *testing.T) {
 			},
 		},
 		{
-			name: "valid macro parsed",
-			body: map[string]any{"name": "x", "protein_g": float64(50)},
+			name:      "valid macro parsed",
+			body:      map[string]any{"name": "x", "protein_g": float64(50)},
 			forCreate: true, wantStatus: 0,
 			check: func(t *testing.T, in *savedFoodInput) {
 				if v, ok := in.macros["protein"]; !ok || v == nil || *v != 50 {
@@ -272,18 +272,18 @@ func TestParseSavedFoodPayload(t *testing.T) {
 			},
 		},
 		{
-			name: "macro over MaxEntryMacro rejected",
-			body: map[string]any{"name": "x", "protein_g": float64(1500)},
+			name:      "macro over MaxEntryMacro rejected",
+			body:      map[string]any{"name": "x", "protein_g": float64(1500)},
 			forCreate: true, wantStatus: 400,
 		},
 		{
-			name: "negative macro rejected",
-			body: map[string]any{"name": "x", "carbs_g": float64(-5)},
+			name:      "negative macro rejected",
+			body:      map[string]any{"name": "x", "carbs_g": float64(-5)},
 			forCreate: true, wantStatus: 400,
 		},
 		{
-			name: "explicit nil macro recorded as nil",
-			body: map[string]any{"name": "x", "fat_g": nil},
+			name:      "explicit nil macro recorded as nil",
+			body:      map[string]any{"name": "x", "fat_g": nil},
 			forCreate: true, wantStatus: 0,
 			check: func(t *testing.T, in *savedFoodInput) {
 				v, ok := in.macros["fat"]

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -26,10 +26,10 @@ import (
 )
 
 type SettingsHandler struct {
-	Pool              *pgxpool.Pool
-	Broker            *sse.Broker
+	Pool               *pgxpool.Pool
+	Broker             *sse.Broker
 	AIKeyEncryptSecret string
-	TrustProxy        bool // for audit log IP extraction
+	TrustProxy         bool // for audit log IP extraction
 }
 
 // Preferences handles POST /settings/preferences

--- a/internal/handler/settings_test.go
+++ b/internal/handler/settings_test.go
@@ -85,10 +85,10 @@ func TestShouldClearStoredAIKey(t *testing.T) {
 	openai := "openai"
 	claude := "claude"
 	tests := []struct {
-		name     string
-		next     *string
-		current  *string
-		want     bool
+		name    string
+		next    *string
+		current *string
+		want    bool
 	}{
 		{"no provider in payload — never clear", nil, &openai, false},
 		{"same provider, current set — autosave must not wipe", &openai, &openai, false},

--- a/internal/middleware/stepup_test.go
+++ b/internal/middleware/stepup_test.go
@@ -13,13 +13,13 @@ import (
 
 func TestStepUpResponse(t *testing.T) {
 	tests := []struct {
-		name           string
-		hasPassword    bool
-		passkeyCount   int
-		oidcCount      int
-		totpEnabled    bool
-		wantMethods    []string
-		wantTotpReq    bool
+		name         string
+		hasPassword  bool
+		passkeyCount int
+		oidcCount    int
+		totpEnabled  bool
+		wantMethods  []string
+		wantTotpReq  bool
 	}{
 		{"password only", true, 0, 0, false, []string{"password"}, false},
 		{"password + totp", true, 0, 0, true, []string{"password"}, true},

--- a/internal/middleware/timezone_test.go
+++ b/internal/middleware/timezone_test.go
@@ -9,7 +9,7 @@ func TestNormalizeTimezone(t *testing.T) {
 		{"", ""},
 		{"UTC", "UTC"},
 		{"Europe/Berlin", "Europe/Berlin"},
-		{"Europe%2FBerlin", "Europe/Berlin"},                     // legacy URL-encoded cookies
+		{"Europe%2FBerlin", "Europe/Berlin"}, // legacy URL-encoded cookies
 		{"America%2FArgentina%2FBuenos_Aires", "America/Argentina/Buenos_Aires"},
 		{"Not/A/Zone", ""},
 		{"Europe%ZZBerlin", ""}, // invalid percent-encoding falls through to LoadLocation, which fails

--- a/internal/service/ai.go
+++ b/internal/service/ai.go
@@ -92,10 +92,10 @@ func DecryptApiKey(ciphertext, secretHex string) string {
 }
 
 type AIResult struct {
-	Calories   int               `json:"calories"`
-	Food       string            `json:"food"`
-	Confidence string            `json:"confidence"`
-	Macros     map[string]int    `json:"macros"`
+	Calories   int            `json:"calories"`
+	Food       string         `json:"food"`
+	Confidence string         `json:"confidence"`
+	Macros     map[string]int `json:"macros"`
 }
 
 // AIProviderError reports a non-2xx response from the upstream AI provider.
@@ -349,4 +349,3 @@ func unhex(c byte) byte {
 	}
 	return 0xFF
 }
-

--- a/internal/service/macros_test.go
+++ b/internal/service/macros_test.go
@@ -150,7 +150,10 @@ func TestComputeDotStatus(t *testing.T) {
 }
 
 func TestWorstDotStatus(t *testing.T) {
-	tests := []struct{ input []string; want string }{
+	tests := []struct {
+		input []string
+		want  string
+	}{
 		{nil, "none"},
 		{[]string{"under"}, "under"},
 		{[]string{"under", "over", "over_threshold"}, "over_threshold"},

--- a/internal/service/mathparser_test.go
+++ b/internal/service/mathparser_test.go
@@ -9,7 +9,11 @@ import (
 )
 
 func TestParseAmountSimpleNumbers(t *testing.T) {
-	tests := []struct{ input string; ok bool; value int }{
+	tests := []struct {
+		input string
+		ok    bool
+		value int
+	}{
 		{"123", true, 123},
 		{"0", true, 0},
 		{"999", true, 999},
@@ -23,7 +27,10 @@ func TestParseAmountSimpleNumbers(t *testing.T) {
 }
 
 func TestParseAmountDecimalRounding(t *testing.T) {
-	tests := []struct{ input string; value int }{
+	tests := []struct {
+		input string
+		value int
+	}{
 		{"123.7", 124},
 		{"123.2", 123},
 		{"123.5", 124},
@@ -37,7 +44,10 @@ func TestParseAmountDecimalRounding(t *testing.T) {
 }
 
 func TestParseAmountArithmetic(t *testing.T) {
-	tests := []struct{ input string; value int }{
+	tests := []struct {
+		input string
+		value int
+	}{
 		{"100 + 50", 150},
 		{"200 - 30", 170},
 		{"10 * 5", 50},
@@ -52,7 +62,10 @@ func TestParseAmountArithmetic(t *testing.T) {
 }
 
 func TestParseAmountParentheses(t *testing.T) {
-	tests := []struct{ input string; value int }{
+	tests := []struct {
+		input string
+		value int
+	}{
 		{"(10 + 20) * 3", 90},
 		{"10 + (20 * 3)", 70},
 		{"((10 + 5) * 2) - 5", 25},
@@ -66,7 +79,10 @@ func TestParseAmountParentheses(t *testing.T) {
 }
 
 func TestParseAmountAlternativeSymbols(t *testing.T) {
-	tests := []struct{ input string; value int }{
+	tests := []struct {
+		input string
+		value int
+	}{
 		{"10 × 5", 50},
 		{"10 x 5", 50},
 		{"100 ÷ 4", 25},
@@ -83,7 +99,10 @@ func TestParseAmountAlternativeSymbols(t *testing.T) {
 }
 
 func TestParseAmountCommas(t *testing.T) {
-	tests := []struct{ input string; value int }{
+	tests := []struct {
+		input string
+		value int
+	}{
 		{"1,000", 1000},
 		{"1,234 + 500", 1734},
 	}
@@ -144,7 +163,10 @@ func TestParseAmountDivisionByZero(t *testing.T) {
 }
 
 func TestParseAmountNegative(t *testing.T) {
-	tests := []struct{ input string; value int }{
+	tests := []struct {
+		input string
+		value int
+	}{
 		{"-10", -10},
 		{"10 + (-5)", 5},
 		{"-(10 + 5)", -15},
@@ -158,7 +180,10 @@ func TestParseAmountNegative(t *testing.T) {
 }
 
 func TestParseAmountComplex(t *testing.T) {
-	tests := []struct{ input string; value int }{
+	tests := []struct {
+		input string
+		value int
+	}{
 		{"100 + 50 * 2 - 10", 190},
 		{"(100 + 50) * 2 - 10", 290},
 		{"100 / (2 + 3) * 4", 80},
@@ -172,7 +197,12 @@ func TestParseAmountComplex(t *testing.T) {
 }
 
 func TestParseAmountMaxAbs(t *testing.T) {
-	tests := []struct{ input string; maxAbs int; ok bool; value int }{
+	tests := []struct {
+		input  string
+		maxAbs int
+		ok     bool
+		value  int
+	}{
 		{"9999", 9999, true, 9999},
 		{"-9999", 9999, true, -9999},
 		{"10000", 9999, false, 0},
@@ -492,7 +522,10 @@ func TestParseAmountSharedCases(t *testing.T) {
 }
 
 func TestSafeMathEvalPrecedence(t *testing.T) {
-	tests := []struct{ expr string; want float64 }{
+	tests := []struct {
+		expr string
+		want float64
+	}{
 		{"2+3*4", 14},
 		{"(2+3)*4", 20},
 		{"2*3+4", 10},

--- a/internal/service/utils_test.go
+++ b/internal/service/utils_test.go
@@ -85,7 +85,11 @@ func TestParseWeight(t *testing.T) {
 }
 
 func TestSubtractDaysUTC(t *testing.T) {
-	tests := []struct{ date string; days int; want string }{
+	tests := []struct {
+		date string
+		days int
+		want string
+	}{
 		{"2025-03-15", 13, "2025-03-02"},
 		{"2025-03-01", 1, "2025-02-28"},
 		{"2024-03-01", 1, "2024-02-29"},

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -18,10 +18,10 @@ import (
 )
 
 const (
-	CookieName     = "schautrack.sid"
-	AnonMaxAge     = 15 * time.Minute
-	AuthMaxAge     = 30 * 24 * time.Hour
-	PruneInterval  = 5 * time.Minute
+	CookieName       = "schautrack.sid"
+	AnonMaxAge       = 15 * time.Minute
+	AuthMaxAge       = 30 * 24 * time.Hour
+	PruneInterval    = 5 * time.Minute
 	defaultStepUpTTL = 30 * time.Minute
 )
 


### PR DESCRIPTION
Closes #324
Closes #390

15 Go files were not gofmt-formatted and nothing checked, so the drift was free to grow. The cost isn't aesthetic — an unformatted file means the next person to touch it produces a diff where the real change hides among reflowed lines.

## The formatting commit is mechanical

gofmt only expanded inline struct field lists onto separate lines:

```go
-	tests := []struct{ input string; ok bool; value int }{
+	tests := []struct {
+		input string
+		ok    bool
+		value int
+	}{
```

`git diff -w` shows nothing beyond that reflow.

## The gate

Runs before the tests: both are fast, and a vet failure is often the honest explanation for a confusing test failure underneath it.

`go vet` earns its place here specifically. It catches the class this repo keeps hitting after a merge — a helper redeclared in a package because two branches each added their own, a copied lock, a Printf verb mismatched to its argument. None are compile errors, and none produce a conflict marker, so nothing else catches them.

`gofmt -l` exits 0 even when it lists files, so the step turns the file list into the failure itself and emits a `::error file=` annotation per file.

## Verification

```
gofmt -l .     # empty
go vet ./...   # clean
go test ./...  # ok, 10/10 (against a real Postgres 18)
```