### PR TITLE
test: build every test pool with database.NewPool, and guard it

### DIFF
--- a/internal/database/migrations_test.go
+++ b/internal/database/migrations_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // TestRetrySchemaInitReturnsLastError is a regression guard for the fail-fast
@@ -135,7 +133,7 @@ func TestAccountLinksShareColumns(t *testing.T) {
 		t.Skip("TEST_DATABASE_URL not set; skipping integration test")
 	}
 	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, url)
+	pool, err := NewPool(ctx, url)
 	if err != nil {
 		t.Fatalf("pool: %v", err)
 	}

--- a/internal/database/onboarding_migration_test.go
+++ b/internal/database/onboarding_migration_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"testing"
 	"time"
-
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // TestOnboardingBackfillRunsOnlyOnColumnCreation pins the one thing
@@ -33,7 +31,7 @@ func TestOnboardingBackfillRunsOnlyOnColumnCreation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	pool, err := pgxpool.New(ctx, url)
+	pool, err := NewPool(ctx, url)
 	if err != nil {
 		t.Fatalf("pool: %v", err)
 	}

--- a/internal/database/test_pool_guard_test.go
+++ b/internal/database/test_pool_guard_test.go
@@ -1,0 +1,93 @@
+package database
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoTestBuildsABarePool is the tripwire for #355 and #412.
+//
+// database.NewPool is not pgxpool.New plus tuning: its AfterConnect registers
+// dateStringCodec for OID 1082, so a DATE column scans straight into a string
+// as YYYY-MM-DD instead of a time.Time (see pool.go — it exists to avoid
+// timezone shifting). A test that opens its own pool with a bare
+// pgxpool.New does not get that codec, so any handler scanning a date into a
+// string field fails with
+//
+//	cannot scan date (OID 1082) in binary format into *string
+//
+// which is a 500 the running app cannot produce. The test then either fails for
+// a reason that does not exist in production, or — worse — passes while
+// exercising a pool that behaves differently from the one it claims to model.
+//
+// Cheaper to forbid than to rediscover: both issues above were found by someone
+// hitting the error while writing an unrelated test.
+func TestNoTestBuildsABarePool(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("resolving the repo root: %v", err)
+	}
+	self := "test_pool_guard_test.go"
+
+	var offenders []string
+	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			// node_modules is enormous and contains no Go.
+			if info.Name() == "node_modules" || info.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(info.Name(), "_test.go") || info.Name() == self {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(src), "pgxpool.New(") {
+			rel, _ := filepath.Rel(root, path)
+			offenders = append(offenders, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the repo: %v", err)
+	}
+	for _, f := range offenders {
+		t.Errorf("%s builds a pool with pgxpool.New; use database.NewPool so the test gets "+
+			"the DATE codec production installs", f)
+	}
+}
+
+// TestNewPoolRegistersTheDateCodec proves the thing the guard above protects.
+// Without it the guard is a style rule; with it, a change to NewPool that drops
+// AfterConnect fails here rather than in whichever handler test next scans a
+// date.
+func TestNewPoolRegistersTheDateCodec(t *testing.T) {
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	pool, err := NewPool(ctx, url)
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	defer pool.Close()
+
+	// The whole point: a DATE comes back as a string, not a time.Time.
+	var got string
+	if err := pool.QueryRow(ctx, "SELECT DATE '2026-08-05'").Scan(&got); err != nil {
+		t.Fatalf("scanning a DATE into a string: %v — the dateStringCodec is not registered", err)
+	}
+	if got != "2026-08-05" {
+		t.Errorf("DATE scanned as %q, want \"2026-08-05\"", got)
+	}
+}

--- a/internal/handler/auth_verify_cap_test.go
+++ b/internal/handler/auth_verify_cap_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/alexedwards/argon2id"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"schautrack/internal/database"
 	"schautrack/internal/middleware"
