### PR TITLE
docs(api): render enums and nested objects, and pin the README env table

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ Configuring SMTP enables all transactional email flows: password reset, registra
 | `ENABLE_BARCODE` | `true` | Enable barcode scanning via OpenFoodFacts. Set `false` to disable. |
 | `ENABLE_REGISTRATION` | `open` | `open` (anyone can register) or `false` / `invite` (requires invite code). Also configurable via `/admin`. |
 | `UPDATE_CHECK_ENABLED` | `true` | Check GitHub (`api.github.com`) for a newer release so the footer can flag an outdated instance. Set `false` to opt out of the outbound request — recommended for privacy-sensitive or air-gapped self-hosts. |
+| `UPDATE_PROVIDER` | `github` | Which forge hosts the release feed the check reads. `github` or `gitlab`. |
+| `UPDATE_REPO` | `schaurian/schautrack` | The `owner/name` the check asks about. Point it at your own fork to track your releases rather than upstream's. |
+| `UPDATE_BASE_URL` | _(empty)_ | API base for a self-hosted forge, e.g. `https://gitlab.example.com/api/v4`. Empty means the provider's public API. |
 
 ### OIDC (Single Sign-On)
 

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -937,7 +937,7 @@ Body composition derived from the most recent body-fat reading. That reading can
 | --- | --- | --- | --- |
 | `ageDays` | `integer` | yes | Whole days between `date` and today. Negative is possible and means fresh: `date` is the account's local date while today is the server's, so a few hours of timezone skew can put the reading marginally ahead. |
 | `bodyFatPct` | `number` | yes | Body fat as a percentage of total mass. A percentage, so never unit-converted. |
-| `category` | `string` or `null` | yes | The band `bodyFatPct` falls in for this sex: `essential`, `athletic`, `fitness`, `average` or `obese`. `null` when the sex is unknown — the bands genuinely differ by sex, so no label is given rather than a wrong one. |
+| `category` | `essential` \| `athletic` \| `fitness` \| `average` \| `obese` \| `null` | yes | The band `bodyFatPct` falls in for this sex: `essential`, `athletic`, `fitness`, `average` or `obese`. `null` when the sex is unknown — the bands genuinely differ by sex, so no label is given rather than a wrong one. |
 | `date` | `string` (date) | yes | The day the body-fat reading was recorded. |
 | `fatMass` | `number` | yes | Fat mass at that reading. In the account's weight unit. |
 | `leanMass` | `number` | yes | Fat-free mass at that reading. In the account's weight unit. |
@@ -1061,6 +1061,28 @@ A linked account, from your point of view.
 | `timezone` | `string` | yes | Their IANA time zone. Their timestamps are rendered in it, not yours. |
 | `user_id` | `integer` | yes | Pass this as the `user` query parameter on a read endpoint. |
 
+#### shares_to_them
+
+What you share back with them.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `notes` | `boolean` | yes | Daily notes. |
+| `nutrition` | `boolean` | yes | Calorie entries and macros. |
+| `todos` | `boolean` | yes | Todos and completions. |
+| `weight` | `boolean` | yes | Weight readings. |
+
+#### shares_with_me
+
+What this account shares WITH you — the only categories `?user=` will serve.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `notes` | `boolean` | yes | Daily notes. |
+| `nutrition` | `boolean` | yes | Calorie entries and macros. |
+| `todos` | `boolean` | yes | Todos and completions. |
+| `weight` | `boolean` | yes | Weight readings. |
+
 ### LinkList
 
 Accounts linked to yours.
@@ -1092,6 +1114,52 @@ The authenticated account, the token, and the account's enabled features.
 | `token` | `object` | yes | The token that authenticated this request. |
 | `user` | `object` | yes | The account this token belongs to. |
 
