### PR TITLE
feat(helm): add values.schema.json; fix(client): label the plan from its payload

### DIFF
--- a/client/src/pages/Dashboard/PlanCard.tsx
+++ b/client/src/pages/Dashboard/PlanCard.tsx
@@ -10,9 +10,15 @@ interface Props {
   weightUnit: string;
 }
 
-export default function PlanCard({ weightUnit }: Props) {
+export default function PlanCard({ weightUnit: contextUnit }: Props) {
   const { t } = useTranslation('dashboard');
   const { data } = useQuery({ queryKey: ['plan'], queryFn: getPlan });
+
+  // Label from the plan payload, not from the dashboard's copy of the account
+  // setting (#410). The server already converted these numbers and said which
+  // unit they are in; the prop is only a fallback for a server that predates
+  // the field.
+  const weightUnit = data?.unit || contextUnit;
 
   // Small local mapping — mirrors the status→label/color approach in Plan.tsx
   // (not exported there, so duplicated here rather than reaching across pages).

--- a/client/src/pages/Plan/Plan.tsx
+++ b/client/src/pages/Plan/Plan.tsx
@@ -71,7 +71,15 @@ export default function Plan() {
     return <div className="flex items-center justify-center py-12"><div className="size-6 rounded-full border-2 border-primary border-t-transparent animate-spin" /></div>;
   }
 
-  const weightUnit = user?.weightUnit || 'kg';
+  // The unit the plan's numbers are actually in, taken from the payload (#410).
+  //
+  // This used to read user?.weightUnit from the auth context. That is a second
+  // source for the same fact, and the two can disagree: the server converts the
+  // whole payload with ConvertPlanResponseToDisplayUnit and stamps the unit it
+  // left them in, so a stale or still-loading auth context labelled real
+  // pounds as "kg". Falling back to the context only while `unit` is absent
+  // keeps older servers working.
+  const weightUnit = data.unit || user?.weightUnit || 'kg';
 
   const handleApplyBudget = async () => {
     setApplying(true);

--- a/helm/schautrack/values.schema.json
+++ b/helm/schautrack/values.schema.json
@@ -1,0 +1,706 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "description": "Generated from values.yaml. Objects whose keys the templates enumerate are closed (additionalProperties: false) so a mistyped key fails at install time instead of silently rendering nothing (#400). Kubernetes-shaped blocks \u2014 resources, nodeSelector, tolerations, affinity, the security contexts, podAnnotations, ingress annotations \u2014 and the postgresql subchart stay open, because the chart forwards them verbatim and closing them would reject valid input.",
+  "properties": {
+    "affinity": {
+      "properties": {},
+      "type": "object"
+    },
+    "ai": {
+      "additionalProperties": false,
+      "properties": {
+        "dailyLimit": {
+          "type": "integer"
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "key": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "keyEncryptionSecret": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "model": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "provider": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "config": {
+      "additionalProperties": false,
+      "properties": {
+        "adminEmail": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "androidCertFingerprints": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "androidPackageName": {
+          "type": "string"
+        },
+        "baseUrl": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "captcha": {
+          "additionalProperties": false,
+          "properties": {
+            "globalThreshold": {
+              "type": [
+                "string",
+                "integer",
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "enableBarcode": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "enableLegal": {
+          "type": "boolean"
+        },
+        "enableRegistration": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "imprintAddress": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "imprintEmail": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "imprintUrl": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "rateLimit": {
+          "additionalProperties": false,
+          "properties": {
+            "api": {
+              "type": [
+                "string",
+                "integer",
+                "boolean",
+                "null"
+              ]
+            },
+            "apiToken": {
+              "type": [
+                "string",
+                "integer",
+                "boolean",
+                "null"
+              ]
+            },
+            "auth": {
+              "type": [
+                "string",
+                "integer",
+                "boolean",
+                "null"
+              ]
+            },
+            "barcode": {
+              "type": [
+                "string",
+                "integer",
+                "boolean",
+                "null"
+              ]
+            },
+            "strict": {
+              "type": [
+                "string",
+                "integer",
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "robotsIndex": {
+          "type": "boolean"
+        },
+        "sessionSecret": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "stepUpTTL": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "supportEmail": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "trustProxy": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "updateCheck": {
+          "additionalProperties": false,
+          "properties": {
+            "baseUrl": {
+              "type": [
+                "string",
+                "integer",
+                "boolean",
+                "null"
+              ]
+            },
+            "enabled": {
+              "type": [
+                "string",
+                "integer",
+                "boolean",
+                "null"
+              ]
+            },
+            "provider": {
+              "type": [
+                "string",
+                "integer",
+                "boolean",
+                "null"
+              ]
+            },
+            "repo": {
+              "type": [
+                "string",
+                "integer",
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "existingSecret": {
+      "type": [
+        "string",
+        "integer",
+        "boolean",
+        "null"
+      ]
+    },
+    "externalDatabase": {
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "fullnameOverride": {
+      "type": [
+        "string",
+        "integer",
+        "boolean",
+        "null"
+      ]
+    },
+    "image": {
+      "additionalProperties": false,
+      "properties": {
+        "pullPolicy": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "imagePullSecrets": {
+      "type": "array"
+    },
+    "ingress": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "properties": {},
+          "type": "object"
+        },
+        "className": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "hosts": {
+          "type": "array"
+        },
+        "tls": {
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "nameOverride": {
+      "type": [
+        "string",
+        "integer",
+        "boolean",
+        "null"
+      ]
+    },
+    "nodeSelector": {
+      "properties": {},
+      "type": "object"
+    },
+    "oidc": {
+      "additionalProperties": false,
+      "properties": {
+        "clientId": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "clientSecret": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "issuer": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "redirectUrl": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "requireInvite": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "passkeys": {
+      "additionalProperties": false,
+      "properties": {
+        "rpId": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "rpName": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "rpOrigins": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "podAnnotations": {
+      "properties": {},
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "properties": {
+        "fsGroup": {
+          "type": "integer"
+        },
+        "runAsGroup": {
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "type": "integer"
+        },
+        "seccompProfile": {
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "postgresql": {
+      "properties": {
+        "auth": {
+          "properties": {
+            "database": {
+              "type": "string"
+            },
+            "password": {
+              "type": [
+                "string",
+                "integer",
+                "boolean",
+                "null"
+              ]
+            },
+            "username": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "properties": {
+            "pullPolicy": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "persistence": {
+          "properties": {
+            "accessMode": {
+              "type": "string"
+            },
+            "annotations": {
+              "properties": {},
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "existingClaim": {
+              "type": [
+                "string",
+                "integer",
+                "boolean",
+                "null"
+              ]
+            },
+            "labels": {
+              "properties": {},
+              "type": "object"
+            },
+            "size": {
+              "type": "string"
+            },
+            "storageClass": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "properties": {
+            "fsGroup": {
+              "type": "integer"
+            },
+            "runAsGroup": {
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "type": "integer"
+            },
+            "seccompProfile": {
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "resources": {
+          "properties": {},
+          "type": "object"
+        },
+        "securityContext": {
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "capabilities": {
+              "properties": {
+                "drop": {
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "runAsNonRoot": {
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "replicaCount": {
+      "type": "integer"
+    },
+    "resources": {
+      "properties": {},
+      "type": "object"
+    },
+    "securityContext": {
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "type": "boolean"
+        },
+        "capabilities": {
+          "properties": {
+            "drop": {
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "runAsNonRoot": {
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "service": {
+      "additionalProperties": false,
+      "properties": {
+        "port": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "serviceAccount": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "properties": {},
+          "type": "object"
+        },
+        "automount": {
+          "type": "boolean"
+        },
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "smtp": {
+      "additionalProperties": false,
+      "properties": {
+        "from": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "host": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "pass": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        },
+        "port": {
+          "type": "integer"
+        },
+        "secure": {
+          "type": "boolean"
+        },
+        "user": {
+          "type": [
+            "string",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    }
+  },
+  "title": "schautrack Helm values",
+  "type": "object"
+}


### PR DESCRIPTION
Closes #400
Closes #410

### #400 — a mistyped Helm value rendered nothing

Every value is guarded with `{{- if .Values.config.foo }}`, so an unrecognised key is not an error — it is simply never read. The issue's example:

```yaml
config:
  updateCheck:
    enable: false      # "enable", not "enabled"
```

installed cleanly and left the update check **on**, with nothing to indicate why.

`values.schema.json` is generated from `values.yaml`, so the two cannot drift. Objects whose keys the templates enumerate are closed; Kubernetes-shaped blocks the chart forwards verbatim — `resources`, `nodeSelector`, `tolerations`, `affinity`, the security contexts, `podAnnotations`, `ingress.annotations` — and the `postgresql` subchart stay open, because closing those would reject valid input.

**Verified against the real `helm` binary, both directions:**

```
$ helm template t helm/schautrack -f typo.yaml
Error: values don't meet the specifications of the schema(s) ...
- at '/config/updateCheck': additional properties 'enable' not allowed

$ helm template t helm/schautrack -f valid.yaml     # enabled: false      → PASS
$ helm template t helm/schautrack -f k8s-blocks.yaml # resources, nodeSelector → PASS
$ helm template t helm/schautrack                    # defaults           → PASS
$ helm lint helm/schautrack                          # 0 failed
```

My first pass closed `config` but not `config.updateCheck`, so the issue's own example still installed. Running it is what caught that — the schema looked right.

### #410 — the Plan page labelled numbers from the wrong source

`Plan.tsx` and `PlanCard.tsx` read `user?.weightUnit` from the auth context to label every number on the page: healthy range, current weight, chart axes, the Katch–McArdle lean-mass line.

That's a second source for the same fact. The server converts the whole payload with `ConvertPlanResponseToDisplayUnit` and stamps `unit` with what it left them in — so a stale or still-loading auth context labels real pounds as `kg`. The numbers and their label came from different places and could disagree.

Both now read `data.unit`, falling back to the context only when the field is absent, which keeps an older server working.

The `unit` field only became available when #361 landed, which is why this was split out.

## Verification

```
helm lint helm/schautrack   # 0 failed
go vet ./...                # clean
go test ./...               # ok, 11/11 (real Postgres 18)
tsc -b                      # clean
vitest run                  # 144/144
```
