### PR TITLE
fix(entries): stop POST /entries discarding a weight and a body fat

### DIFF
--- a/internal/handler/entries_crud.go
+++ b/internal/handler/entries_crud.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -47,15 +48,25 @@ func (h *EntriesHandler) CreateEntry(w http.ResponseWriter, r *http.Request) {
 	// create, so the two collapse to a NULL entry_name.
 	entryName, _ := optionalEntryName(body, "entry_name")
 
-	// Parse weight (frontend may send as string or number)
+	// Parse weight (frontend may send as string or number).
+	//
+	// An unparseable weight is a 400, not a shrug (#319). This used to leave
+	// hasWeight false and carry on, so the request answered 200 having stored
+	// nothing: the user typed a weight, saw success, and it was not there.
+	// Every sibling field on this handler — calories, macros, body fat —
+	// already rejects a value it cannot parse, so silently dropping this one
+	// was also the odd case out.
 	var weightVal float64
 	hasWeight := false
 	if wv, _ := optionalString(body, "weight"); wv != nil && *wv != "" {
 		wr := service.ParseWeight(*wv)
-		if wr.Ok {
-			weightVal = wr.Value
-			hasWeight = true
+		if !wr.Ok {
+			ErrorJSON(w, http.StatusBadRequest,
+				fmt.Sprintf("Weight must be a number greater than 0 and at most %g", service.MaxWeight))
+			return
 		}
+		weightVal = wr.Value
+		hasWeight = true
 	}
 
 	bodyFat, ok := parseBodyFatUpdate(body)
@@ -102,7 +113,9 @@ func (h *EntriesHandler) CreateEntry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !amount.HasCalorieEntry && !hasMacroEntry && !hasWeight {
+	// bodyFat.Set counts as content: a body-fat-only request is a real write
+	// now that it is no longer discarded (#327).
+	if !amount.HasCalorieEntry && !hasMacroEntry && !hasWeight && !bodyFat.Set {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid entry data")
 		return
 	}
@@ -139,10 +152,34 @@ func (h *EntriesHandler) CreateEntry(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if hasWeight {
+	// A body fat with no weight is still a reading worth keeping (#327).
+	//
+	// This used to write only when hasWeight, so
+	// POST /entries {"body_fat": "24.3"} answered 200 having stored nothing —
+	// while an out-of-range body fat got a 400 from parseBodyFatUpdate above.
+	// A validation error for a bad value and a silent success for a good one
+	// is the worst pairing available.
+	//
+	// UpsertWeightEntryPartial is exactly the shape for this: KeepWeight
+	// applies the body fat to an existing row for that date and reports
+	// ErrNoWeightEntry when there is none, rather than inventing a weight to
+	// hang the reading on. That mirrors what the weight endpoint already
+	// answers for the same request.
+	switch {
+	case hasWeight:
 		_, err := service.UpsertWeightEntry(r.Context(), tx, user.ID, entryDate, weightVal, bodyFat)
 		if err != nil {
 			ErrorJSON(w, http.StatusInternalServerError, "Failed to save weight")
+			return
+		}
+	case bodyFat.Set:
+		_, err := service.UpsertWeightEntryPartial(r.Context(), tx, user.ID, entryDate, service.KeepWeight, bodyFat)
+		if errors.Is(err, service.ErrNoWeightEntry) {
+			ErrorJSON(w, http.StatusBadRequest, "Log a weight for that date first")
+			return
+		}
+		if err != nil {
+			ErrorJSON(w, http.StatusInternalServerError, "Failed to save body fat")
 			return
 		}
 	}

--- a/internal/handler/entries_weight_bodyfat_integration_test.go
+++ b/internal/handler/entries_weight_bodyfat_integration_test.go
@@ -1,0 +1,128 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"schautrack/internal/middleware"
+	"schautrack/internal/model"
+	"schautrack/internal/sse"
+)
+
+// postEntry drives the real POST /entries handler for the seeded user and
+// returns the recorder. Uses the same pool the v1 harness builds, which is
+// database.NewPool — so the DATE codec production installs is present.
+func postEntry(t *testing.T, e *v1Env, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	h := &EntriesHandler{Pool: e.Pool, Broker: sse.NewBroker(e.Pool)}
+
+	req := httptest.NewRequest(http.MethodPost, "/entries", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(middleware.WithTestUser(req.Context(),
+		&model.User{ID: e.UserID, Email: e.Email}))
+
+	rec := httptest.NewRecorder()
+	h.CreateEntry(rec, req)
+	return rec
+}
+
+func weightRow(t *testing.T, e *v1Env, date string) (weight *float64, bodyFat *float64, found bool) {
+	t.Helper()
+	err := e.Pool.QueryRow(e.Ctx,
+		`SELECT weight, body_fat FROM weight_entries WHERE user_id = $1 AND entry_date = $2`,
+		e.UserID, date).Scan(&weight, &bodyFat)
+	if err != nil {
+		return nil, nil, false
+	}
+	return weight, bodyFat, true
+}
+
+// TestCreateEntryRejectsAnUnparseableWeight pins #319. The weight used to be
+// dropped when it did not parse, leaving hasWeight false, so the request
+// answered 200 having stored nothing — the user typed a weight, saw success,
+// and it was not there. Every sibling field on this handler already rejects
+// what it cannot parse.
+func TestCreateEntryRejectsAnUnparseableWeight(t *testing.T) {
+	e := newV1Env(t)
+
+	for _, w := range []string{"abc", "-5", "0", "99999"} {
+		rec := postEntry(t, e, `{"entry_date":"2026-08-05","weight":"`+w+`"}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("weight %q: status = %d, want 400 (body: %s)", w, rec.Code, rec.Body.String())
+		}
+		if _, _, found := weightRow(t, e, "2026-08-05"); found {
+			t.Errorf("weight %q: a row was written for a rejected weight", w)
+		}
+	}
+
+	// A parseable weight still works, so the rejection is not over-broad.
+	rec := postEntry(t, e, `{"entry_date":"2026-08-05","weight":"82.4"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("valid weight: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	w, _, found := weightRow(t, e, "2026-08-05")
+	if !found || w == nil || *w != 82.4 {
+		t.Errorf("stored weight = %v (found=%v), want 82.4", w, found)
+	}
+}
+
+// TestCreateEntryStoresABodyFatWithoutAWeight pins #327. body_fat was parsed
+// and range-checked — an out-of-range value got a 400 — but only written when a
+// weight came along in the same request. So a GOOD body fat returned 200 and
+// was thrown away while a BAD one was rejected: a validation error for the
+// wrong value and a silent success for the right one.
+func TestCreateEntryStoresABodyFatWithoutAWeight(t *testing.T) {
+	e := newV1Env(t)
+	const date = "2026-08-06"
+
+	// With no weight logged for the date there is nothing to attach the
+	// reading to, and inventing a weight would be worse than refusing.
+	rec := postEntry(t, e, `{"entry_date":"`+date+`","body_fat":"24.3"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("body fat with no weight row: status = %d, want 400 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	// Log a weight, then send body fat alone: it must land.
+	if rec := postEntry(t, e, `{"entry_date":"`+date+`","weight":"80"}`); rec.Code != http.StatusOK {
+		t.Fatalf("seeding the weight: status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	rec = postEntry(t, e, `{"entry_date":"`+date+`","body_fat":"24.3"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("body fat alone: status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	w, bf, found := weightRow(t, e, date)
+	if !found {
+		t.Fatal("no weight row after a body-fat-only save")
+	}
+	if bf == nil || *bf != 24.3 {
+		t.Errorf("stored body_fat = %v, want 24.3 — the reading was discarded", bf)
+	}
+	if w == nil || *w != 80 {
+		t.Errorf("stored weight = %v, want 80 — a body-fat-only save must not disturb it", w)
+	}
+
+	// And an out-of-range value is still a 400, so the fix did not widen what
+	// is accepted.
+	if rec := postEntry(t, e, `{"entry_date":"`+date+`","body_fat":"99"}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("out-of-range body fat: status = %d, want 400", rec.Code)
+	}
+}
+
+// TestCreateEntryStillRejectsAnEmptyRequest checks the "Invalid entry data"
+// guard did not get lost when bodyFat.Set joined the content test.
+func TestCreateEntryStillRejectsAnEmptyRequest(t *testing.T) {
+	e := newV1Env(t)
+	rec := postEntry(t, e, `{"entry_date":"2026-08-07"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("empty entry: status = %d, want 400 (body: %s)", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["error"] != "Invalid entry data" {
+		t.Errorf("error = %v, want \"Invalid entry data\"", body["error"])
+	}
+}


### PR DESCRIPTION
Closes #319
Closes #327

Two ways `POST /entries` accepted data and threw it away, both answering `200`.

### #319 — an unparseable weight was dropped

```go
wr := service.ParseWeight(*wv)
if wr.Ok { weightVal = wr.Value; hasWeight = true }
// no else — silently dropped
```

The request succeeded and the weight was never written. The user typed a weight, saw success, and it was not there. Calories, macros and body fat on this same handler all already reject what they cannot parse — this was the odd one out. Now a 400 naming the accepted range.

### #327 — a valid body fat was discarded when no weight came with it

`body_fat` was parsed *and range-checked* — an out-of-range value got a 400 — but only written under `if hasWeight`. So `POST /entries {"body_fat":"24.3"}` returned `200 {"ok":true}` having stored nothing.

A validation error for a **bad** value and a silent success for a **good** one is the worst available pairing: it teaches the caller the field is being processed.

Now routed through `UpsertWeightEntryPartial` with `KeepWeight`, which applies the reading to an existing row and reports `ErrNoWeightEntry` when there is none — rather than inventing a weight to hang it on. That matches what the weight endpoint already answers for the same request. `bodyFat.Set` also joins the "is there any content?" test, so a body-fat-only request is no longer rejected as `Invalid entry data`.

## Verification

DB-backed tests that assert the row, not just the status — the whole failure mode here was a 200 with nothing written, which a status-only test would have passed:

```
--- PASS: TestCreateEntryRejectsAnUnparseableWeight
--- PASS: TestCreateEntryStoresABodyFatWithoutAWeight
--- PASS: TestCreateEntryStillRejectsAnEmptyRequest
```

They also pin the boundaries the fixes must not widen: a valid weight still stores, an out-of-range body fat is still a 400, a body-fat-only save leaves the weight untouched, and an empty request still gets `Invalid entry data`.

```
go vet ./...   # clean
go test ./...  # ok, 11/11 (real Postgres 18)
```

I grepped the suite for assertions pinning the old behaviour before writing the fix — nine such tests have turned up elsewhere in this repo today. None here.
