### PR TITLE
fix(parser): bound the int conversion and align negative-half rounding

### DIFF
--- a/client/src/lib/mathParser.test.ts
+++ b/client/src/lib/mathParser.test.ts
@@ -241,14 +241,11 @@ describe('parseAmount', () => {
 
       ['', false, 0, 'empty input'],
 
-      // Known remaining divergence from the Go twin: Math.round rounds a half
-      // toward +Infinity, math.Round rounds it away from zero. They agree on
-      // every positive half ('123.5' -> 124 on both) and disagree on every
-      // negative one, so these rows are TS-only and are deliberately absent
-      // from testdata/parse_amount_cases.json. Filed as #408 rather than
-      // changed here: it is a rounding decision, not a parsing one.
-      ['-1.5', true, -1, 'Math.round(-1.5) = -1; Go math.Round(-1.5) = -2'],
-      ['10-11.5', true, -1, 'same, reached through an expression'],
+      // The negative-half divergence is gone (#408): parseAmount rounds half
+      // away from zero via roundHalfAwayFromZero, matching Go's math.Round.
+      // The cases moved to testdata/parse_amount_cases.json, where both
+      // implementations run them, which is the only place that can prove they
+      // still agree.
     ];
     for (const [input, ok, value, why] of cases) {
       expect(parseAmount(input), `${JSON.stringify(input)} (${why})`).toEqual({ ok, value });

--- a/client/src/lib/mathParser.ts
+++ b/client/src/lib/mathParser.ts
@@ -5,6 +5,28 @@
 // built from /[0-9.]/ characters only.
 const NUMBER_RE = /^(?:\d+(?:\.\d*)?|\.\d+)$/;
 
+/**
+ * Rounds a half AWAY FROM ZERO, matching Go's `math.Round`.
+ *
+ * `Math.round` rounds a half toward +Infinity: `Math.round(-1.5)` is `-1`,
+ * while `math.Round(-1.5)` is `-2`. They agree on every positive half and on
+ * everything that is not exactly `.5`, and disagree on every negative one — so
+ * `10-11.5` previewed as -1 in the browser and was stored as -2 by the server
+ * (#408). The preview is the number the user reads before submitting; it has to
+ * be the number that gets saved.
+ *
+ * The client moves rather than the server because the server's value is what is
+ * already in the database: changing `math.Round` would silently redefine what a
+ * historical entry meant. Away-from-zero is also the symmetric convention —
+ * round(1.5) = 2 and round(-1.5) = -2 — which is what an arithmetic preview
+ * should do.
+ *
+ * Keep in sync with ParseAmount in internal/service/mathparser.go.
+ */
+function roundHalfAwayFromZero(value: number): number {
+  return value < 0 ? -Math.round(-value) : Math.round(value);
+}
+
 // Safe mathematical expression evaluator using recursive descent parser
 function safeMathEval(expr: string): number {
   let pos = 0;
@@ -122,7 +144,16 @@ export function parseAmount(input: string | number | null | undefined, options: 
   try {
     const value = safeMathEval(expr);
     if (typeof value !== 'number' || !Number.isFinite(value)) return { ok: false, value: 0 };
-    const rounded = Math.round(value);
+    const rounded = roundHalfAwayFromZero(value);
+    // Reject anything outside the int32 range even when no maxAbs is given.
+    // The Go side must do this because converting an out-of-range float64 to
+    // int is implementation-defined there and yields math.MinInt64 (#364);
+    // JavaScript has no such trap, but the two parsers have to agree, and the
+    // value ends up in an INTEGER column either way. Without this, an
+    // unbounded parseAmount("99999999999999999999*99999999999999999999")
+    // returned ok on one side and not the other.
+    // Keep in sync with the bound in internal/service/mathparser.go.
+    if (rounded > 2147483647 || rounded < -2147483648) return { ok: false, value: 0 };
     if (maxAbs !== null && Math.abs(rounded) > maxAbs) return { ok: false, value: 0 };
     return { ok: true, value: rounded };
   } catch {

--- a/internal/service/mathparser.go
+++ b/internal/service/mathparser.go
@@ -98,11 +98,30 @@ func ParseAmount(input string, maxAbs int) ParseAmountResult {
 		return ParseAmountResult{Ok: false, Value: 0}
 	}
 
-	rounded := int(math.Round(val))
-	if maxAbs > 0 && abs(rounded) > maxAbs {
+	// Bound the float BEFORE converting to int.
+	//
+	// Converting an out-of-range float64 to int is implementation-defined in
+	// Go, and on amd64 and arm64 it yields the integer indefinite value
+	// math.MinInt64. abs(math.MinInt64) is math.MinInt64 — still negative — so
+	// `abs(rounded) > maxAbs` was false and the bound waved it through:
+	// ParseAmount("99999999999999999999*99999999999999999999", 9999) returned
+	// Ok with a value of -9223372036854775808, which the entry handlers then
+	// tried to store (#364).
+	//
+	// Checking in float space has no such edge: rounded is finite here (Inf and
+	// NaN are rejected above), and comparing it against maxAbs as a float is
+	// exact for every magnitude that could pass — maxAbs is at most 9999.
+	rounded := math.Round(val)
+	if maxAbs > 0 && math.Abs(rounded) > float64(maxAbs) {
 		return ParseAmountResult{Ok: false, Value: 0}
 	}
-	return ParseAmountResult{Ok: true, Value: rounded}
+	// With no maxAbs the caller has opted out of the range check, so the
+	// conversion still has to be guarded — otherwise the same indefinite value
+	// escapes through the unbounded path.
+	if rounded > math.MaxInt32 || rounded < math.MinInt32 {
+		return ParseAmountResult{Ok: false, Value: 0}
+	}
+	return ParseAmountResult{Ok: true, Value: int(rounded)}
 }
 
 func abs(x int) int {

--- a/testdata/parse_amount_cases.json
+++ b/testdata/parse_amount_cases.json
@@ -16,14 +16,16 @@
     "belong here - it belongs in that language's own test file.",
     "",
     "Deliberately NOT in this table:",
-    "  - Negative half-values ('-1.5', '10-11.5'). Go's math.Round rounds half away",
-    "    from zero (-2); JavaScript's Math.round rounds half toward +Inf (-1). That",
-    "    is a real divergence, tracked separately in issue #408.",
     "  - Inputs that evaluate to a negative zero ('-0', '-0.4'). JavaScript yields",
     "    -0, Go yields a plain 0. Nothing observable distinguishes them (-0 === 0,",
     "    String(-0) is '0', JSON.stringify(-0) is '0'), but a deep-equal assertion",
     "    does. Pinned per-language instead.",
-    "  - maxAbs behaviour, which each side pins in its own table."
+    "  - maxAbs behaviour, which each side pins in its own table.",
+    "",
+    "Negative half-values ARE pinned here as of #408: the TS side now rounds half",
+    "away from zero to match Go's math.Round, so both agree on -1.5 -> -2.",
+    "Out-of-int32 magnitudes are pinned too, as of #364: both reject rather than",
+    "one overflowing to math.MinInt64 and the other returning a float."
   ],
   "cases": [
     {
@@ -33,55 +35,55 @@
       "why": "U+0020 as a thousands separator, intended"
     },
     {
-      "input": "1\u00a0000",
+      "input": "1 000",
       "ok": true,
       "value": 1000,
       "why": "NBSP thousands separator (fr-FR, de-CH copy-paste)"
     },
     {
-      "input": "1\u202f000",
+      "input": "1 000",
       "ok": true,
       "value": 1000,
       "why": "narrow NBSP thousands separator (fr-FR)"
     },
     {
-      "input": "1\u2009000",
+      "input": "1 000",
       "ok": true,
       "value": 1000,
       "why": "thin space thousands separator"
     },
     {
-      "input": "1\u2007000",
+      "input": "1 000",
       "ok": true,
       "value": 1000,
       "why": "figure space thousands separator"
     },
     {
-      "input": "1\u3000000",
+      "input": "1　000",
       "ok": true,
       "value": 1000,
       "why": "ideographic space (CJK full-width)"
     },
     {
-      "input": "1\u1680000",
+      "input": "1 000",
       "ok": true,
       "value": 1000,
       "why": "ogham space mark, still a space separator"
     },
     {
-      "input": "5\u00855",
+      "input": "55",
       "ok": true,
       "value": 55,
       "why": "U+0085 NEL: unicode.IsSpace yes, JS \\s no - stripped on both"
     },
     {
-      "input": "5\ufeff5",
+      "input": "5﻿5",
       "ok": true,
       "value": 55,
       "why": "U+FEFF BOM: JS \\s yes, unicode.IsSpace no - stripped on both"
     },
     {
-      "input": "\u00a05\u00a0",
+      "input": " 5 ",
       "ok": true,
       "value": 5,
       "why": "surrounding NBSP"
@@ -99,7 +101,7 @@
       "why": "vertical tab, form feed, carriage return"
     },
     {
-      "input": "2\u00a0x\u00a03",
+      "input": "2 x 3",
       "ok": true,
       "value": 6,
       "why": "NBSP around the multiplication shorthand"
@@ -111,13 +113,13 @@
       "why": "digits concatenate: a typo becomes a plausible number"
     },
     {
-      "input": "5\u200b5",
+      "input": "5​5",
       "ok": false,
       "value": 0,
       "why": "U+200B ZWSP is in neither whitespace set - not stripped, rejected"
     },
     {
-      "input": "5\u20605",
+      "input": "5⁠5",
       "ok": false,
       "value": 0,
       "why": "U+2060 WORD JOINER is not whitespace either"
@@ -303,7 +305,7 @@
       "why": "spaced form is an explicit multiplication by zero"
     },
     {
-      "input": "0\u00a0x\u00a010",
+      "input": "0 x 10",
       "ok": true,
       "value": 0,
       "why": "NBSP-spaced form matches the U+0020-spaced form: the hex check runs before whitespace is stripped"
@@ -315,7 +317,7 @@
       "why": "comma is stripped first, so this is 10*2"
     },
     {
-      "input": "10 \u00d7 5",
+      "input": "10 × 5",
       "ok": true,
       "value": 50,
       "why": "multiplication sign"
@@ -333,25 +335,25 @@
       "why": "uppercase ASCII X"
     },
     {
-      "input": "100 \u00f7 4",
+      "input": "100 ÷ 4",
       "ok": true,
       "value": 25,
       "why": "division sign"
     },
     {
-      "input": "10 \u2013 5",
+      "input": "10 – 5",
       "ok": true,
       "value": 5,
       "why": "en dash as minus"
     },
     {
-      "input": "10 \u2014 5",
+      "input": "10 — 5",
       "ok": true,
       "value": 5,
       "why": "em dash as minus"
     },
     {
-      "input": "10 \u2212 5",
+      "input": "10 − 5",
       "ok": true,
       "value": 5,
       "why": "minus sign as minus"
@@ -651,31 +653,31 @@
       "why": "what a stringified 1234567 looks like"
     },
     {
-      "input": "\uff10",
+      "input": "０",
       "ok": false,
       "value": 0,
       "why": "fullwidth zero"
     },
     {
-      "input": "\uff11\uff12\uff13",
+      "input": "１２３",
       "ok": false,
       "value": 0,
       "why": "fullwidth digits"
     },
     {
-      "input": "\u0661\u0662\u0663",
+      "input": "١٢٣",
       "ok": false,
       "value": 0,
       "why": "Arabic-Indic digits"
     },
     {
-      "input": "\u00bd",
+      "input": "½",
       "ok": false,
       "value": 0,
       "why": "vulgar fraction"
     },
     {
-      "input": "\u2153",
+      "input": "⅓",
       "ok": false,
       "value": 0,
       "why": "vulgar fraction"
@@ -685,6 +687,60 @@
       "ok": false,
       "value": 0,
       "why": "stringified nil from an absent JSON key"
+    },
+    {
+      "input": "-1.5",
+      "ok": true,
+      "value": -2,
+      "why": "#408: negative half rounds away from zero on both sides"
+    },
+    {
+      "input": "-2.5",
+      "ok": true,
+      "value": -3,
+      "why": "#408: same, and not banker's rounding either"
+    },
+    {
+      "input": "10-11.5",
+      "ok": true,
+      "value": -2,
+      "why": "#408: the expression form from the issue"
+    },
+    {
+      "input": "-0.5",
+      "ok": true,
+      "value": -1,
+      "why": "#408: rounds to -1 on both, not -0"
+    },
+    {
+      "input": "0-0.5",
+      "ok": true,
+      "value": -1,
+      "why": "#408: same via arithmetic"
+    },
+    {
+      "input": "99999999999999999999*99999999999999999999",
+      "ok": false,
+      "value": 0,
+      "why": "#364: out of int32 range - Go used to overflow to math.MinInt64 and pass the bound check"
+    },
+    {
+      "input": "2147483648",
+      "ok": false,
+      "value": 0,
+      "why": "#364: one past int32 max"
+    },
+    {
+      "input": "-2147483649",
+      "ok": false,
+      "value": 0,
+      "why": "#364: one past int32 min"
+    },
+    {
+      "input": "2147483647",
+      "ok": true,
+      "value": 2147483647,
+      "why": "#364: int32 max itself is fine"
     }
   ]
 }


### PR DESCRIPTION
Closes #364
Closes #408

### #364 — the bound check passed an overflowed value

`ParseAmount` converted the evaluated float straight to `int`. Converting an out-of-range `float64` to `int` is implementation-defined in Go and yields `math.MinInt64` on amd64/arm64 — and `abs(math.MinInt64)` is *itself*, still negative, so `abs(rounded) > maxAbs` was **false** and the guard waved it through:

```
ParseAmount("99999999999999999999*99999999999999999999", 9999)
  -> Ok=true Value=-9223372036854775808
```

The range check now happens in float space before the conversion, plus an int32 guard for callers passing no `maxAbs`.

### #408 — negative halves disagreed across the two parsers

`math.Round` rounds a half away from zero (`-2`); `Math.round` rounds toward +Infinity (`-1`). Every positive half agreed, every negative one didn't — so `10-11.5` **previewed as -1 and was stored as -2**. The preview is the number the user reads before submitting.

The **client** moves, not the server: the server's value is what is already in the database, and changing `math.Round` would silently redefine what a historical entry meant. Away-from-zero is also the symmetric convention.

### The two fixes interact

Aligning the rounding alone would have introduced a *new* divergence, because the int32 bound exists only on the Go side — an unbounded huge expression would then be rejected by Go and accepted by TS. The TS parser got the same guard.

Both are pinned in `testdata/parse_amount_cases.json`, the shared table both implementations run — the only place that can prove they still agree. Two TS-only rows documenting the rounding divergence as permanent were removed; their cases moved into the shared table.

## Verification
```
go test ./...     # ok, 10/10 (real Postgres 18)
npx vitest run    # 144/144
```