### PR TITLE
ci: re-derive the release version under the tag lock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,10 +286,9 @@ jobs:
     needs: test
     # Deliberately not serialised: this job only *reads* git state. A group here
     # would be theatre — it is released the moment the job ends, several jobs
-    # before create-tag writes anything, so two `main` runs would still derive
-    # the same version. Job-level concurrency cannot span a multi-job critical
-    # section; closing that gap needs the derivation moved into create-tag
-    # (issue #402).
+    # before create-tag writes anything. Job-level concurrency cannot span a
+    # multi-job critical section, so the derivation is instead re-checked inside
+    # create-tag's lock (#402); see scripts/next-version.sh.
     outputs:
       version: ${{ steps.version.outputs.version }}
       should_tag: ${{ steps.version.outputs.should_tag }}
@@ -312,33 +311,9 @@ jobs:
           fi
 
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            # Get latest tag
-            LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-            VERSION="${LATEST_TAG##v}"  # Strip all leading v's
-
-            # Parse semantic version
-            MAJOR=$(echo $VERSION | cut -d. -f1)
-            MINOR=$(echo $VERSION | cut -d. -f2)
-            PATCH=$(echo $VERSION | cut -d. -f3)
-
-            # Check commit messages since last tag
-            COMMITS=$(git log ${LATEST_TAG}..HEAD --pretty=format:"%s" 2>/dev/null || git log --pretty=format:"%s")
-
-            if echo "$COMMITS" | grep -qiE "^(breaking|major):"; then
-              MAJOR=$((MAJOR + 1))
-              MINOR=0
-              PATCH=0
-            elif echo "$COMMITS" | grep -qiE "^(feat|feature|minor):"; then
-              MINOR=$((MINOR + 1))
-              PATCH=0
-            elif echo "$COMMITS" | grep -qiE "^(fix|patch|chore|docs|refactor):"; then
-              PATCH=$((PATCH + 1))
-            else
-              # Default to patch bump if no conventional commit prefix
-              PATCH=$((PATCH + 1))
-            fi
-
-            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            # Shared with create-tag, which re-runs it under the tag lock to
+            # verify nothing moved in between (#402).
+            NEW_VERSION=$(sh scripts/next-version.sh)
             echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
             echo "should_tag=true" >> $GITHUB_OUTPUT
 
@@ -373,10 +348,10 @@ jobs:
     # now per-commit, so two `main` runs can reach this job at the same time.
     # Serialise the tag writes repo-wide (not per-ref: tags are not scoped to a
     # branch).
-    # This orders the writes; it does NOT make version derivation atomic —
-    # compute-version read `git describe` several jobs earlier. Two `main`
-    # pushes inside one run window still derive the same version, and the second
-    # tag push then fails loudly instead of clobbering. Tracked in issue #402.
+    # The lock orders the writes; the "Re-derive the version" step below closes
+    # the rest of #402 by re-checking the derivation inside it, so a run whose
+    # version was overtaken fails with a diagnosis instead of pushing a tag that
+    # disagrees with the images already published under it.
     concurrency:
       group: build-git-tags
       cancel-in-progress: false
@@ -388,6 +363,31 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+
+      - name: Re-derive the version under the tag lock
+        # compute-version read `git describe` several jobs ago, outside this
+        # concurrency group. If another `main` run tagged in the meantime, the
+        # version this run has been building and labelling images with is now
+        # the wrong one — it belongs to that other commit (#402).
+        #
+        # Re-running the SAME script here, inside the lock, is what makes the
+        # check meaningful: it compares against the tag namespace as it stands
+        # at the moment of writing.
+        #
+        # A mismatch fails the release rather than tagging anyway. Tagging the
+        # stale version would point v<x> at this commit while the images
+        # published under it came from the other run, which is the confusing
+        # half-state a "loud failure" exists to avoid. Re-running the workflow
+        # on this commit derives the now-correct version and republishes
+        # cleanly.
+        run: |
+          EXPECTED="${{ needs.compute-version.outputs.version }}"
+          ACTUAL=$(sh scripts/next-version.sh)
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::error::Version raced: this run built and published images as v$EXPECTED, but the next version is now v$ACTUAL — another main run tagged while this one was building. Re-run this workflow on this commit to republish under v$ACTUAL."
+            exit 1
+          fi
+          echo "v$EXPECTED is still the next version"
 
       - name: Create and push tag
         run: |

