### PR TITLE
feat(v1): idempotent AI estimate, server feature flags on /me, rate_per_week

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -67,9 +67,19 @@
       "post": {
         "operationId": "estimateFromPhoto",
         "summary": "Estimate nutrition from a food photo",
-        "description": "Requires the `ai:estimate` scope, which no other scope implies — every call spends the operator's AI budget, so it must be granted deliberately. The account's daily AI limit applies here exactly as it does in the app, as does a per-account rate limit matching the app's own estimate endpoint — this is not a cheaper path to the provider. Returns 404 when no AI provider is configured. This is the one `POST` that does not honour `Idempotency-Key`: sending the header returns 400 rather than being ignored, so a caller is never left believing a retry is safe when it is not.",
+        "description": "Requires the `ai:estimate` scope, which no other scope implies — every call spends the operator's AI budget, so it must be granted deliberately. The account's daily AI limit applies here exactly as it does in the app, as does a per-account rate limit matching the app's own estimate endpoint — this is not a cheaper path to the provider. Returns 404 when no AI provider is configured; `GET /me` reports whether it is, under `server.features.ai_estimate`. Honours `Idempotency-Key`, and this is the endpoint it matters most on: a retried estimate would spend the AI budget twice and burn a second slot in the account's daily cap, for a photo already analysed.",
         "tags": [
           "AI"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Optional. A key you generate once per logical operation and reuse when retrying. The first request executes and its response is stored; a retry with the same key replays that response instead of creating a second record, and carries `Idempotency-Replayed: true`. Reusing a key for a different request body is rejected with 409. Keys are remembered for 24 hours.",
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "requestBody": {
           "required": true,
@@ -88,6 +98,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Estimate"
+                }
+              }
+            },
+            "headers": {
+              "Idempotency-Replayed": {
+                "description": "Present and `true` only on a replayed response — the request matched a stored Idempotency-Key and nothing new was created. Absent on the first request. This is the only way to distinguish a replay from a fresh create, since a replay repeats the original status code.",
+                "schema": {
+                  "type": "boolean"
                 }
               }
             }
@@ -4044,6 +4062,24 @@
             "type": "object",
             "description": "The server answering.",
             "properties": {
+              "features": {
+                "type": "object",
+                "description": "Which OPTIONAL endpoints this deployment actually serves. Separate from the account-level `features` below on purpose: this is how the operator configured the instance, that is what the user switched on, and a client needs to tell \"you turned this off\" apart from \"this server does not offer it\". Both fields are always present.",
+                "properties": {
+                  "ai_estimate": {
+                    "type": "boolean",
+                    "description": "An AI provider is configured, so `POST /ai/estimate` is live. The account's daily cap still applies on top."
+                  },
+                  "barcode": {
+                    "type": "boolean",
+                    "description": "`GET /barcode/{code}` will attempt a lookup. When `false` it answers 404 `feature-disabled`."
+                  }
+                },
+                "required": [
+                  "barcode",
+                  "ai_estimate"
+                ]
+              },
               "today": {
                 "type": "string",
                 "format": "date",
@@ -4058,7 +4094,8 @@
             },
             "required": [
               "version",
-              "today"
+              "today",
+              "features"
             ]
           },
           "token": {
@@ -5169,9 +5206,9 @@
               "date"
             ]
           },