+#### features
+
+Per-account opt-ins that change how the rest of the API behaves. Read-only: they are switched in the app's settings, not through this API. Every field is always present.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `auto_calc_calories` | `boolean` | yes | Calories are computed from macros. When `true`, `POST /entries` derives `calories` from the macros it was given rather than trusting the value sent, and `PATCH /entries/{id}` rejects `calories` with a `422`. |
+| `body_fat` | `boolean` | yes | Body-fat readings are enabled. When `false` a stored reading is not shown in the app. |
+| `macros` | `boolean` | yes | At least one macro (protein, carbs, fat, fiber, sugar) is enabled for this account, so macro values are shown in the app. |
+| `notes` | `boolean` | yes | Daily notes are enabled. When `false`, `GET` and `PUT /notes/{date}` answer `409`. |
+| `todos` | `boolean` | yes | Todos are enabled in the app. The todo endpoints work either way, but a todo created while this is `false` is invisible to the user. |
+
+#### server
+
+The server answering.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `today` | `string` (date) | yes | Today's date in the account's time zone. |
+| `version` | `string` | yes | The running build version. |
+
+#### token
+
+The token that authenticated this request.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `expires_at` | `string` or `null` | yes | When it stops working. `null` means never. |
+| `id` | `integer` | yes | Token identifier. |
+| `name` | `string` | yes | The label given when it was created. |
+| `prefix` | `string` | yes | The token's non-secret prefix. |
+| `scopes` | array of `string` | yes | Everything this token may do. |
+
+#### user
+
+The account this token belongs to.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `daily_goal` | `integer` or `null` | yes | Daily calorie goal, if set. |
+| `email` | `string` | yes | Account email. |
+| `id` | `integer` | yes | Account identifier. |
+| `language` | `string` or `null` | yes | UI language, if set. |
+| `timezone` | `string` | yes | IANA time zone. Determines what `today` and every bare date mean. |
+| `weight_unit` | `kg` \| `lb` | yes | The unit weight readings are stored in. |
+
 ### Note
 
 One day's free-text note.