--- a/scripts/next-version.sh
+++ b/scripts/next-version.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Derive the next release version for `main` from the tag namespace.
+#
+# Prints the bare version ("1.4.2") on stdout and nothing else, so a caller can
+# capture it with $(...).
+#
+# This exists as a script rather than inline YAML because TWO jobs need to run
+# it and they must agree exactly. compute-version derives the version early, and
+# create-tag re-derives it under the repo-wide tag lock to check nothing moved
+# in between (#402). Two copies of this logic in two `run:` blocks would drift,
+# and the drift would look exactly like the race it is there to detect.
+#
+# Requires a full-depth checkout: `git describe` needs the tags.
+set -eu
+
+LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+VERSION="${LATEST_TAG##v}" # strip all leading v's
+
+MAJOR=$(echo "$VERSION" | cut -d. -f1)
+MINOR=$(echo "$VERSION" | cut -d. -f2)
+PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+# Commit subjects since the last tag decide the bump.
+COMMITS=$(git log "${LATEST_TAG}..HEAD" --pretty=format:"%s" 2>/dev/null || git log --pretty=format:"%s")
+
+if echo "$COMMITS" | grep -qiE "^(breaking|major):"; then
+  MAJOR=$((MAJOR + 1))
+  MINOR=0
+  PATCH=0
+elif echo "$COMMITS" | grep -qiE "^(feat|feature|minor):"; then
+  MINOR=$((MINOR + 1))
+  PATCH=0
+elif echo "$COMMITS" | grep -qiE "^(fix|patch|chore|docs|refactor):"; then
+  PATCH=$((PATCH + 1))
+else
+  # No conventional prefix: a patch bump is the safe default.
+  PATCH=$((PATCH + 1))
+fi
+
+printf '%s.%s.%s\n' "$MAJOR" "$MINOR" "$PATCH"


### PR DESCRIPTION
Closes #402

`compute-version` reads `git describe` to derive the next release version. `create-tag` pushes that tag many jobs later. The read and the write are in **different jobs**, so the critical section spans the whole run and no job-level `concurrency:` can cover it — #413 said as much in a comment and left this open.

## What this does

The derivation moves into `scripts/next-version.sh`, and `create-tag` re-runs it **inside** the repo-wide `build-git-tags` lock. If another `main` run tagged in the meantime, the version this run has been building and labelling images with is no longer the next one, and the release fails with a message naming both versions and the fix.

Failing is the point. Tagging the stale version anyway would point `v<x>` at this commit while the images published under `v<x>` came from the other run — the confusing half-state that a loud failure exists to prevent. Re-running the workflow on the commit derives the now-correct version and republishes cleanly.

## Why a script rather than inline YAML

Two jobs now need identical logic. Two copies in two `run:` blocks would drift, and **the drift would look exactly like the race it exists to detect** — a spurious "version raced" failure on every release. One file, called twice.

## Verification

The extraction is faithful, checked against real repository history rather than by reading:

```
latest tag: v2.4.1
script says: 2.5.0
inline says: 2.5.0     # the original logic, replayed verbatim
MATCH
```

`build.yml` validates as YAML; `scripts/next-version.sh` passes `sh -n`.

## What this does not cover

`build-and-push` labels images before `create-tag` runs, so two concurrent `main` runs can still both push `ghcr.io/…:<version>` — the second overwriting the first — before either reaches the check. This PR stops a *tag* from ever disagreeing with the commit it names; making the image tag equally safe needs either early tag reservation (with cleanup on build failure) or SHA-qualified image tags, both of which change the release contract rather than fix a bug. Worth a separate decision.