-          "rate_kg_per_week": {
+          "rate_per_week": {
             "type": "number",
-            "description": "The requested pace per week. Present when `pace_mode` is `rate`. In the unit given by the plan's `unit` field. **Not necessarily kilograms, despite the name** — the name is the `weight_goals.rate_kg_per_week` column's, and the goal is stored and echoed in the account's own unit. Unlike the plan's other weight fields it was not renamed, because the same key is the request body of the app's `PUT /plan/goal`; see schaurian/schautrack#396."
+            "description": "The requested pace per week. Present when `pace_mode` is `rate`. In the unit given by the plan's `unit` field. Renamed from `rate_kg_per_week`, which was not necessarily kilograms: the goal is stored and echoed in the account's own unit. `PUT /plan/goal` still accepts the old key on input so existing clients keep working."
           },
           "start_date": {
             "type": "string",

--- a/client/src/api/plan.ts
+++ b/client/src/api/plan.ts
@@ -21,7 +21,7 @@ export function clearMetrics() {
 export function upsertGoal(g: {
   target_weight: number;
   pace_mode: 'rate' | 'date';
-  rate_kg_per_week?: number;
+  rate_per_week?: number;
   target_date?: string;
 }) {
   return api<{ ok: boolean; goal: WeightGoal }>('/api/plan/goal', {

--- a/client/src/pages/Plan/GoalForm.tsx
+++ b/client/src/pages/Plan/GoalForm.tsx
@@ -23,7 +23,7 @@ export default function GoalForm({ goal, computed, warnings, weightUnit, metrics
   const queryClient = useQueryClient();
   const [targetWeight, setTargetWeight] = useState(goal ? String(goal.target_weight) : '');
   const [paceMode, setPaceMode] = useState<'rate' | 'date'>(goal?.pace_mode || 'rate');
-  const [rate, setRate] = useState(goal?.rate_kg_per_week != null ? String(goal.rate_kg_per_week) : '');
+  const [rate, setRate] = useState(goal?.rate_per_week != null ? String(goal.rate_per_week) : '');
   const [targetDate, setTargetDate] = useState(goal?.target_date || '');
 
   // Autosaves like every other form. A goal is only writable once it has a
@@ -40,7 +40,7 @@ export default function GoalForm({ goal, computed, warnings, weightUnit, metrics
       target_weight: parseFloat(d.targetWeight),
       pace_mode: d.paceMode,
       ...(d.paceMode === 'rate'
-        ? { rate_kg_per_week: parseFloat(d.rate) }
+        ? { rate_per_week: parseFloat(d.rate) }
         : { target_date: d.targetDate }),
     });
     queryClient.invalidateQueries({ queryKey: ['plan'] });

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -219,7 +219,7 @@ export interface WeightGoal {
   start_date: string;
   target_weight: number;
   pace_mode: 'rate' | 'date';
-  rate_kg_per_week: number | null;
+  rate_per_week: number | null;
   target_date: string | null;
   activity_level: string | null;
   status: 'active' | 'achieved' | 'abandoned';

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -888,7 +888,11 @@ POST /api/v1/ai/estimate
 
 **Scope:** `ai:estimate`
 
-Requires the `ai:estimate` scope, which no other scope implies — every call spends the operator's AI budget, so it must be granted deliberately. The account's daily AI limit applies here exactly as it does in the app, as does a per-account rate limit matching the app's own estimate endpoint — this is not a cheaper path to the provider. Returns 404 when no AI provider is configured. This is the one `POST` that does not honour `Idempotency-Key`: sending the header returns 400 rather than being ignored, so a caller is never left believing a retry is safe when it is not.
+Requires the `ai:estimate` scope, which no other scope implies — every call spends the operator's AI budget, so it must be granted deliberately. The account's daily AI limit applies here exactly as it does in the app, as does a per-account rate limit matching the app's own estimate endpoint — this is not a cheaper path to the provider. Returns 404 when no AI provider is configured; `GET /me` reports whether it is, under `server.features.ai_estimate`. Honours `Idempotency-Key`, and this is the endpoint it matters most on: a retried estimate would spend the AI budget twice and burn a second slot in the account's daily cap, for a photo already analysed.
+
+| Parameter | In | Required | Description |
+| --- | --- | --- | --- |
+| `Idempotency-Key` | header |  | Optional. A key you generate once per logical operation and reuse when retrying. The first request executes and its response is stored; a retry with the same key replays that response instead of creating a second record, and carries `Idempotency-Replayed: true`. Reusing a key for a different request body is rejected with 409. Keys are remembered for 24 hours. |
 
 **Request body** (required): [`EstimateInput`](#estimateinput)
 
@@ -1132,8 +1136,18 @@ The server answering.
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
+| `features` | `object` | yes | Which OPTIONAL endpoints this deployment actually serves. Separate from the account-level `features` below on purpose: this is how the operator configured the instance, that is what the user switched on, and a client needs to tell "you turned this off" apart from "this server does not offer it". Both fields are always present. |
 | `today` | `string` (date) | yes | Today's date in the account's time zone. |
 | `version` | `string` | yes | The running build version. |
+
+#### server.features
+
+Which OPTIONAL endpoints this deployment actually serves. Separate from the account-level `features` below on purpose: this is how the operator configured the instance, that is what the user switched on, and a client needs to tell "you turned this off" apart from "this server does not offer it". Both fields are always present.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `ai_estimate` | `boolean` | yes | An AI provider is configured, so `POST /ai/estimate` is live. The account's daily cap still applies on top. |
+| `barcode` | `boolean` | yes | `GET /barcode/{code}` will attempt a lookup. When `false` it answers 404 `feature-disabled`. |
 
 #### token
 
@@ -1441,7 +1455,7 @@ The active weight goal, echoed in the account's unit. Read-only here: setting a 
 | `created_at` | `string` (date-time) | yes | When the goal was created (UTC). |
 | `id` | `integer` | yes | Goal identifier. |
 | `pace_mode` | `rate` \| `date` | yes | `rate` sets a weekly pace directly; `date` derives one from `target_date`. |
-| `rate_kg_per_week` | `number` |  | The requested pace per week. Present when `pace_mode` is `rate`. In the unit given by the plan's `unit` field. **Not necessarily kilograms, despite the name** — the name is the `weight_goals.rate_kg_per_week` column's, and the goal is stored and echoed in the account's own unit. Unlike the plan's other weight fields it was not renamed, because the same key is the request body of the app's `PUT /plan/goal`; see schaurian/schautrack#396. |
+| `rate_per_week` | `number` |  | The requested pace per week. Present when `pace_mode` is `rate`. In the unit given by the plan's `unit` field. Renamed from `rate_kg_per_week`, which was not necessarily kilograms: the goal is stored and echoed in the account's own unit. `PUT /plan/goal` still accepts the old key on input so existing clients keep working. |
 | `start_date` | `string` (date) | yes | The day the goal was set. |
 | `start_weight` | `number` | yes | Weight when the goal was set. In the unit given by the plan's `unit` field. |
 | `status` | `active` \| `achieved` \| `abandoned` | yes | `active`, `achieved` or `abandoned` — always `active` here, since this endpoint only returns the active goal. |

--- a/internal/handler/plan.go
+++ b/internal/handler/plan.go
@@ -271,14 +271,24 @@ func (h *PlanHandler) ClearMetrics(w http.ResponseWriter, r *http.Request) {
 // UpsertGoal handles PUT /plan/goal
 func (h *PlanHandler) UpsertGoal(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		TargetWeight  float64  `json:"target_weight"`
-		PaceMode      string   `json:"pace_mode"`
-		RateKgPerWeek *float64 `json:"rate_kg_per_week"`
-		TargetDate    *string  `json:"target_date"`
+		TargetWeight float64  `json:"target_weight"`
+		PaceMode     string   `json:"pace_mode"`
+		RatePerWeek  *float64 `json:"rate_per_week"`
+		TargetDate   *string  `json:"target_date"`
+
+		// LegacyRateKgPerWeek accepts the pre-#396 spelling. The response
+		// renamed to rate_per_week because the value is in the account's unit,
+		// but this is a REQUEST field too — refusing the old name would break
+		// any client written against the previous shape for no benefit, and
+		// the two cannot disagree because only one is ever read.
+		LegacyRateKgPerWeek *float64 `json:"rate_kg_per_week"`
 	}
 	if err := ReadJSON(r, &body); err != nil {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid request.")
 		return
+	}
+	if body.RatePerWeek == nil {
+		body.RatePerWeek = body.LegacyRateKgPerWeek
 	}
 
 	now := time.Now()
@@ -287,7 +297,7 @@ func (h *PlanHandler) UpsertGoal(w http.ResponseWriter, r *http.Request) {
 	startDate := service.FormatDateInTz(now, tz)
 
 	if !validateTargetWeight(body.TargetWeight) || !validatePaceMode(body.PaceMode) ||
-		!validateRateKgPerWeek(body.PaceMode, body.RateKgPerWeek) ||
+		!validateRateKgPerWeek(body.PaceMode, body.RatePerWeek) ||
 		!validateTargetDate(body.PaceMode, body.TargetDate, startDate) {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid goal.")
 		return
@@ -309,7 +319,7 @@ func (h *PlanHandler) UpsertGoal(w http.ResponseWriter, r *http.Request) {
 		StartDate:     startDate,
 		TargetWeight:  body.TargetWeight,
 		PaceMode:      body.PaceMode,
-		RateKgPerWeek: body.RateKgPerWeek,
+		RateKgPerWeek: body.RatePerWeek,
 		TargetDate:    body.TargetDate,
 		ActivityLevel: user.ActivityLevel,
 	}

--- a/internal/handler/v1_capabilities.go
+++ b/internal/handler/v1_capabilities.go
@@ -330,6 +330,13 @@ func (h *V1Handler) buildMe(r *http.Request, user *model.User) v1Me {
 	// second interpretation here would eventually disagree with the 422 that
 	// UpdateEntryV1 returns, which is exactly the confusion #344 is about.
 	mu := service.ParseMacroUser(user.MacrosEnabled, user.MacroGoals, user.DailyGoal, user.GoalThreshold)
+	// Mirrors the nil checks BarcodeV1 and EstimateV1 make before answering
+	// feature-disabled, so /me and the endpoints cannot disagree.
+	out.Server.Features = v1ServerFeatures{
+		Barcode:    h.Barcode != nil,
+		AIEstimate: h.AIEstimate != nil,
+	}
+
 	out.Features = v1Features{
 		BodyFat:          user.BodyFatEnabled,
 		Todos:            user.TodosEnabled,

--- a/internal/handler/v1_idempotency_test.go
+++ b/internal/handler/v1_idempotency_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -27,12 +28,12 @@ import (
 // accepts the header and ignores it, and because an unknown header — unlike an
 // unknown body field — is rejected nowhere, the caller reads the 201 as
 // retry-safety it does not have.
-var idempotencyRejectingPosts = map[string]bool{
-	// Not a create, and not replayable today: the estimate is billed per call
-	// and produced by the app's own handler. Honouring the header here is a
-	// feature, not a bug fix; until then it says so rather than pretending.
-	"POST /ai/estimate": true,
-}
+// Empty since #359: POST /ai/estimate was the last entry and now honours the
+// header like every other create. The map stays because the structural guard
+// below needs the third option to exist — a future POST that genuinely cannot
+// replay should be listed here and wrapped in rejectIdempotencyKey, not left
+// silently unwrapped.
+var idempotencyRejectingPosts = map[string]bool{}
 
 // specIdempotentRoutes returns the routes whose OpenAPI entry declares the
 // Idempotency-Key header — the client-visible half of the same promise.
@@ -202,7 +203,21 @@ func newIdemHarness(t *testing.T, email string) *idemHarness {
 		t.Fatalf("minting a token failed: %v", err)
 	}
 
-	h := &V1Handler{Pool: pool}
+	// A stub AI provider, so /ai/estimate can be replay-tested like every other
+	// idempotent POST (#359). Without it the route answers 404 feature-disabled
+	// and the replay assertion below could never run — which is exactly how an
+	// endpoint ends up "covered" by a test that never exercises it.
+	//
+	// The body embeds a counter so a genuine second execution would produce
+	// DIFFERENT bytes: the replay assertion compares the two responses, and an
+	// identical constant would pass whether or not anything was replayed.
+	aiCalls := 0
+	h := &V1Handler{Pool: pool, AIEstimate: func(w http.ResponseWriter, r *http.Request) {
+		aiCalls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{"calories":%d,"name":"stub estimate"}`, 100+aiCalls)
+	}}
 	return &idemHarness{pool: pool, router: h.MountAPIV1(pool), token: raw, userID: userID, ctx: ctx}
 }
 
@@ -259,6 +274,7 @@ func TestIdempotentPostsReplayInsteadOfDuplicating(t *testing.T) {
 		"POST /todos":                  {"/todos", `{"name":"Replay probe","schedule":{"type":"daily"}}`},
 		"POST /saved-foods":            {"/saved-foods", `{"name":"Replay probe food","calories":95}`},
 		"POST /saved-foods/{id}/track": {"/saved-foods/" + strconv.Itoa(seeded.ID) + "/track", `{}`},
+		"POST /ai/estimate":            {"/ai/estimate", `{"image":"ZmFrZQ=="}`},
 	}
 
 	for route := range specIdempotentRoutes(t) {
@@ -368,27 +384,27 @@ func TestFailedRequestReleasesTheIdempotencyKey(t *testing.T) {
 	}
 }
 
-// TestUnsupportedIdempotencyKeyIsRejectedByTheRouter proves the guard is wired
-// ahead of the handler on the one POST that does not honour the header: the
-// same request without the header reaches the handler and 404s (no AI provider
-// is configured here), so the 400 can only come from the guard.
-func TestUnsupportedIdempotencyKeyIsRejectedByTheRouter(t *testing.T) {
-	hh := newIdemHarness(t, "idempotency-unsupported@handler.test")
+// TestAIEstimateNoLongerRejectsTheHeader is what #359 turned the old
+// "rejected by the router" assertion into.
+//
+// The header used to be refused with 400 on this one route. It is now honoured,
+// so the observable change is that sending it no longer short-circuits: the
+// request reaches the handler and gets whatever the handler answers — here a
+// 404, because this harness configures no AI provider. A 400 would mean the
+// reject guard is still wired.
+func TestAIEstimateNoLongerRejectsTheHeader(t *testing.T) {
+	hh := newIdemHarness(t, "idempotency-ai-estimate@handler.test")
 
-	rec := hh.post(t, "/ai/estimate", "some-key", `{"image":"x"}`)
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400 (body %s)", rec.Code, rec.Body.String())
-	}
-	var p map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &p); err != nil {
-		t.Fatalf("body is not JSON: %v", err)
-	}
-	if detail, _ := p["detail"].(string); !strings.Contains(detail, "Idempotency-Key") {
-		t.Errorf("detail = %q, want it to name the header so the client knows what to drop", detail)
+	withKey := hh.post(t, "/ai/estimate", "some-key", `{"image":"x"}`)
+	if withKey.Code == http.StatusBadRequest {
+		t.Fatalf("Idempotency-Key is still rejected on /ai/estimate (body %s)", withKey.Body.String())
 	}
 
-	if rec := hh.post(t, "/ai/estimate", "", `{"image":"x"}`); rec.Code == http.StatusBadRequest {
-		t.Errorf("the same request without the header also 400s (body %s); "+
-			"the rejection above proves nothing", rec.Body.String())
+	// And it reaches the same place the header-less request does, which is what
+	// "honoured rather than special-cased" means.
+	without := hh.post(t, "/ai/estimate", "", `{"image":"x"}`)
+	if withKey.Code != without.Code {
+		t.Errorf("with header = %d, without = %d; the header changed the outcome",
+			withKey.Code, without.Code)
 	}
 }

--- a/internal/handler/v1_misc.go
+++ b/internal/handler/v1_misc.go
@@ -39,8 +39,34 @@ type v1Me struct {
 	Server struct {
 		Version string `json:"version"`
 		Today   string `json:"today"`
+
+		// Features reports which OPTIONAL endpoints this deployment actually
+		// serves. Distinct from the account-level `features` below, and kept
+		// under `server` for exactly that reason: one is what the user turned
+		// on, the other is how the operator configured the instance, and
+		// merging them would make a client unable to tell "you disabled this"
+		// from "this server does not offer it".
+		Features v1ServerFeatures `json:"features"`
 	} `json:"server"`
 	Features v1Features `json:"features"`
+}
+
+// v1ServerFeatures reports the endpoints that exist in the route table and the
+// OpenAPI document unconditionally but answer 404 feature-disabled depending on
+// how the server is configured (#392).
+//
+// Without this, discovering that an instance has no AI provider meant sending a
+// photo and reading the 404 — and a client cannot tell that apart from a
+// genuine not-found without parsing the problem `type`. Both fields are always
+// present so a client never has to distinguish false from absent.
+type v1ServerFeatures struct {
+	// Barcode is true when BarcodeV1 is wired, i.e. GET /barcode/{code} will
+	// attempt a lookup rather than answering feature-disabled.
+	Barcode bool `json:"barcode"`
+
+	// AIEstimate is true when an AI provider is configured. The account's own
+	// daily cap still applies on top — this only says the endpoint is live.
+	AIEstimate bool `json:"ai_estimate"`
 }
 
 // v1Features reports the per-account opt-ins that change how the rest of the

--- a/internal/handler/v1_router.go
+++ b/internal/handler/v1_router.go
@@ -140,10 +140,15 @@ func (h *V1Handler) MountAPIV1(pool *pgxpool.Pool) chi.Router {
 			optionalLimiter(h.BarcodeLimiter)).Get("/barcode/{code}", h.BarcodeV1)
 
 		// Its own scope, implied by nothing: every call spends real money.
-		// Not idempotent and not (yet) replayable, so it says so out loud
-		// rather than accepting an Idempotency-Key it would ignore.
+		//
+		// Idempotent since #359, and it is the endpoint that most needs to be:
+		// a retried estimate spends the operator's AI budget twice AND burns a
+		// second slot in the account's daily cap, for a photo the caller
+		// already paid to analyse. It used to reject the header outright, which
+		// was honest but left the most expensive operation on the surface as
+		// the only one a timeout could silently double.
 		r.With(middleware.RequireScope(service.ScopeAIEstimate),
-			optionalLimiter(h.AILimiter)).Post("/ai/estimate", rejectIdempotencyKey(h.EstimateV1))
+			optionalLimiter(h.AILimiter)).Post("/ai/estimate", h.withIdempotency(h.EstimateV1))
 
 		r.Route("/entries", func(r chi.Router) {
 			r.With(middleware.RequireScope(service.ScopeEntriesRead)).Get("/", h.ListEntries)

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -70,13 +70,17 @@ type WeightEntry struct {
 }
 
 type WeightGoal struct {
-	ID            int        `json:"id"`
-	UserID        int        `json:"user_id"`
-	StartWeight   float64    `json:"start_weight"`
-	StartDate     string     `json:"start_date"`
-	TargetWeight  float64    `json:"target_weight"`
-	PaceMode      string     `json:"pace_mode"` // "rate" | "date"
-	RateKgPerWeek *float64   `json:"rate_kg_per_week,omitempty"`
+	ID           int     `json:"id"`
+	UserID       int     `json:"user_id"`
+	StartWeight  float64 `json:"start_weight"`
+	StartDate    string  `json:"start_date"`
+	TargetWeight float64 `json:"target_weight"`
+	PaceMode     string  `json:"pace_mode"` // "rate" | "date"
+	// Wire name is rate_per_week: the value is in the ACCOUNT's unit, so
+	// "kg" in the JSON was a lie for every lb account (#396). The Go field
+	// and the column keep their names — those really are the kg-era
+	// identifiers, and renaming a column is a migration this does not need.
+	RateKgPerWeek *float64   `json:"rate_per_week,omitempty"`
 	TargetDate    *string    `json:"target_date,omitempty"`
 	ActivityLevel *string    `json:"activity_level,omitempty"`
 	Status        string     `json:"status"`

--- a/internal/openapi/spec.go
+++ b/internal/openapi/spec.go
@@ -560,7 +560,19 @@ func schemas() map[string]*Schema {
 			"server": object("The server answering.", map[string]*Schema{
 				"version": str("The running build version."),
 				"today":   dateStr("Today's date in the account's time zone."),
-			}, "version", "today"),
+				"features": object(
+					"Which OPTIONAL endpoints this deployment actually serves. Separate from the "+
+						"account-level `features` below on purpose: this is how the operator configured "+
+						"the instance, that is what the user switched on, and a client needs to tell "+
+						"\"you turned this off\" apart from \"this server does not offer it\". Both fields "+
+						"are always present.",
+					map[string]*Schema{
+						"barcode": boolean("`GET /barcode/{code}` will attempt a lookup. When `false` it " +
+							"answers 404 `feature-disabled`."),
+						"ai_estimate": boolean("An AI provider is configured, so `POST /ai/estimate` is " +
+							"live. The account's daily cap still applies on top."),
+					}, "barcode", "ai_estimate"),
+			}, "version", "today", "features"),
 			"features": object(
 				"Per-account opt-ins that change how the rest of the API behaves. "+
 					"Read-only: they are switched in the app's settings, not through this API. "+
@@ -732,11 +744,10 @@ func planSchemas() map[string]*Schema {
 				"start_date":    dateStr("The day the goal was set."),
 				"target_weight": number("The target." + inUnit),
 				"pace_mode":     enumStr("`rate` sets a weekly pace directly; `date` derives one from `target_date`.", "rate", "date"),
-				"rate_kg_per_week": number("The requested pace per week. Present when `pace_mode` is `rate`." + inUnit +
-					" **Not necessarily kilograms, despite the name** — the name is the `weight_goals.rate_kg_per_week` " +
-					"column's, and the goal is stored and echoed in the account's own unit. Unlike the plan's other " +
-					"weight fields it was not renamed, because the same key is the request body of the app's " +
-					"`PUT /plan/goal`; see schaurian/schautrack#396."),
+				"rate_per_week": number("The requested pace per week. Present when `pace_mode` is `rate`." + inUnit +
+					" Renamed from `rate_kg_per_week`, which was not necessarily kilograms: the goal is stored and " +
+					"echoed in the account's own unit. `PUT /plan/goal` still accepts the old key on input so existing " +
+					"clients keep working."),
 				"target_date":    dateStr("The requested finish date. Present when `pace_mode` is `date`."),
 				"activity_level": enumStr("The activity level recorded with the goal: `sedentary`, `light`, `moderate`, `active` or `very_active`.", "sedentary", "light", "moderate", "active", "very_active"),
 				"status":         enumStr("`active`, `achieved` or `abandoned` — always `active` here, since this endpoint only returns the active goal.", "active", "achieved", "abandoned"),
@@ -1248,12 +1259,14 @@ func paths() map[string]*PathItem {
 				"spends the operator's AI budget, so it must be granted deliberately. The account's " +
 				"daily AI limit applies here exactly as it does in the app, as does a per-account " +
 				"rate limit matching the app's own estimate endpoint — this is not a cheaper path " +
-				"to the provider. Returns 404 when no AI provider is configured. This is the one " +
-				"`POST` that does not honour `Idempotency-Key`: sending the header returns 400 " +
-				"rather than being ignored, so a caller is never left believing a retry is safe " +
-				"when it is not.",
+				"to the provider. Returns 404 when no AI provider is configured; `GET /me` reports " +
+				"whether it is, under `server.features.ai_estimate`. " +
+				"Honours `Idempotency-Key`, and this is the endpoint it matters most on: a retried " +
+				"estimate would spend the AI budget twice and burn a second slot in the account's " +
+				"daily cap, for a photo already analysed.",
 			Tags: []string{"AI"}, Scope: service.ScopeAIEstimate,
 			Security:    []SecurityRequirement{{"bearerAuth": {service.ScopeAIEstimate}}},
+			Parameters:  []Parameter{idempotencyParam},
 			RequestBody: &RequestBody{Required: true, Content: jsonBody(ref("EstimateInput"))},
 			Responses: merge(map[string]*Response{
 				"200": ok200("The estimate.", ref("Estimate")),


### PR DESCRIPTION
Closes #359
Closes #392
Closes #396

### #359 — `POST /ai/estimate` now honours `Idempotency-Key`

It was the only v1 `POST` on the rejecting side. Rejecting was honest, but it left the **most expensive operation on the surface** as the only one a timeout could silently double: a retried estimate spends the operator's AI budget twice *and* burns a second slot in the account's daily cap, for a photo already analysed.

The structural guard (`TestEveryV1PostDecidesOnIdempotencyKey`) still requires every POST to decide; `idempotencyRejectingPosts` is now empty but kept, so a future endpoint that genuinely cannot replay has somewhere to be listed rather than being left silently unwrapped.

### #392 — `/me` reports which optional endpoints the server actually serves

`GET /barcode/{code}` and `POST /ai/estimate` exist in the route table and the OpenAPI document unconditionally, but answer `404 feature-disabled` depending on server configuration. Discovering that meant sending a photo and reading the 404 — which a client cannot distinguish from a genuine not-found without parsing the problem `type`.

Reported under `server.features`, **not** merged into the existing account-level `features`. That separation is the point: one is what the user switched off, the other is what the operator never configured, and a client needs to tell them apart. Populated from the same nil checks the endpoints make, so `/me` and the endpoints cannot disagree.

### #396 — `goal.rate_kg_per_week` renamed to `rate_per_week`

The last unit-lying name in the plan payload. For an `lb` account that value is pounds per week; #361 renamed the four response fields and this one survived because it is **also a request field**.

Resolved by renaming the response and **still accepting the old key on input**, so no existing client breaks. The Go field and the database column keep their names — those genuinely are the kg-era identifiers, and renaming a column is a migration this doesn't need.

Client updated in all four places (`types`, `api/plan.ts`, `GoalForm` read and write).

### Tests flipped

`TestUnsupportedIdempotencyKeyIsRejectedByTheRouter` asserted the 400 this PR removes; it became `TestAIEstimateNoLongerRejectsTheHeader`, checking the header no longer changes the outcome.

`TestIdempotentPostsReplayInsteadOfDuplicating` then failed with *"honours Idempotency-Key but has no request fixture here"* — so the harness now wires a stub AI provider. **The stub's response embeds a call counter**, so a genuine second execution would produce different bytes: with a constant body the replay assertion would pass whether or not anything replayed.

## Verification

```
go run ./cmd/apidocs -check   # up to date
go vet ./...                  # clean
go test ./...                 # ok, 11/11 (real Postgres 18)
npx tsc -b --noEmit           # clean
npx vitest run                # 144/144
```

Client suite and typecheck run because #396 renames a field the Plan page reads and writes.