@@ -348,7 +347,7 @@ func TestLoginOversizedPasswordIsIndistinguishableEndToEnd(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	pool, err := pgxpool.New(ctx, url)
+	pool, err := database.NewPool(ctx, url)
 	if err != nil {
 		t.Fatalf("pool: %v", err)
 	}
@@ -429,7 +428,7 @@ func TestStepUpOversizedPasswordIsIndistinguishableEndToEnd(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	pool, err := pgxpool.New(ctx, url)
+	pool, err := database.NewPool(ctx, url)
 	if err != nil {
 		t.Fatalf("pool: %v", err)
 	}

--- a/internal/handler/bounds_db_test.go
+++ b/internal/handler/bounds_db_test.go
@@ -578,7 +578,7 @@ func boundsTestDB(t *testing.T) (context.Context, *pgxpool.Pool, int) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	t.Cleanup(cancel)
 
-	pool, err := pgxpool.New(ctx, url)
+	pool, err := database.NewPool(ctx, url)
 	if err != nil {
 		t.Fatalf("pool: %v", err)
 	}

--- a/internal/handler/invite_email_test.go
+++ b/internal/handler/invite_email_test.go
@@ -170,7 +170,7 @@ func inviteTestPool(t *testing.T) (context.Context, *pgxpool.Pool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	t.Cleanup(cancel)
 
-	pool, err := pgxpool.New(ctx, url)
+	pool, err := database.NewPool(ctx, url)
 	if err != nil {
 		t.Fatalf("pool: %v", err)
 	}

--- a/internal/handler/onboarding_test.go
+++ b/internal/handler/onboarding_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	"schautrack/internal/database"
 	"schautrack/internal/middleware"
 	"schautrack/internal/model"
@@ -36,7 +34,7 @@ func TestOnboardingCompleteKeepsFirstTimestamp(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	pool, err := pgxpool.New(ctx, url)
+	pool, err := database.NewPool(ctx, url)
 	if err != nil {
 		t.Fatalf("pool: %v", err)
 	}

--- a/internal/handler/v1_foods_list_test.go
+++ b/internal/handler/v1_foods_list_test.go
@@ -29,7 +29,7 @@ func savedFoodsTestPool(t *testing.T) (context.Context, *pgxpool.Pool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	t.Cleanup(cancel)
 
-	pool, err := pgxpool.New(ctx, url)
+	pool, err := database.NewPool(ctx, url)
 	if err != nil {
 		t.Fatalf("pool: %v", err)
 	}

--- a/internal/handler/v1_me_features_test.go
+++ b/internal/handler/v1_me_features_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	"schautrack/internal/database"
 	"schautrack/internal/model"
 	"schautrack/internal/openapi"
@@ -157,7 +155,7 @@ func TestMeFeaturesRoundTripFromDatabase(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	pool, err := pgxpool.New(ctx, url)
+	pool, err := database.NewPool(ctx, url)
 	if err != nil {
 		t.Fatalf("pool: %v", err)
 	}

--- a/internal/middleware/links_test.go
+++ b/internal/middleware/links_test.go
@@ -46,7 +46,7 @@ func linkTestDB(t *testing.T) (context.Context, *pgxpool.Pool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	t.Cleanup(cancel)
 
-	pool, err := pgxpool.New(ctx, url)
+	pool, err := database.NewPool(ctx, url)
 	if err != nil {
 		t.Fatalf("pool: %v", err)
 	}

--- a/internal/middleware/v1_bodylimit_test.go
+++ b/internal/middleware/v1_bodylimit_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	"schautrack/internal/apierr"
 	"schautrack/internal/database"
@@ -52,7 +51,7 @@ func TestV1BodyLimitBeatsTheGlobalLimit(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	pool, err := pgxpool.New(ctx, url)
+	pool, err := database.NewPool(ctx, url)
 	if err != nil {
 		t.Fatalf("pool: %v", err)
 	}


### PR DESCRIPTION
Closes #355
Closes #412

`database.NewPool` is not `pgxpool.New` plus tuning. Its `AfterConnect` registers `dateStringCodec` for OID 1082, so a `DATE` column scans straight into a `string` as `YYYY-MM-DD` rather than a `time.Time` — `pool.go` added it to avoid timezone shifting.

Eleven test call sites across four packages opened a bare `pgxpool.New`, so they ran against a pool that behaves differently from the one the app uses. The failure mode:

```
cannot scan date (OID 1082) in binary format into *string
```

That's a 500 production cannot produce — so the test either fails for a reason that doesn't exist, or passes while modelling the wrong pool. Both issues were found by someone hitting this while writing an unrelated test.

## Two tests, doing different jobs

`TestNoTestBuildsABarePool` walks the repo and fails on any `_test.go` containing `pgxpool.New`. **Verified it actually fires** — a probe file under `internal/handler` was reported by path, and the test passed again once removed. A guard nobody has seen fail is a guard you're trusting on faith.

`TestNewPoolRegistersTheDateCodec` proves what the guard protects: it scans a `DATE` into a `string` through `NewPool`. Without it the guard is a style rule; with it, dropping `AfterConnect` fails here rather than in whichever handler test next touches a date.

## Verification
```
go vet ./...   # clean
go test ./...  # ok, 10/10 (real Postgres 18)
```