### PR TITLE
fix(auth): stop the bcrypt migration rewriting the password, bound backup codes, equalize 2FA-reset timing

### DIFF
--- a/internal/handler/auth_helpers.go
+++ b/internal/handler/auth_helpers.go
@@ -69,7 +69,44 @@ func hashPassword(password string) (string, error) {
 	return argon2id.CreateHash(password, argon2id.DefaultParams)
 }
 
+// maxBackupCodeBytes bounds the backup code a client may submit. A generated
+// code is 8 digits; the slack is for a pasted value carrying separators or
+// surrounding whitespace, so a user's formatting mistake still fails on the
+// comparison rather than on an invisible length rule.
+const maxBackupCodeBytes = 64
+
+// bcryptMaxBytes is how much of a password bcrypt actually consumes. Its
+// blowfish key schedule reads 18 x 4 = 72 bytes and ignores the rest;
+// CompareHashAndPassword neither errors nor costs more for a longer input.
+const bcryptMaxBytes = 72
+
+// migratePasswordHash upgrades a legacy bcrypt hash to argon2id after a
+// successful login.
+//
+// It refuses to migrate a password longer than bcrypt validated (#397).
+// bcrypt compared only the first 72 bytes, so every string sharing that prefix
+// logged in — but argon2id compares the WHOLE string. Re-hashing the submitted
+// bytes therefore narrows the account to one specific member of the set that
+// used to work, chosen by whoever logged in last:
+//
+//   - a user whose real password is 80 characters, who has been logging in with
+//     a browser that truncates at 72, silently loses the ability to use the
+//     other spelling;
+//   - worse, anyone who obtained the 72-byte prefix could log in AND, in the
+//     same request, rewrite the stored hash to a longer string of their
+//     choosing that the real owner does not know.
+//
+// Skipping the migration leaves the account on bcrypt, which is exactly the
+// status quo: no worse than before, and no silent change to what the password
+// is. These accounts stay on bcrypt until someone logs in with a password
+// bcrypt could fully see, or changes it — both of which go through the normal
+// argon2id path.
 func migratePasswordHash(pool *pgxpool.Pool, userID int, password string) {
+	if len(password) > bcryptMaxBytes {
+		slog.Warn("skipping bcrypt->argon2id migration: password exceeds what bcrypt validated",
+			"user_id", userID, "bytes", len(password), "bcrypt_limit", bcryptMaxBytes)
+		return
+	}
 	hash, err := hashPassword(password)
 	if err != nil {
 		return
@@ -162,6 +199,26 @@ func verifyAndUseBackupCodeForLogin(r *http.Request, pool *pgxpool.Pool, userID 
 // It reads all unused codes, finds a match in-memory, then uses an atomic UPDATE
 // with a WHERE used = FALSE condition to prevent race conditions.
 func verifyAndMarkBackupCode(r *http.Request, pool *pgxpool.Pool, userID int, code string) bool {
+	// Bound the client string before it reaches the hash loop (#404).
+	//
+	// VerifyBackupCode re-hashes `code` once per unused code, so with
+	// service.BackupCodeCount stored codes an unbounded token is that many
+	// SHA-256 passes over whatever the client sent. Only ReadJSON's 10 MB body
+	// limit stood in the way: a 10 MB token cost roughly a quarter second of
+	// CPU per request, unauthenticated at the login 2FA step.
+	//
+	// A real code is 8 digits (service.GenerateBackupCodes), so anything longer
+	// than this cannot match any stored hash — the check costs nothing and
+	// rejects exactly the inputs that were only ever going to fail. The bound
+	// is loose rather than exactly 8 so that a formatted paste ("1234-5678",
+	// surrounding spaces) still reaches the comparison and fails on its own
+	// merits rather than on a length rule the user cannot see.
+	if len(code) > maxBackupCodeBytes {
+		slog.Warn("rejected an over-long backup code before hashing",
+			"user_id", userID, "bytes", len(code), "limit", maxBackupCodeBytes)
+		return false
+	}
+
 	rows, err := pool.Query(r.Context(),
 		"SELECT id, code_hash FROM totp_backup_codes WHERE user_id = $1 AND used = FALSE", userID)
 	if err != nil {
@@ -247,6 +304,18 @@ func (h *AuthHandler) Reset2FA(w http.ResponseWriter, r *http.Request) {
 			"SELECT id, password_hash, totp_enabled, language FROM users WHERE email = $1", emailClean,
 		).Scan(&userID, &passwordHash, &totpEnabled, &userLanguage)
 		if err != nil {
+			// Pay the verification cost we are skipping (#401).
+			//
+			// An unknown address returned here after a cheap index miss, while
+			// a known one went on to spend a full argon2id verification below.
+			// The bodies were identical and the durations were not, so a
+			// stopwatch answered "is this address registered?" — to an
+			// UNAUTHENTICATED caller, which is what makes this worse than the
+			// same shape on an authenticated route.
+			//
+			// Login already equalizes its own unknown-email path this way; this
+			// endpoint takes the same email and password and simply forgot to.
+			equalizeLoginTiming(body.Password)
 			ErrorJSON(w, http.StatusUnauthorized, "Invalid credentials.")
 			return
 		}

--- a/internal/handler/auth_helpers_crypto_test.go
+++ b/internal/handler/auth_helpers_crypto_test.go
@@ -1,0 +1,43 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMigrationRefusesWhatBcryptDidNotValidate pins #397.
+//
+// bcrypt reads 72 bytes; argon2id reads all of them. Migrating the submitted
+// string after a bcrypt login therefore narrows the account to one member of
+// the set that used to work, picked by whoever logged in last — including
+// someone who only ever had the 72-byte prefix.
+func TestMigrationRefusesWhatBcryptDidNotValidate(t *testing.T) {
+	if bcryptMaxBytes != 72 {
+		t.Fatalf("bcryptMaxBytes = %d, want 72 — this is a property of bcrypt's key schedule, not a tunable",
+			bcryptMaxBytes)
+	}
+
+	// A nil pool would panic if the guard let execution through, which is the
+	// assertion: the length check must return before touching the database.
+	long := strings.Repeat("a", bcryptMaxBytes+1)
+	migratePasswordHash(nil, 1, long)
+
+	// Exactly at the bound is fine to migrate — bcrypt saw all of it — but with
+	// a nil pool we can only assert it gets far enough to try, so that case is
+	// covered by the handler tests instead.
+}
+
+// TestBackupCodeLengthGuard pins #404: the client string is bounded before it
+// reaches a hash loop that runs once per stored code.
+func TestBackupCodeLengthGuard(t *testing.T) {
+	if maxBackupCodeBytes < 8 {
+		t.Fatalf("maxBackupCodeBytes = %d, below the 8 digits a real code has", maxBackupCodeBytes)
+	}
+	if maxBackupCodeBytes > 256 {
+		t.Errorf("maxBackupCodeBytes = %d is too loose to bound the per-code SHA-256 work", maxBackupCodeBytes)
+	}
+	// A nil pool would panic if the guard let execution through.
+	if verifyAndMarkBackupCode(nil, nil, 1, strings.Repeat("9", maxBackupCodeBytes+1)) {
+		t.Error("an over-long backup code was accepted")
+	}
+}


### PR DESCRIPTION
Closes #397
Closes #401
Closes #404

### #397 — the migration could change what the password *is*

`migratePasswordHash` re-hashed the submitted string with argon2id after a successful bcrypt login. bcrypt reads **72 bytes**; argon2id reads all of them. So the migration narrowed the account to one specific member of the set that used to work, picked by whoever logged in last:

- a user whose real password is 80 characters, logging in through something that truncates at 72, silently loses the other spelling;
- worse, anyone holding only the 72-byte prefix could log in **and rewrite the stored hash to a longer string the owner does not know**.

It now declines to migrate what bcrypt did not fully validate. The account stays on bcrypt — exactly the status quo, no worse than before — until someone logs in with a password bcrypt could see in full, or changes it.

Truncating to 72 instead would have been wrong: the user typing their real 80-character password would then fail to log in.

### #404 — unbounded hashing, once per stored code

`verifyAndMarkBackupCode` re-hashes the client string for **every** unused code. Only `ReadJSON`'s 10 MB limit stood in the way, so a 10 MB token was 8 SHA-256 passes over 10 MB — about a quarter second of CPU, unauthenticated, at the login 2FA step. A real code is 8 digits, so anything past a loose 64-byte bound cannot match any stored hash and is refused before the loop.

### #401 — enumeration oracle on the 2FA-reset request

Unknown email returned after a cheap index miss; known email paid a full argon2id verification. Identical bodies, different durations — a stopwatch answered *"is this address registered?"* to an unauthenticated caller. Login already equalizes its own unknown-email path; this endpoint takes the same email and password and simply didn't.

## Verification
```
go vet ./...   # clean
go test ./...  # ok, 10/10 (real Postgres 18)
```