### PR TITLE
fix(log): route the last eight log.Printf sites through slog

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -3,7 +3,7 @@ package database
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"math"
 	"time"
 
@@ -544,17 +544,17 @@ func retrySchemaInit(maxRetries int, initialDelay time.Duration, run func() erro
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		lastErr = run()
 		if lastErr == nil {
-			log.Println("Schema initialization successful")
+			slog.Info("schema initialization successful")
 			return nil
 		}
 
 		delay := time.Duration(float64(initialDelay) * math.Pow(2, float64(attempt-1)))
-		log.Printf("Schema init failed (attempt %d/%d): %v", attempt, maxRetries, lastErr)
+		slog.Error("schema init failed", "attempt", attempt, "max_attempts", maxRetries, "error", lastErr)
 		if attempt < maxRetries {
-			log.Printf("Retrying in %v...", delay)
+			slog.Warn("retrying schema init", "delay", delay)
 			time.Sleep(delay)
 		} else {
-			log.Println("Schema initialization failed after all retries; aborting startup.")
+			slog.Error("schema initialization failed after all retries; aborting startup", "attempts", maxRetries, "error", lastErr)
 		}
 	}
 	return lastErr
@@ -987,7 +987,7 @@ func runAllMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 			// replica's migrations until this process exits. Close it so the
 			// server releases the lock; Release then destroys it instead of
 			// returning it to the pool.
-			log.Printf("failed to release migration advisory lock, closing connection: %v", err)
+			slog.Error("failed to release migration advisory lock, closing connection", "error", err)
 			conn.Conn().Close(unlockCtx)
 		}
 		conn.Release()

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -83,7 +83,7 @@ func AttachUser(pool *pgxpool.Pool) func(http.Handler) http.Handler {
 
 			user, err := GetUserByID(r.Context(), pool, userID)
 			if err != nil {
-				log.Printf("Failed to load user from session: %v", err)
+				slog.Error("failed to load user from session", "error", err)
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/middleware/links.go
+++ b/internal/middleware/links.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -71,7 +71,7 @@ func RequireLinkAuth(pool *pgxpool.Pool, category string) func(http.Handler) htt
 						json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "Not authorized"})
 						return
 					}
-					log.Printf("Link auth check failed: %v", err)
+					slog.Error("link auth check failed", "error", err)
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusInternalServerError)
 					json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "Authorization check failed"})

--- a/internal/service/email.go
+++ b/internal/service/email.go
@@ -6,7 +6,7 @@ import (
 	"embed"
 	"fmt"
 	htmltemplate "html/template"
-	"log"
+	"log/slog"
 	"math/big"
 	"net"
 	"net/smtp"
@@ -140,7 +140,7 @@ func (es *EmailService) SendEmail(to, subject, text, html string) error {
 		// generic message. Swallowing the error here made every caller
 		// report success even when nothing was sent — combined with the
 		// unverified-user cleanup that silently cost accounts.
-		log.Printf("SMTP send failed: %v", err)
+		slog.Error("SMTP send failed", "error", err)
 		return fmt.Errorf("email send failed: %w", err)
 	}
 	return nil


### PR DESCRIPTION
Closes #389

`main.go` calls `slog.SetDefault`, so the log package is already rerouted through the same JSON handler — these lines did reach stdout. But they arrived as records at **INFO**, the level slog hardcodes for log-package output, with the whole message as one preformatted string.

Three consequences, each defeating the point of structured logging:

- An SMTP send failure and a schema-init failure sat **below any error threshold** — no alert rule could match them.
- The error was interpolated into the message rather than carried as an attribute, so **no two occurrences could be grouped**.
- The message text was unique per occurrence, so there was **nothing stable to alert on**.

Each site now gets the level it deserves — `Error` for SMTP send, link auth, session user load, schema-init failure and advisory-lock release; `Warn` for the schema-init retry; `Info` for the success line — with errors and varying values as attributes.

Messages are lowercased to match the slog convention already used elsewhere, so one query style finds them all.

The only `"log"` imports left are two recovery tests that capture the log package's output deliberately.

## Verification
```
go vet ./...   # clean
go test ./...  # ok, 10/10 (real Postgres 18)
```