### PR TITLE
fix(admin): validate the RP ID, passkey origins and SMTP host; cover legacy bcrypt

### DIFF
--- a/internal/handler/admin_settings.go
+++ b/internal/handler/admin_settings.go
@@ -2,8 +2,10 @@ package handler
 
 import (
 	"fmt"
+	"net"
 	"net/mail"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -91,7 +93,8 @@ var adminSettings = []AdminSetting{
 	{Key: "passkeys_rp_name", Env: "PASSKEYS_RP_NAME", Section: "passkeys", Tier: "restart",
 		Help: "Display name shown in passkey prompts (default: Schautrack)."},
 	{Key: "passkeys_rp_origins", Env: "PASSKEYS_RP_ORIGINS", Section: "passkeys", Tier: "restart", Dangerous: true,
-		Help: "Allowed origins, comma-separated full URLs with scheme. Defaults to https://<rp_id>."},
+		Help:     "Allowed origins, comma-separated full URLs with scheme. Defaults to https://<rp_id>.",
+		Validate: validOriginList},
 
 	// =========================================================================
 	// Features
@@ -110,7 +113,8 @@ var adminSettings = []AdminSetting{
 	// SMTP
 	// =========================================================================
 	{Key: "smtp_host", Env: "SMTP_HOST", Section: "smtp", Tier: "restart",
-		Help: "SMTP server hostname."},
+		Help:     "SMTP server hostname.",
+		Validate: validHostPort},
 	{Key: "smtp_port", Env: "SMTP_PORT", Section: "smtp", Tier: "restart",
 		Help:     "SMTP server port (default: 587).",
 		Validate: validPort},
@@ -296,14 +300,100 @@ func validDuration(v string) error {
 
 // validRPID rejects values that contain a scheme, port, or path — the WebAuthn
 // RP ID is just the hostname.
+// hostnameRe matches a DNS hostname by RFC 1123 label rules: each label is
+// 1-63 chars of letters, digits and hyphens, not starting or ending with a
+// hyphen. A single label ("localhost") is allowed — self-hosted deployments
+// use one — and so is a trailing dot on a fully-qualified name.
+//
+// Underscores are deliberately excluded. They are legal in some DNS records
+// but not in hostnames, and WebAuthn compares the RP ID against the browser's
+// origin host, which will never contain one.
+var hostnameRe = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.?$`)
+
+// validRPID requires a bare hostname.
+//
+// This was a three-character blocklist — it rejected only "://", "/" and ":"
+// — so "not a hostname", "exam_ple.com" and "example.com " (trailing space)
+// were all accepted (#348). Getting the RP ID wrong breaks passkey login for
+// every user at once, and it is a restart-tier setting, so the failure appears
+// at the next boot rather than at the write that caused it. An allow-list is
+// the only shape that can catch a value that is merely not a hostname.
+//
+// The blocklist's own cases still fail, now as a consequence of the grammar
+// rather than as three special cases: a scheme, a port or a path all introduce
+// characters no label may contain.
 func validRPID(v string) error {
 	if v == "" {
 		return nil
 	}
-	if strings.Contains(v, "://") || strings.Contains(v, "/") || strings.Contains(v, ":") {
-		return fmt.Errorf("must be a hostname only (no scheme, port, or path)")
+	if len(v) > 253 {
+		return fmt.Errorf("must be at most 253 characters")
+	}
+	if !hostnameRe.MatchString(v) {
+		return fmt.Errorf("must be a bare hostname (no scheme, port, path, spaces, or underscores)")
 	}
 	return nil
+}
+
+// validOriginList validates passkeys_rp_origins: a comma-separated list of
+// full origins.
+//
+// It had no validator at all (#350). WebAuthn compares the browser's origin
+// against this list byte-for-byte, so a missing scheme or a trailing slash
+// does not "mostly work" — it silently matches nothing and every passkey login
+// fails. Restart-tier and Dangerous, so the damage lands at the next boot,
+// far from the admin who typed it.
+func validOriginList(v string) error {
+	if v == "" {
+		return nil
+	}
+	for _, raw := range strings.Split(v, ",") {
+		o := strings.TrimSpace(raw)
+		if o == "" {
+			return fmt.Errorf("contains an empty entry — check for a stray comma")
+		}
+		u, err := url.Parse(o)
+		if err != nil || u.Host == "" {
+			return fmt.Errorf("%q must be a full origin, e.g. https://app.example.com", o)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return fmt.Errorf("%q must use http:// or https://", o)
+		}
+		// An origin is scheme + host [+ port] and nothing else. A path — even
+		// a bare "/" — makes the string unequal to what a browser sends.
+		if u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+			return fmt.Errorf("%q must be an origin only: no path, query, or fragment (drop the trailing slash)", o)
+		}
+	}
+	return nil
+}
+
+// validHostPort accepts a bare hostname, optionally with a port, for
+// smtp_host. It had no validator either (#350); a bad value surfaces as a
+// failed send long after the setting was saved.
+//
+// A port is tolerated here rather than rejected: smtp_port exists, but
+// "smtp.example.com:587" is what people paste, and splitting it is friendlier
+// than refusing it outright would be. IPv6 literals must be bracketed, which
+// is what net.SplitHostPort expects anyway.
+func validHostPort(v string) error {
+	if v == "" {
+		return nil
+	}
+	host := v
+	if h, _, err := net.SplitHostPort(v); err == nil {
+		host = h
+	}
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		if ip := net.ParseIP(host[1 : len(host)-1]); ip != nil {
+			return nil
+		}
+		return fmt.Errorf("%q is not a valid IPv6 literal", host)
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return nil
+	}
+	return validRPID(host)
 }
 
 func oneOf(allowed ...string) func(string) error {

--- a/internal/handler/admin_settings_test.go
+++ b/internal/handler/admin_settings_test.go
@@ -211,14 +211,17 @@ func TestValidRPID(t *testing.T) {
 		{in: "[::1]", ok: false, note: "bracketed IPv6 literal — also contains ':'"},
 		{in: "//example.com", ok: false, note: "contains '/'"},
 
-		// Known gap: the validator is a three-character blocklist, so anything
-		// without :// , / or : passes — including values that are not valid
-		// hostnames at all. Getting the RP ID wrong breaks passkey login for
-		// every user at once, with no error at write time. Pinned here so the
-		// gap is visible; tracked separately rather than widened under #309.
-		{in: "example.com ", ok: true, note: "KNOWN GAP: trailing whitespace accepted"},
-		{in: "not a hostname", ok: true, note: "KNOWN GAP: spaces accepted"},
-		{in: "exam_ple.com", ok: true, note: "KNOWN GAP: underscore accepted"},
+		// #348 replaced the three-character blocklist with a hostname grammar,
+		// so a value that is merely not a hostname is now caught at write time
+		// rather than breaking passkey login for everyone at the next restart.
+		{in: "example.com ", ok: false, note: "trailing whitespace is not part of a hostname"},
+		{in: "not a hostname", ok: false, note: "spaces are not legal in a label"},
+		{in: "exam_ple.com", ok: false, note: "underscores are legal in some DNS records but not in hostnames, and never in a browser origin"},
+		{in: "localhost", ok: true, note: "a single label is valid — self-hosted deployments use one"},
+		{in: "app.example.com", ok: true, note: "the ordinary case"},
+		{in: "example.com.", ok: true, note: "a fully-qualified name keeps its trailing dot"},
+		{in: "-bad.example.com", ok: false, note: "a label may not start with a hyphen"},
+		{in: "bad-.example.com", ok: false, note: "nor end with one"},
 	})
 }
 

--- a/internal/handler/auth_bcrypt_legacy_test.go
+++ b/internal/handler/auth_bcrypt_legacy_test.go
@@ -1,0 +1,112 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Legacy bcrypt hashes are still accepted by verifyPassword and were covered by
+// nothing (#371): a grep for `$2[aby]$` across internal/ found no test at all.
+//
+// That branch is load-bearing in two directions. Accounts created before the
+// argon2id switch still authenticate through it, and the E2E suite seeds users
+// by writing bcrypt hashes directly — since #323 those come from bcryptjs, so
+// "does the app accept what bcryptjs produces?" had no answer in Go.
+//
+// Costs are deliberately kept at bcrypt.MinCost: these assert routing and
+// acceptance, not work factor, and a default-cost hash per case would make the
+// package noticeably slower for nothing.
+
+func bcryptHashAtCost(t *testing.T, password string, cost int) string {
+	t.Helper()
+	h, err := bcrypt.GenerateFromPassword([]byte(password), cost)
+	if err != nil {
+		t.Fatalf("generating a bcrypt hash: %v", err)
+	}
+	return string(h)
+}
+
+func TestVerifyPasswordAcceptsLegacyBcrypt(t *testing.T) {
+	const password = "correct horse battery staple"
+	hash := bcryptHashAtCost(t, password, bcrypt.MinCost)
+
+	if !strings.HasPrefix(hash, "$2a$") && !strings.HasPrefix(hash, "$2b$") {
+		t.Fatalf("hash %.4q has neither prefix verifyPassword routes on", hash)
+	}
+
+	ok, err := verifyPassword(hash, password)
+	if err != nil {
+		t.Fatalf("verifyPassword returned an error: %v", err)
+	}
+	if !ok {
+		t.Error("a correct password did not verify against its bcrypt hash")
+	}
+
+	if ok, _ := verifyPassword(hash, password+"x"); ok {
+		t.Error("a wrong password verified against a bcrypt hash")
+	}
+}
+
+// TestVerifyPasswordAcceptsBcryptjsHashes uses hashes produced by the bcryptjs
+// the E2E seeds now use (#323), pasted as literals so this does not depend on
+// Node being installed. bcryptjs emits $2b$, which golang.org/x/crypto/bcrypt
+// accepts; if that ever stopped being true the suite would fail at "Setup
+// failed" with no explanation, long before any spec ran.
+func TestVerifyPasswordAcceptsBcryptjsHashes(t *testing.T) {
+	// Generated with the repo's own bcryptjs and verified by it before being
+	// pasted here:
+	//
+	//	node -e 'const b=require("bcryptjs");const h=b.hashSync("test1234test",10);
+	//	         console.log(h, b.compareSync("test1234test", h))'
+	//
+	// "test1234test" is the password e2e/setup-test-user.ts seeds, so this is
+	// the exact byte sequence the suite writes into users.password_hash.
+	cases := []struct{ password, hash string }{
+		{"test1234test", "$2b$10$.UMNLvyRn.SDYPy2FnxITundj6wLEYzWsigw7mx/Jfa/9zcFXbFU6"},
+		{"link-test-pw", "$2b$10$K4V09fZ3YXfQC1OMLwmApOWRD2RiW0zTg/pfZl3538q9kU/mCCH3a"},
+	}
+	for _, c := range cases {
+		ok, err := verifyPassword(c.hash, c.password)
+		if err != nil {
+			t.Fatalf("verifyPassword(%.7q…): %v", c.hash, err)
+		}
+		if !ok {
+			t.Errorf("a bcryptjs $2b$ hash was rejected — the E2E seeds would fail before any spec ran")
+		}
+	}
+}
+
+// TestVerifyPasswordRoutesOnThePrefix pins the branch itself: an argon2id hash
+// must not be handed to bcrypt and vice versa. The two formats are
+// distinguishable only by prefix, and getting the routing wrong fails closed
+// (every login rejected) rather than open — but silently, and for everyone.
+func TestVerifyPasswordRoutesOnThePrefix(t *testing.T) {
+	const password = "another password entirely"
+
+	argonHash, err := hashPassword(password)
+	if err != nil {
+		t.Fatalf("hashPassword: %v", err)
+	}
+	if !strings.HasPrefix(argonHash, "$argon2id$") {
+		t.Fatalf("hashPassword produced %.10q, want an $argon2id$ hash", argonHash)
+	}
+	if ok, err := verifyPassword(argonHash, password); err != nil || !ok {
+		t.Errorf("argon2id hash did not verify (ok=%v, err=%v)", ok, err)
+	}
+
+	// A bcrypt hash must not verify a password it does not match, even though
+	// both formats start with "$".
+	bcryptHash := bcryptHashAtCost(t, password, bcrypt.MinCost)
+	if ok, _ := verifyPassword(bcryptHash, "wrong"); ok {
+		t.Error("bcrypt branch accepted a wrong password")
+	}
+
+	// An unrecognised format falls through to the argon2id comparison, which
+	// errors rather than accepting. Asserting it never returns true is the
+	// property that matters.
+	if ok, _ := verifyPassword("$2y$10$notarealhashvalue", password); ok {
+		t.Error("an unsupported hash format verified")
+	}
+}


### PR DESCRIPTION
Closes #348
Closes #350
Closes #371

Three admin settings that could be saved wrong and only fail later, plus the untested half of `verifyPassword`.

### #348 — `validRPID` was a three-character blocklist

It rejected only `://`, `/` and `:`, so `not a hostname`, `exam_ple.com` and `example.com ` (trailing space) all passed. Getting the RP ID wrong breaks passkey login **for every user at once**, and it is restart-tier — so the damage lands at the next boot, far from the admin who typed it. A blocklist cannot catch a value that is merely not a hostname; this is now an RFC 1123 grammar.

Underscores are deliberately excluded: legal in some DNS records, never in a hostname, and never in the browser origin WebAuthn compares against. `localhost` and a trailing dot both stay valid — self-hosted deployments use the former.

The blocklist's own cases still fail, now as a consequence of the grammar rather than three special cases.

### #350 — two settings had no validator at all

**`passkeys_rp_origins`** (restart-tier, `Dangerous`): WebAuthn compares the browser's origin against this list byte-for-byte, so a missing scheme or a **trailing slash** doesn't "mostly work" — it matches nothing and every passkey login fails. Now requires each comma-separated entry to be a full `http(s)` origin with no path, query or fragment.

**`smtp_host`**: a bad value surfaces as a failed send long after the save. Now validated as a hostname, optionally with a port — `smtp.example.com:587` is tolerated rather than refused, because it's what people paste, and `smtp_port` existing doesn't make that a mistake worth blocking.

### #371 — the legacy bcrypt branch had no test

`grep -rn '\$2[aby]\$' internal/ --include=*_test.go` found nothing. That branch is load-bearing twice over: pre-argon2id accounts authenticate through it, and the E2E suite seeds users by writing bcrypt hashes directly — since #323 from `bcryptjs`, so *"does Go accept what bcryptjs produces?"* had no answer.

Now covered: a Go-generated hash, **real bcryptjs-generated hashes** for the passwords the E2E seeds use, and the prefix routing itself.

> The first version of that test used a bcrypt "test vector" I wrote from memory. It was the hash for a different password, and the test failed — correctly. The literals are now generated by the repo's own `bcryptjs` and verified by `bcrypt.compareSync` before being pasted, with the command recorded in the comment.

### Three `KNOWN GAP` assertions flipped

`TestValidRPID` pinned the three accepted-but-wrong values as `ok: true` with a note explaining the gap. Those are now `ok: false`, plus cases for the boundaries the grammar introduces (leading/trailing hyphen, single label, trailing dot).

## Verification

```
go vet ./...   # clean
go test ./...  # ok, 11/11 (real Postgres 18)
```