@@ -1117,7 +1185,7 @@ The weight-loss plan: body metrics, active goal, computed budget, projected curv
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `bmi` | `number` or `null` | yes | Body mass index. `null` without both a height and a weight. |
-| `bmiCategory` | `string` or `null` | yes | The band `bmi` falls in: `underweight`, `normal`, `overweight` or `obese`. |
+| `bmiCategory` | `underweight` \| `normal` \| `overweight` \| `obese` \| `null` | yes | The band `bmi` falls in: `underweight`, `normal`, `overweight` or `obese`. |
 | `composition` | [`BodyComposition`](#bodycomposition) or `null` | yes | Derived from the most recent body-fat reading. `null` when none was recorded. |
 | `computed` | [`PlanComputed`](#plancomputed) or `null` | yes | The budget and projection. `null` unless the body metrics are complete AND an active goal has a usable pace. |
 | `currentCalorieGoal` | `integer` or `null` | yes | The account's daily calorie target as it stands now, which need not equal `computed.budgetKcal` — the recommendation is only applied when the user accepts it. |
@@ -1137,7 +1205,7 @@ The energy budget and the projection it produces.
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `bmr` | `number` | yes | Basal metabolic rate, kcal/day, per `bmrFormula`. |
-| `bmrFormula` | `string` | yes | Which estimator produced `bmr`: `katch_mcardle` when a body-fat reading was available (it works off lean mass, the more accurate basis), `mifflin_st_jeor` otherwise. |
+| `bmrFormula` | `mifflin_st_jeor` \| `katch_mcardle` | yes | Which estimator produced `bmr`: `katch_mcardle` when a body-fat reading was available (it works off lean mass, the more accurate basis), `mifflin_st_jeor` otherwise. |
 | `budgetClamped` | `boolean` | yes | Whether the budget was raised to the safe floor for this sex. The matching `budget_clamped` warning is also emitted. |
 | `budgetKcal` | `integer` | yes | The recommended daily intake, kcal. |
 | `etaDate` | `string` or `null` | yes | The date `etaWeeks` lands on. `null` when the ETA is not a finite number. |
@@ -1152,11 +1220,11 @@ The body metrics the plan is computed from. Each is `null` until the account sup
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `activityLevel` | `string` or `null` | yes | `sedentary`, `light`, `moderate`, `active` or `very_active`. Decides the multiplier applied to BMR to reach TDEE. |
+| `activityLevel` | `sedentary` \| `light` \| `moderate` \| `active` \| `very_active` \| `null` | yes | `sedentary`, `light`, `moderate`, `active` or `very_active`. Decides the multiplier applied to BMR to reach TDEE. |
 | `birthYear` | `integer` or `null` | yes | Year of birth; age is derived from it. |
 | `complete` | `boolean` | yes | Whether all four are set. `computed` stays `null` while this is `false`. |
 | `heightCm` | `number` or `null` | yes | Height in centimetres. Never converted — this is not a weight. |
-| `sex` | `string` or `null` | yes | `male`, `female` or `other`. Used by the Mifflin–St Jeor formula and the calorie floor. |
+| `sex` | `male` \| `female` \| `other` \| `null` | yes | `male`, `female` or `other`. Used by the Mifflin–St Jeor formula and the calorie floor. |
 
 ### PlanTrend
 
@@ -1168,7 +1236,7 @@ Observed progress: a least-squares fit over the readings from the last 30 days. 
 | `projectedDate` | `string` or `null` | yes | The date `projectedWeeks` lands on. `null` when it cannot be projected. |
 | `projectedWeeks` | `number` | yes | Weeks to the target at the observed rate. `-1` when it cannot be projected. |
 | `slopeKgPerWeek` | `number` | yes | Fitted change per week, negative when losing. In the account's weight unit. Not necessarily kg, despite the name. |
-| `status` | `string` | yes | Progress against the plan's pace: `ahead` from 110%, `on_track` from 85%, `behind` below that. `stalled` when the fitted change is under 0.05 per week, `wrong_direction` when it moves away from the target, `insufficient_data` when `hasData` is false. |
+| `status` | `insufficient_data` \| `stalled` \| `wrong_direction` \| `behind` \| `on_track` \| `ahead` | yes | Progress against the plan's pace: `ahead` from 110%, `on_track` from 85%, `behind` below that. `stalled` when the fitted change is under 0.05 per week, `wrong_direction` when it moves away from the target, `insufficient_data` when `hasData` is false. |
 
 ### PlanWarning
 
@@ -1176,7 +1244,7 @@ A safety note about the plan. Branch on `code`; `message` is English prose that 
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `code` | `string` | yes | What is being flagged: `budget_clamped` (the budget was raised to the safe floor), `aggressive_rate` (the pace exceeds 1% of body weight per week), `target_underweight` or `target_obese` (the target weight falls in that BMI band). |
+| `code` | `budget_clamped` \| `aggressive_rate` \| `target_underweight` \| `target_obese` | yes | What is being flagged: `budget_clamped` (the budget was raised to the safe floor), `aggressive_rate` (the pace exceeds 1% of body weight per week), `target_underweight` or `target_obese` (the target weight falls in that BMI band). |
 | `message` | `string` | yes | Human-readable explanation, in English. |
 
 ### Problem
@@ -1254,7 +1322,7 @@ When a todo recurs.
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `days` | array of `integer` |  | Required when `type` is `weekly`. |
-| `type` | `string` | yes | `daily` every day; `weekly` on the listed days. |
+| `type` | `daily` \| `weekly` | yes | `daily` every day; `weekly` on the listed days. |
 
 ### SeriesPoint
 
@@ -1275,7 +1343,7 @@ Account settings to change. Omit a field to leave it alone.
 | `daily_goal` | `integer` or `null` |  | Daily calorie goal. `null` clears it. |
 | `language` | `string` or `null` |  | UI language: one of en, de, es, fr, it, nl, pl, pt. `null` restores automatic. |
 | `timezone` | `string` |  | IANA time zone name, e.g. `Europe/Berlin`. Decides what every bare date means. |
-| `weight_unit` | `string` |  | Display unit. Changing it does NOT convert stored readings — they are kept as entered. |
+| `weight_unit` | `kg` \| `lb` |  | Display unit. Changing it does NOT convert stored readings — they are kept as entered. |
 
 ### Todo
 
@@ -1357,7 +1425,7 @@ A weight reading. One per account per day.
 | `body_fat` | `number` or `null` | yes | Body fat as a percentage, or `null` when the day carries no measurement. |
 | `created_at` | `string` (date-time) | yes | When first recorded (UTC). |
 | `date` | `string` (date) | yes | The day this reading belongs to. |
-| `unit` | `string` | yes | The account's weight unit. Readings are stored as entered and never converted. |
+| `unit` | `kg` \| `lb` | yes | The account's weight unit. Readings are stored as entered and never converted. |
 | `updated_at` | `string` (date-time) | yes | When last changed (UTC). |
 | `weight` | `number` | yes | The reading, in `unit`. |
 
@@ -1368,14 +1436,14 @@ The active weight goal, echoed in the account's unit. Read-only here: setting a 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `achieved_at` | `string` (date-time) |  | When the goal was met (UTC). Absent while it is active. |
-| `activity_level` | `string` |  | The activity level recorded with the goal: `sedentary`, `light`, `moderate`, `active` or `very_active`. |
+| `activity_level` | `sedentary` \| `light` \| `moderate` \| `active` \| `very_active` |  | The activity level recorded with the goal: `sedentary`, `light`, `moderate`, `active` or `very_active`. |
 | `created_at` | `string` (date-time) | yes | When the goal was created (UTC). |
 | `id` | `integer` | yes | Goal identifier. |
-| `pace_mode` | `string` | yes | `rate` sets a weekly pace directly; `date` derives one from `target_date`. |
+| `pace_mode` | `rate` \| `date` | yes | `rate` sets a weekly pace directly; `date` derives one from `target_date`. |
 | `rate_kg_per_week` | `number` |  | The requested pace per week. Present when `pace_mode` is `rate`. In the account's weight unit. Not necessarily kg, despite the name. |
 | `start_date` | `string` (date) | yes | The day the goal was set. |
 | `start_weight` | `number` | yes | Weight when the goal was set. In the account's weight unit. |
-| `status` | `string` | yes | `active`, `achieved` or `abandoned` — always `active` here, since this endpoint only returns the active goal. |
+| `status` | `active` \| `achieved` \| `abandoned` | yes | `active`, `achieved` or `abandoned` — always `active` here, since this endpoint only returns the active goal. |
 | `target_date` | `string` (date) |  | The requested finish date. Present when `pace_mode` is `date`. |
 | `target_weight` | `number` | yes | The target. In the account's weight unit. |
 | `updated_at` | `string` (date-time) | yes | When it was last changed (UTC). |

--- a/internal/config/readme_env_test.go
+++ b/internal/config/readme_env_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// buildTimeOnly lists environment variables that config reads but a self-hoster
+// never sets, so the README's table is not the place for them.
+var buildTimeOnly = map[string]string{
+	"BUILD_VERSION": "injected by the Docker build via -ldflags; not operator-configurable",
+}
+
+// TestReadmeDocumentsEveryEnvVar keeps CLAUDE.md's claim honest: it calls the
+// README table "the canonical, exhaustive table with all defaults", and it was
+// not — UPDATE_PROVIDER, UPDATE_REPO and UPDATE_BASE_URL configured *where* the
+// update check looks and appeared nowhere (#398), so an operator pointing an
+// instance at their own fork had to read config.go to find out how.
+//
+// A doc that is exhaustive-by-assertion stays exhaustive; one that is
+// exhaustive-by-intention drifts on the next variable added.
+func TestReadmeDocumentsEveryEnvVar(t *testing.T) {
+	src, err := os.ReadFile("config.go")
+	if err != nil {
+		t.Fatalf("reading config.go: %v", err)
+	}
+	readme, err := os.ReadFile(filepath.Join("..", "..", "README.md"))
+	if err != nil {
+		t.Fatalf("reading README.md: %v", err)
+	}
+
+	// Both spellings config.go uses to read the environment.
+	re := regexp.MustCompile(`(?:os\.Getenv|envOr|envInt|envBool)\("([A-Z][A-Z0-9_]*)"`)
+	seen := map[string]bool{}
+	for _, m := range re.FindAllStringSubmatch(string(src), -1) {
+		seen[m[1]] = true
+	}
+	if len(seen) == 0 {
+		t.Fatal("no environment variables found in config.go — this test is not reading real code")
+	}
+
+	var missing []string
+	for name := range seen {
+		if _, ok := buildTimeOnly[name]; ok {
+			continue
+		}
+		if !strings.Contains(string(readme), "`"+name+"`") {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(missing)
+	for _, name := range missing {
+		t.Errorf("%s is read by config.go but absent from README.md; add it to the env table "+
+			"(or to buildTimeOnly here, with the reason)", name)
+	}
+}

--- a/internal/openapi/markdown.go
+++ b/internal/openapi/markdown.go
@@ -256,23 +256,56 @@ func (d *Document) schemaReference() string {
 			continue
 		}
 
-		required := map[string]bool{}
-		for _, r := range s.Required {
-			required[r] = true
-		}
-
-		b.WriteString("| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n")
-		for _, field := range sortedKeys(s.Properties) {
-			p := s.Properties[field]
-			req := ""
-			if required[field] {
-				req = "yes"
-			}
-			fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n", field, typeName(p), req, p.Description)
-		}
-		b.WriteString("\n")
+		writeFieldTable(&b, s, "")
 	}
 	return b.String()
+}
+
+// writeFieldTable renders one schema's fields, then recurses into any property
+// that is an inline object with properties of its own.
+//
+// Without the recursion a nested object printed as the single word `object` and
+// its fields appeared nowhere in the document (#393). Me was the worst case: its
+// user, token, server and features objects carry most of what the endpoint
+// returns, and the Markdown said nothing about any of them. A $ref is different
+// — typeName already links to that component's own section — so only inline
+// objects are expanded here.
+//
+// prefix carries the dotted path so the sub-table has a heading a reader can
+// match to the parent row ("Me.user"), and so two schemas with a `user` object
+// do not produce two identically titled sections.
+func writeFieldTable(b *strings.Builder, s *Schema, prefix string) {
+	required := map[string]bool{}
+	for _, r := range s.Required {
+		required[r] = true
+	}
+
+	b.WriteString("| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n")
+	for _, field := range sortedKeys(s.Properties) {
+		p := s.Properties[field]
+		req := ""
+		if required[field] {
+			req = "yes"
+		}
+		fmt.Fprintf(b, "| `%s` | %s | %s | %s |\n", field, typeName(p), req, p.Description)
+	}
+	b.WriteString("\n")
+
+	for _, field := range sortedKeys(s.Properties) {
+		p := s.Properties[field]
+		if p == nil || p.Ref != "" || len(p.Properties) == 0 {
+			continue
+		}
+		path := field
+		if prefix != "" {
+			path = prefix + "." + field
+		}
+		fmt.Fprintf(b, "#### %s\n\n", path)
+		if p.Description != "" {
+			fmt.Fprintf(b, "%s\n\n", p.Description)
+		}
+		writeFieldTable(b, p, path)
+	}
 }
 
 // typeName renders a schema's type for the docs table, including references,
@@ -290,6 +323,21 @@ func typeName(s *Schema) string {
 			parts = append(parts, typeName(alt))
 		}
 		return strings.Join(parts, " or ")
+	}
+	// An enum renders as its members, not as the type they happen to share.
+	// "string" tells a reader nothing they could not have guessed; `kg` | `lb`
+	// is the entire contract of the field (#363). Checked before the type
+	// switch so it wins for every underlying type, not just string.
+	if len(s.Enum) > 0 {
+		var parts []string
+		for _, v := range s.Enum {
+			if v == nil {
+				parts = append(parts, "`null`")
+				continue
+			}
+			parts = append(parts, fmt.Sprintf("`%v`", v))
+		}
+		return strings.Join(parts, " \\| ")
 	}
 	switch t := s.Type.(type) {
 	case string:


### PR DESCRIPTION
Closes #363
Closes #393
Closes #398

Three places the generated documentation said less than the code knew.

### #363 — enums rendered as `string`

`typeName` handled `$ref`, arrays and type unions but never `enum`, so every constrained string printed as plain `` `string` ``. `Weight.unit` is not "a string" — it is `` `kg` `` or `` `lb` ``, and that *is* the field's contract. Enum members now render in the type column, checked before the type switch so it applies whatever the underlying type is.

### #393 — nested objects printed as the single word `object`

A property whose type is an inline object had its own fields emitted nowhere in the document. `Me` was the clearest case: `user`, `token`, `server` and `features` carry most of what the endpoint returns, and the Markdown said nothing about any of them.

`writeFieldTable` now recurses into inline objects and emits a sub-table headed by the dotted path (`Me.user`), so a reader can match it to the parent row and two schemas with a `user` object don't collide. `$ref`s are deliberately *not* expanded — `typeName` already links to that component's own section.

### #398 — three env vars missing from the "exhaustive" table

`CLAUDE.md` calls the README table "the canonical, exhaustive table with all defaults". `UPDATE_PROVIDER`, `UPDATE_REPO` and `UPDATE_BASE_URL` configure *where* the update check looks, and appeared nowhere — so an operator pointing an instance at their own fork had to read `config.go` to find out how.

Added, and then made durable: `TestReadmeDocumentsEveryEnvVar` extracts every variable `config.go` reads and fails if the README doesn't mention it. `BUILD_VERSION` is allowlisted with its reason (injected by the Docker build, not operator-configurable).

**Verified the guard fires** — renaming the `UPDATE_REPO` row made it fail by name, and it passed again once restored. A doc that is exhaustive-by-assertion stays exhaustive; one that is exhaustive-by-intention drifts on the next variable added.

## Verification

```
go run ./cmd/apidocs -check   # up to date
go vet ./...                  # clean
go test ./...                 # ok, 11/11 (real Postgres 18)
```
