### PR TITLE
fix(api): reject NUL bytes with a 400, and let null clear a saved food's calories

### DIFF
--- a/internal/handler/saved_foods.go
+++ b/internal/handler/saved_foods.go
@@ -142,12 +142,20 @@ func parseSavedFoodPayload(body map[string]any, forCreate bool) (*savedFoodInput
 		}
 	}
 
-	// An explicit null amount is deliberately *not* a clear: it leaves
-	// hasAmount false, so Update omits the column entirely. Only an empty
-	// string clears it. Preserved from before the refactor.
-	if amount, present := optionalString(body, "amount"); present && amount != nil {
+	// An explicit null clears the amount, exactly like an empty string (#388).
+	//
+	// Null used to leave hasAmount false, so Update omitted the column and — if
+	// nothing else was in the body — answered 400 "No updates provided" while
+	// the stored calories stayed put. That is precisely what the UI sends when
+	// the field is emptied (SavedFoodsModal: `payload.amount = raw.trim() === ''
+	// ? null : Number(raw)`), so clearing a saved food's calories reported an
+	// error and silently did nothing.
+	//
+	// The macro fields below already treated null and "" the same way; amount
+	// was the odd one out.
+	if amount, present := optionalString(body, "amount"); present {
 		out.hasAmount = true
-		if *amount != "" {
+		if amount != nil && *amount != "" {
 			parsed := service.ParseAmount(*amount, MaxEntryCalories)
 			if !parsed.Ok {
 				return nil, http.StatusBadRequest, fmt.Sprintf("Calories must be between -%d and %d", MaxEntryCalories, MaxEntryCalories)

--- a/internal/handler/saved_foods_test.go
+++ b/internal/handler/saved_foods_test.go
@@ -252,12 +252,17 @@ func TestParseSavedFoodPayload(t *testing.T) {
 			forCreate: true, wantStatus: 400,
 		},
 		{
-			name:      "explicit nil amount leaves hasAmount false",
+			// #388: a nil amount is a clear, not a no-op — see the amount table
+			// in TestParseSavedFoodPayloadAmount for why.
+			name:      "explicit nil amount clears the column",
 			body:      map[string]any{"name": "x", "amount": nil},
 			forCreate: true, wantStatus: 0,
 			check: func(t *testing.T, in *savedFoodInput) {
-				if in.hasAmount {
-					t.Errorf("hasAmount = true, want false for nil amount")
+				if !in.hasAmount {
+					t.Errorf("hasAmount = false, want true for nil amount")
+				}
+				if in.amount != nil {
+					t.Errorf("amount = %v, want nil (cleared)", *in.amount)
 				}
 			},
 		},
@@ -496,7 +501,11 @@ func TestParseSavedFoodPayloadAmount(t *testing.T) {
 		wantMsg   bool
 	}{
 		{"key absent leaves the column alone", `{"name":"x"}`, false, true, 0, false},
-		{"null leaves hasAmount false", `{"name":"x","amount":null}`, false, true, 0, false},
+		// #388: null clears the amount, exactly like "" and "   " below. It used to
+		// leave hasAmount false, so a body of only {"amount": null} — what the UI
+		// sends when the field is emptied — answered 400 "No updates provided" and
+		// left the stored calories in place.
+		{"null clears it", `{"name":"x","amount":null}`, true, true, 0, false},
 		{"empty string clears it", `{"name":"x","amount":""}`, true, true, 0, false},
 		{"whitespace clears it", `{"name":"x","amount":"   "}`, true, true, 0, false},
 		{"a numeric string sets it", `{"name":"x","amount":"500"}`, true, false, 500, false},

--- a/internal/handler/v1_common.go
+++ b/internal/handler/v1_common.go
@@ -147,6 +147,23 @@ func decodeV1(w http.ResponseWriter, r *http.Request, dst any) *apierr.Problem {
 		return apierr.BadRequest("The request body must be a JSON object.")
 	}
 
+	// A NUL byte in any string is refused here rather than by Postgres (#378).
+	//
+	// `"a\u0000b"` is valid JSON and encoding/json decodes it to a Go string
+	// holding a NUL. Postgres TEXT cannot store one, so the INSERT failed with
+	// SQLSTATE 22021 and dbFail turned that into a 500 — ten error paths across
+	// five handlers answering "internal server error" for a request that is
+	// entirely the caller's fault.
+	//
+	// Checked on the raw bytes, which is both the cheapest and the most complete
+	// place: a literal NUL cannot appear unescaped in valid JSON (it is a control
+	// character, and encoding/json rejects it), so the \u0000 escape is the only
+	// spelling that reaches a decoded string. One scan here covers every field of
+	// every v1 endpoint, present and future, without each handler remembering.
+	if bytes.Contains(raw, []byte(`\u0000`)) {
+		return apierr.BadRequest("Text fields cannot contain NUL characters.")
+	}
+
 	// Pass 2 fills dst from the object. It runs over the bytes pass 1 already
 	// read, so the body is never read twice.
 	obj := json.NewDecoder(bytes.NewReader(raw))

--- a/internal/handler/v1_nul_bytes_integration_test.go
+++ b/internal/handler/v1_nul_bytes_integration_test.go
@@ -8,25 +8,21 @@ import (
 	"schautrack/internal/service"
 )
 
-// A NUL byte in a text field is a 500. See #378.
+// A NUL byte in a text field is a 400. See #378, now fixed.
 //
 // nulEscape below is the six characters backslash-u-zero-zero-zero-zero: a
 // perfectly legal JSON escape that decodes to a Go string containing 0x00.
-// Postgres TEXT cannot store that byte, so the INSERT fails with SQLSTATE 22021
-// and dbFail turns a client mistake into an internal-error problem.
+// Postgres TEXT cannot store that byte, so the INSERT used to fail with
+// SQLSTATE 22021 and dbFail turned a client mistake into a 500.
 //
-// These tests assert the CURRENT behaviour deliberately. Writing them the right
-// way round would mean committing a red suite; writing them loosely ("4xx or
-// 5xx, whatever") would mean the fix lands with nothing noticing. Pinned to 500
-// with a pointer to #378, they fail the moment someone fixes it — which is the
-// signal the fixer needs to invert them.
-//
-// TODO(#378): when a NUL is rejected before it reaches SQL, change every
-// expected status below to the 4xx it should have been all along and rename
-// this file to say what it now guards.
+// These assertions were pinned to 500 on purpose while the bug stood, with a
+// TODO asking whoever fixed it to invert them. That is what happened: decodeV1
+// now refuses the escape on the raw body before anything is decoded, so every
+// v1 endpoint answers 400 rather than ten handlers each learning the lesson
+// separately.
 const nulEscape = `\u0000`
 
-func TestV1NulByteInATextFieldIsAn500(t *testing.T) {
+func TestV1NulByteInATextFieldIsRejected(t *testing.T) {
 	e := newV1Env(t)
 	token := e.allScopesToken()
 
@@ -72,9 +68,9 @@ func TestV1NulByteInATextFieldIsAn500(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			rec := e.do(call{Method: c.method, Path: c.path, Token: token, Body: c.body})
 
-			if rec.Code != http.StatusInternalServerError {
-				t.Fatalf("status = %d — if this is now a 4xx, #378 is fixed: invert every assertion "+
-					"in this file and rename it (body: %s)", rec.Code, rec.Body.String())
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 — a NUL is the caller's mistake, never a server "+
+					"failure (body: %s)", rec.Code, rec.Body.String())
 			}
 			// Whatever the status, the contract's error format still holds.
 			requireProblemShape(t, rec)
@@ -82,11 +78,16 @@ func TestV1NulByteInATextFieldIsAn500(t *testing.T) {
 	}
 }
 
-// TestV1ValidatedFieldsRejectNulProperly is the other half of #378, and the
-// reason the fix is worth making: the fields that go through a parser or a
-// closed set already answer 422. The string columns are the exception, not the
-// rule.
-func TestV1ValidatedFieldsRejectNulProperly(t *testing.T) {
+// TestV1ValidatedFieldsRejectNul covers the fields that have their own parser
+// or closed set. They used to answer 422 — the value was well-formed JSON but
+// not a legal timezone/language/date — while the free-text columns 500d.
+//
+// Both are 400 now, because the check that fires first is about the ENCODING
+// rather than the value: a NUL cannot be stored in any text column, so which
+// field it landed in does not change the answer. Uniform is the right trade
+// here; the alternative is a rule whose status depends on whether the field
+// happens to have a validator, which no client could predict.
+func TestV1ValidatedFieldsRejectNul(t *testing.T) {
 	e := newV1Env(t)
 	token := e.allScopesToken()
 
@@ -102,8 +103,8 @@ func TestV1ValidatedFieldsRejectNulProperly(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			rec := e.do(call{Method: c.method, Path: c.path, Token: token, Body: c.body})
-			if rec.Code != http.StatusUnprocessableEntity {
-				t.Fatalf("status = %d, want 422 (body: %s)", rec.Code, rec.Body.String())
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 (body: %s)", rec.Code, rec.Body.String())
 			}
 			requireProblemShape(t, rec)
 		})

--- a/internal/handler/v1_nul_guard_test.go
+++ b/internal/handler/v1_nul_guard_test.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestDecodeV1RejectsNulBytes pins #378. A NUL in a text field used to reach
+// Postgres, fail with SQLSTATE 22021 and surface as a 500 through dbFail —
+// across ten error paths in five handlers, for a request entirely of the
+// caller's making.
+func TestDecodeV1RejectsNulBytes(t *testing.T) {
+	var dst v1CommonTestBody
+
+	for _, body := range []string{
+		`{"name":"a\u0000b"}`,
+		`{"name":"\u0000"}`,
+		`{"name":"trailing\u0000"}`,
+	} {
+		got := decodeV1(httptest.NewRecorder(),
+			httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), &dst)
+		if got == nil {
+			t.Errorf("decodeV1(%s) accepted a NUL byte", body)
+			continue
+		}
+		if got.Status != http.StatusBadRequest {
+			t.Errorf("decodeV1(%s) = %d, want 400 (a client mistake, not a server failure)", body, got.Status)
+		}
+	}
+
+	// A literal NUL byte is not valid JSON at all — encoding/json rejects it as
+	// a control character — so it can never reach a decoded string. Pinned so
+	// the raw-bytes check above is known to cover every reachable spelling.
+	got := decodeV1(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{\"name\":\"a\x00b\"}")), &dst)
+	if got == nil || got.Status != http.StatusBadRequest {
+		t.Errorf("a literal NUL in the body = %v, want a 400", got)
+	}
+
+	// The escape must not be confused with harmless neighbours.
+	for _, body := range []string{`{"name":"\u0041"}`, `{"name":"u0000"}`, `{"name":"0000"}`} {
+		if got := decodeV1(httptest.NewRecorder(),
+			httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), &dst); got != nil {
+			t.Errorf("decodeV1(%s) = %v, want accepted", body, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #378
Closes #388

### #378 — a NUL byte was a 500

A JSON string may legally contain the `\u0000` escape, and encoding/json decodes it to a Go string holding a NUL. Postgres `TEXT` cannot store that byte, so the INSERT failed with SQLSTATE 22021 and `dbFail` turned it into a **500** — ten error paths across five handlers reporting an internal failure for a request entirely of the caller's making.

Rejected in `decodeV1` on the raw body. That's the cheapest *and* most complete place: a literal NUL cannot appear unescaped in valid JSON, so the escape is the only spelling that reaches a decoded string, and one scan covers every field of every v1 endpoint instead of ten handlers each learning the lesson.

**Behaviour note:** fields with their own validator previously answered 422 and now answer 400. Uniform is deliberate — the check is about the *encoding*, not the value. A NUL is unstorable in any text column, so which field it landed in shouldn't change the answer. The alternative is a status that depends on whether a field happens to have a validator, which no client could predict.

### #388 — clearing calories silently did nothing

An explicit `null` amount left `hasAmount` false, so `Update` omitted the column and — with nothing else in the body — replied `400 "No updates provided"` while the stored value stayed put. That is exactly what the UI sends when the field is emptied. The macro fields already treated `null` and `""` alike; amount was the odd one out.

### Tests that pinned the old behaviour

`v1_nul_bytes_integration_test.go` was written deliberately backwards, with a TODO asking whoever fixed #378 to invert its assertions and rename it — its failure message says so outright. Done, along with two saved-food assertions.

## Verification

```
go vet ./...   # clean
go test ./...  # ok, 10/10 (real Postgres 18)
```
