### PR TITLE
fix(auth): fail closed on a missing session and a malformed ?user=

### DIFF
--- a/internal/handler/registration_test.go
+++ b/internal/handler/registration_test.go
@@ -489,6 +489,34 @@ func TestEmailChangeRequest_NormalizesAndReachesSameEmailCheck(t *testing.T) {
 // The validator gates EVERY write, and gates no read
 // =============================================================================
 
+// funcKey names a declaration uniquely within the package: "Receiver.Method"
+// for a method, the bare name for a free function.
+//
+// The map was keyed by fd.Name.Name alone, which collides — the handler package
+// has Create, Delete, Get, List, Login, Me, Update and others declared on
+// several receivers. Files are walked in os.ReadDir order, so the last one won
+// and every lookup below silently resolved to whichever file sorted last.
+//
+// "Login" was the one that mattered: it resolved to OIDCHandler.Login (oidc.go)
+// rather than AuthHandler.Login (auth.go), so
+// TestCredentialValidatorsDoNotGateLogin — the guard that stops #306's
+// validators from locking out grandfathered accounts — was asserting about the
+// OIDC redirect handler. Adding validatePassword to the real password login
+// would have passed (#399).
+func funcKey(fd *ast.FuncDecl) string {
+	if fd.Recv == nil || len(fd.Recv.List) == 0 {
+		return fd.Name.Name
+	}
+	t := fd.Recv.List[0].Type
+	if star, ok := t.(*ast.StarExpr); ok {
+		t = star.X
+	}
+	if id, ok := t.(*ast.Ident); ok {
+		return id.Name + "." + fd.Name.Name
+	}
+	return fd.Name.Name
+}
+
 // parseHandlerPackage parses the handler package sources (no test files) so
 // the assertions below can look at real call graphs rather than at strings.
 func parseHandlerPackage(t *testing.T) map[string]*ast.FuncDecl {
@@ -509,9 +537,17 @@ func parseHandlerPackage(t *testing.T) map[string]*ast.FuncDecl {
 			t.Fatalf("parsing %s: %v", name, err)
 		}
 		for _, d := range f.Decls {
-			if fd, ok := d.(*ast.FuncDecl); ok {
-				funcs[fd.Name.Name] = fd
+			fd, ok := d.(*ast.FuncDecl)
+			if !ok {
+				continue
 			}
+			key := funcKey(fd)
+			if prev, dup := funcs[key]; dup {
+				t.Fatalf("two declarations of %s in the handler package (%s and this one); "+
+					"funcKey must produce a unique name per function or these tests silently "+
+					"assert about the wrong one", key, prev.Name.Name)
+			}
+			funcs[key] = fd
 		}
 	}
 	if len(funcs) == 0 {
@@ -545,13 +581,13 @@ func TestCredentialValidatorsGateEveryWrite(t *testing.T) {
 	funcs := parseHandlerPackage(t)
 
 	emailWrites := []string{
-		"registerCredentials", // credential registration (auth.go)
-		"handleLogin",         // OIDC auto-provisioning (oidc.go)
-		"EmailChangeRequest",  // email change (auth_email.go)
+		"AuthHandler.registerCredentials", // credential registration (auth.go)
+		"OIDCHandler.handleLogin",         // OIDC auto-provisioning (oidc.go)
+		"AuthHandler.EmailChangeRequest",  // email change (auth_email.go)
 		// invite_codes.email is compared against the canonical registrant
 		// address, so an invite written in any other form is a permanently
 		// unredeemable code (issue #342).
-		"CreateInvite", // admin invite (admin.go)
+		"AdminHandler.CreateInvite", // admin invite (admin.go)
 	}
 	for _, name := range emailWrites {
 		fn, ok := funcs[name]
@@ -565,9 +601,9 @@ func TestCredentialValidatorsGateEveryWrite(t *testing.T) {
 	}
 
 	passwordWrites := []string{
-		"registerCredentials", // auth.go
-		"ResetPassword",       // auth_password.go
-		"Password",            // settings.go (SettingsHandler.Password)
+		"AuthHandler.registerCredentials", // auth.go
+		"AuthHandler.ResetPassword",       // auth_password.go
+		"SettingsHandler.Password",        // settings.go
 	}
 	for _, name := range passwordWrites {
 		fn, ok := funcs[name]
@@ -589,10 +625,10 @@ func TestCredentialValidatorsDoNotGateLogin(t *testing.T) {
 	funcs := parseHandlerPackage(t)
 
 	readPaths := []string{
-		"Login",          // auth.go — password login
-		"ForgotPassword", // auth_password.go — reset request, looks the user up by email
-		"VerifyEmail",    // auth_email.go — consumes a token for an existing address
-		"verifyPassword", // auth_helpers.go — the hash comparison itself
+		"AuthHandler.Login",          // auth.go — password login, NOT OIDCHandler.Login
+		"AuthHandler.ForgotPassword", // auth_password.go — reset request, looks the user up by email
+		"AuthHandler.VerifyEmail",    // auth_email.go — consumes a token for an existing address
+		"verifyPassword",             // auth_helpers.go — free function, the hash comparison itself
 	}
 	for _, name := range readPaths {
 		fn, ok := funcs[name]
@@ -614,9 +650,9 @@ func TestCredentialValidatorsDoNotGateLogin(t *testing.T) {
 // grandfathered address into a failed login instead of a successful one.
 func TestOIDCEmailValidationRunsAfterTheLookups(t *testing.T) {
 	funcs := parseHandlerPackage(t)
-	fn, ok := funcs["handleLogin"]
+	fn, ok := funcs["OIDCHandler.handleLogin"]
 	if !ok {
-		t.Fatal("handleLogin not found")
+		t.Fatal("OIDCHandler.handleLogin not found")
 	}
 
 	var lookupPos, validatePos token.Pos

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -112,8 +112,29 @@ func RequireLogin(next http.Handler) http.Handler {
 // OIDC unlink) so federated users can only manage auth at their IdP.
 func RequireLocalAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No session is a rejection, not a pass. This used to check only
+		// "is the session federated?", so an anonymous request — no session
+		// at all — fell straight through to the handler.
+		//
+		// That was safe only because all nine routes mounting this also mount
+		// RequireLogin ahead of it, which nothing enforced: an unwritten
+		// ordering convention across nine registrations guarding the password
+		// change, the email-change flow, and every 2FA route. A guard whose
+		// safety depends on another guard being remembered is one refactor
+		// away from being no guard at all, and these are exactly the routes
+		// where failing open is worst.
+		//
+		// Checking the session rather than the user keeps this a pure
+		// "is this session local?" test, which is what the name promises —
+		// it just no longer treats "there is no session" as "yes".
 		sess := session.GetSession(r)
-		if sess != nil && sess.GetString("auth_method") == "oidc" {
+		if sess == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]any{"error": "Authentication required"})
+			return
+		}
+		if sess.GetString("auth_method") == "oidc" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusForbidden)
 			json.NewEncoder(w).Encode(map[string]any{"error": "Log in with a password to change authentication settings."})

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -245,11 +245,14 @@ func TestRequireLocalAuth(t *testing.T) {
 		{"oidc session", &session.Session{Data: map[string]any{"auth_method": "oidc"}}, false, http.StatusForbidden},
 		{"session with no auth_method", &session.Session{Data: map[string]any{}}, true, http.StatusOK},
 
-		// Documented, deliberate: the middleware is always mounted BELOW
-		// RequireLogin, which has already rejected a request with no session.
-		// It is recorded here so that anyone who mounts it on its own knows it
-		// does not authenticate.
-		{"no session at all (RequireLogin's job)", nil, true, http.StatusOK},
+		// No session is refused outright (#373). This used to pass through on
+		// the grounds that RequireLogin is always mounted above it — true of
+		// all nine current registrations, and enforced by nothing. An
+		// unwritten ordering convention guarding the password change, the
+		// email-change flow and every 2FA route is one refactor away from
+		// being no guard at all, so the middleware now fails closed on its
+		// own.
+		{"no session at all", nil, false, http.StatusUnauthorized},
 	}
 
 	for _, tt := range tests {

--- a/internal/middleware/links.go
+++ b/internal/middleware/links.go
@@ -33,11 +33,32 @@ func RequireLinkAuth(pool *pgxpool.Pool, category string) func(http.Handler) htt
 				return
 			}
 
+			// A `user` that does not parse is a 400, not a silent fallback.
+			//
+			// This used to discard the parse error and answer with the
+			// CALLER'S OWN data: `?user=abc` returned 200 and your entries,
+			// while `?user=<a real linked id>` returned theirs. Same URL
+			// shape, same status, different account — and no way for the
+			// client to tell which it got. A typo'd or truncated id therefore
+			// looked like a successful read of the wrong person's day.
+			//
+			// resolveTarget on /api/v1 already rejects this (v1_links.go); the
+			// two surfaces read the same parameter and disagreeing about what
+			// it means is the actual defect. Matching the stricter one costs a
+			// caller one obvious error instead of one wrong answer.
 			targetUserID := currentUser.ID
 			if userParam := r.URL.Query().Get("user"); userParam != "" {
-				if id, err := strconv.Atoi(userParam); err == nil {
-					targetUserID = id
+				id, err := strconv.Atoi(userParam)
+				if err != nil || id <= 0 {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusBadRequest)
+					json.NewEncoder(w).Encode(map[string]any{
+						"ok":    false,
+						"error": "The \"user\" parameter must be the numeric id of a linked account.",
+					})
+					return
 				}
+				targetUserID = id
 			}
 
 			var targetUser *model.User

--- a/internal/middleware/links_test.go
+++ b/internal/middleware/links_test.go
@@ -318,21 +318,56 @@ func TestRequireLinkAuth(t *testing.T) {
 	t.Run("malformed and hostile ?user= values", func(t *testing.T) {
 		clearLink(t, ctx, pool, alice.ID, bob.ID)
 
-		// Values that do not parse as an integer fall back to the caller's own
-		// id. That is fail-closed — you see your own data, never someone
-		// else's — and is pinned here so the fallback cannot quietly become
-		// "ignore the check". (/api/v1 answers 400 for the same input; the two
-		// surfaces differ on purpose, the legacy one predates the problem+json
-		// contract.)
-		for _, raw := range []string{"abc", "1.5", "", "%20", "null", "1;2", "1+OR+1=1"} {
+		// A value that does not parse is refused with 400 (#376).
+		//
+		// It used to fall back to the caller's own id, which never leaked data
+		// but did something worse in its own way: `?user=abc` and
+		// `?user=<a real linked id>` both answered 200, with different
+		// accounts' data and no way for the client to tell which it had got.
+		// A truncated or typo'd id read as a successful answer about the wrong
+		// person. resolveTarget on /api/v1 already rejected these; the two
+		// surfaces read the same parameter, and disagreeing about what it
+		// means was the defect.
+		// "1;2" is deliberately absent: Go rejects a semicolon-separated query
+		// pair outright (net/url, since Go 1.17), so Get("user") returns "" and
+		// the request is indistinguishable from one that never sent the
+		// parameter. That is handled by the empty-value case below.
+		for _, raw := range []string{"abc", "1.5", "%20", "null", "1+OR+1=1"} {
 			res := runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, "user="+raw)
-			res.assertAllowed(t, alice.ID, fmt.Sprintf("unparseable ?user=%q falls back to self", raw))
+			if res.reached {
+				t.Errorf("unparseable ?user=%q reached the handler; want a 400", raw)
+			}
+			if res.status != http.StatusBadRequest {
+				t.Errorf("unparseable ?user=%q: status = %d, want 400", raw, res.status)
+			}
 		}
 
-		// Values that DO parse but name no reachable account are denied, and
-		// denied identically — a different status or body would let a caller
-		// enumerate which user ids exist.
-		for _, raw := range []string{"0", "-1", "2147483647", "99999999999999999"} {
+		// An EMPTY `user=` is not malformed — it is the same as omitting the
+		// parameter, and must still mean "my own data". Kept separate from the
+		// loop above so the two cannot be conflated.
+		runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, "user=").
+			assertAllowed(t, alice.ID, "empty ?user= means self")
+
+		// Zero and negatives are 400 like the unparseable values above, not
+		// 403. Serial ids start at 1, so these name no account that could ever
+		// exist — refusing them is a statement about the parameter's shape, not
+		// about which accounts are real, and it leaks nothing. /api/v1's
+		// resolveTarget draws the line in the same place (`id <= 0`).
+		for _, raw := range []string{"0", "-1"} {
+			res := runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, "user="+raw)
+			if res.reached {
+				t.Errorf("?user=%s reached the handler; want a 400", raw)
+			}
+			if res.status != http.StatusBadRequest {
+				t.Errorf("?user=%s: status = %d, want 400", raw, res.status)
+			}
+		}
+
+		// A POSITIVE id that names no reachable account is a different matter:
+		// it is a well-formed id that might or might not exist, so it is denied
+		// exactly like an unlinked one. A distinct status or body here WOULD
+		// let a caller enumerate which user ids exist.
+		for _, raw := range []string{"2147483647", "99999999999999999"} {
 			res := runLinkAuth(t, ctx, pool, service.ShareNutrition, alice, "user="+raw)
 			res.assertDenied(t, fmt.Sprintf("?user=%s", raw))
 		}


### PR DESCRIPTION
Closes #373
Closes #376
Closes #399

Three guards that were correct only by convention.

### #373 — `RequireLocalAuth` passed anonymous requests through

It tested *"is this session federated?"* and treated "there is no session" as **no**. Safe only because all nine routes that mount it also mount `RequireLogin` first — an ordering nothing enforced, protecting the password change, the email-change flow and every 2FA route. A guard whose safety depends on another guard being remembered is one refactor from being no guard. Now rejects a missing session itself.

### #376 — a malformed `?user=` returned the caller's own data

`?user=abc` and `?user=<a real linked id>` both answered **200**, with different accounts' data and nothing to distinguish them. No leak, but a truncated or typo'd id read as a successful answer about the wrong person. `/api/v1`'s `resolveTarget` already rejected these — two surfaces reading the same parameter and disagreeing about its meaning *was* the defect.

Zero and negatives join the 400 case: serial ids start at 1, so they name nothing that can exist and refusing them reveals nothing. A **positive** id that merely doesn't exist keeps its 403 — that distinction would be an enumeration oracle.

### #399 — the structural guard was asserting about the wrong function

`parseHandlerPackage` keyed its AST map by bare function name. The handler package declares `Create`, `Delete`, `Get`, `List`, `Login`, `Me`, `Update` on several receivers, and files are walked in `ReadDir` order — last one wins. `"Login"` resolved to `OIDCHandler.Login`, so `TestCredentialValidatorsDoNotGateLogin` was asserting about the OIDC redirect handler. Adding `validatePassword` to the real password login would have passed.

Keys are now receiver-qualified, and a collision is a hard failure rather than a silent overwrite.

### Tests that pinned the old behaviour

Two existing assertions documented the fail-open cases as deliberate; both flipped with the reasoning recorded. `"1;2"` left the malformed set — Go rejects a semicolon-separated query pair outright (net/url, since 1.17), so it never reaches the parse.

## Verification
```
go vet ./...   # clean
go test ./...  # ok, 10/10 (real Postgres 18)
```