### PR TITLE
feat(import): report which rows were skipped and why, and add a dry run

### DIFF
--- a/client/src/api/settings.ts
+++ b/client/src/api/settings.ts
@@ -79,10 +79,43 @@ export function cancelEmailChange() {
 // Routed through api() so the step-up modal can intercept the 403 and retry
 // after re-auth. FormData body is left untouched (api() only auto-sets
 // Content-Type for string bodies, so the multipart boundary stays intact).
-export function importData(file: File): Promise<{ ok: boolean; message?: string; error?: string }> {
+/** One row the server could not read, and why. `reason` is a stable code. */
+export interface ImportSkippedRow {
+  /** `entry` or `weight` — the two arrays are indexed separately. */
+  kind: string;
+  /** Position in that array in the uploaded file. */
+  index: number;
+  /** The row's date when it had a readable one; absent when the date is why it failed. */
+  date?: string;
+  /** `not_an_object` | `invalid_date` | `invalid_amount` | `invalid_weight` | `row_limit` */
+  reason: string;
+}
+
+export interface ImportResult {
+  ok: boolean;
+  message?: string;
+  error?: string;
+  /** True when nothing was written. */
+  dry_run?: boolean;
+  skipped?: {
+    /** Every dropped row, including those past the report cap. */
+    total: number;
+    /** How many are listed in `rows`. */
+    reported: number;
+    rows: ImportSkippedRow[];
+  };
+}
+
+/**
+ * @param dryRun Parse and report without writing. The real import DELETEs the
+ * account's existing entries before inserting, so this is the only way to see
+ * what a file would do while that is still reversible.
+ */
+export function importData(file: File, dryRun = false): Promise<ImportResult> {
   const formData = new FormData();
   formData.append('import_file', file);
-  return api<{ ok: boolean; message?: string; error?: string }>('/settings/import', {
+  if (dryRun) formData.append('dry_run', 'true');
+  return api<ImportResult>('/settings/import', {
     method: 'POST',
     body: formData,
   });

--- a/docs/api-internal.md
+++ b/docs/api-internal.md
@@ -318,7 +318,7 @@ returns `401` when unauthenticated.
 | POST | `/settings/email/verify` | Session +Local +CSRF | Verify the new email with a code. |
 | POST | `/settings/email/cancel` | Session +Local +CSRF | Cancel a pending email change. |
 | POST | `/settings/export` | Session +StepUp +CSRF | Export all account data. |
-| POST | `/settings/import` | Session +StepUp +CSRF | Import account data. |
+| POST | `/settings/import` | Session +StepUp +CSRF | Import account data. Send `dry_run=true` to parse and report without writing — the real import DELETEs existing entries first. Responds `{ok, dry_run, message, skipped:{total, reported, rows:[{kind, index, date?, reason}]}}`; `reason` is one of `not_an_object`, `invalid_date`, `invalid_amount`, `invalid_weight`, `row_limit`, and `rows` is capped while `total` is not. |
 | POST | `/delete` | Session +StepUp +CSRF | Delete the account. |
 
 ### Account links

--- a/internal/handler/entries_export.go
+++ b/internal/handler/entries_export.go
@@ -212,6 +212,50 @@ type importData struct {
 	// the import succeeded (#351).
 	skippedEntries int
 	skippedWeights int
+
+	// skipped names the dropped rows: which one, and why. The counts above
+	// say a partial import happened; this says what to fix (#409). With a
+	// 500-row export and seven bad amounts, "7 rows" is enough to know
+	// something is wrong and not enough to do anything about it — and the
+	// import DELETEs the user's existing entries first, so there is no second
+	// chance to diff against the original.
+	//
+	// Capped at maxReportedSkips so a hostile file cannot turn a 10,000-row
+	// rejection into a 10,000-element response; skippedEntries/skippedWeights
+	// remain the true totals.
+	skipped []skippedRow
+}
+
+// maxReportedSkips bounds the per-row detail. Fifty is well past the point
+// where a human is reading individual rows and still small enough that the
+// response stays a response.
+const maxReportedSkips = 50
+
+// skippedRow is one dropped import row. Reason is a stable code rather than
+// prose so a client can group or translate it; the wire shape is documented on
+// the ImportResult schema.
+type skippedRow struct {
+	// Kind is "entry" or "weight" — the two arrays are indexed separately, so
+	// an index alone would be ambiguous.
+	Kind string `json:"kind"`
+	// Index is the row's position in its array in the uploaded file, so the
+	// user can go straight to it.
+	Index int `json:"index"`
+	// Date is the row's date when it had a readable one. Absent when the date
+	// itself is why the row was dropped.
+	Date string `json:"date,omitempty"`
+	// Reason is one of: not_an_object, invalid_date, invalid_amount,
+	// invalid_weight, row_limit.
+	Reason string `json:"reason"`
+}
+
+// record appends a skip, up to the cap. Callers still bump the counters, so
+// the totals stay accurate past it.
+func (d *importData) record(kind string, index int, date, reason string) {
+	if len(d.skipped) >= maxReportedSkips {
+		return
+	}
+	d.skipped = append(d.skipped, skippedRow{Kind: kind, Index: index, Date: date, Reason: reason})
 }
 
 // isEmpty reports whether the import carries nothing worth writing. Import
@@ -253,17 +297,23 @@ func parseImportData(parsed map[string]any) importData {
 	}
 
 	// Parse entries
+	//
+	// rec collects the per-row detail as we go; the counters stay the source of
+	// truth for the totals, because rec stops appending at maxReportedSkips.
+	var rec importData
 	var toInsert []importEntry
 	var skippedEntries int
 	if entries, ok := parsed["entries"].([]any); ok {
 		for i, e := range entries {
 			if len(toInsert) >= 10000 {
 				skippedEntries += len(entries) - i
+				rec.record("entry", i, "", "row_limit")
 				break
 			}
 			entry, ok := e.(map[string]any)
 			if !ok {
 				skippedEntries++
+				rec.record("entry", i, "", "not_an_object")
 				continue
 			}
 			dateStr := ""
@@ -273,12 +323,16 @@ func parseImportData(parsed map[string]any) importData {
 				dateStr = v
 			}
 			if !isValidDate(dateStr) {
+				// No date reported: the date is why this row was dropped, and
+				// echoing an unparseable one back would suggest it was read.
 				skippedEntries++
+				rec.record("entry", i, "", "invalid_date")
 				continue
 			}
 			amountResult := service.ParseAmount(fmt.Sprintf("%v", entry["amount"]), MaxEntryCalories)
 			if !amountResult.Ok || amountResult.Value == 0 {
 				skippedEntries++
+				rec.record("entry", i, dateStr, "invalid_amount")
 				continue
 			}
 			var name *string
@@ -316,11 +370,13 @@ func parseImportData(parsed map[string]any) importData {
 		for i, w := range weights {
 			if len(weightToInsert) >= 10000 {
 				skippedWeights += len(weights) - i
+				rec.record("weight", i, "", "row_limit")
 				break
 			}
 			wEntry, ok := w.(map[string]any)
 			if !ok {
 				skippedWeights++
+				rec.record("weight", i, "", "not_an_object")
 				continue
 			}
 			dateStr := ""
@@ -331,11 +387,13 @@ func parseImportData(parsed map[string]any) importData {
 			}
 			if !isValidDate(dateStr) {
 				skippedWeights++
+				rec.record("weight", i, "", "invalid_date")
 				continue
 			}
 			wr := service.ParseWeight(fmt.Sprintf("%v", wEntry["weight"]))
 			if !wr.Ok {
 				skippedWeights++
+				rec.record("weight", i, dateStr, "invalid_weight")
 				continue
 			}
 			// An unparseable body fat drops just that field — the weight is
@@ -366,6 +424,7 @@ func parseImportData(parsed map[string]any) importData {
 		hasUserSettings: hasUserSettings,
 		skippedEntries:  skippedEntries,
 		skippedWeights:  skippedWeights,
+		skipped:         rec.skipped,
 	}
 }
 
@@ -383,6 +442,62 @@ func parseImportData(parsed map[string]any) importData {
 // to the response: Account.tsx renders `message` verbatim, so it reaches the
 // user with no client, OpenAPI or i18n change. Per-row diagnostics (which rows,
 // and why) would need a real response-shape change and are filed as #409.
+// importParts renders the "N entries and M weight records" fragment. Shared so
+// the dry run and the real import cannot describe the same file differently —
+// the whole point of a rehearsal is that it predicts the performance.
+//
+// hasUserSettings is not included here: the dry run reports it identically via
+// its own caller, and threading a fourth boolean through would obscure that
+// these two lists must stay in step.
+func importParts(entries, weights int) []string {
+	var parts []string
+	if entries > 0 {
+		parts = append(parts, fmt.Sprintf("%d entries", entries))
+	}
+	if weights > 0 {
+		parts = append(parts, fmt.Sprintf("%d weight records", weights))
+	}
+	return parts
+}
+
+// isTruthyFormValue reads a multipart flag. Accepts the spellings an HTML form
+// and a scripted client each produce, rather than only Go's strconv set.
+func isTruthyFormValue(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// importSkippedPayload renders the per-row diagnostics.
+//
+// total is reported separately from the list because the list is capped: a
+// file with 10,000 unreadable rows reports all 10,000 in `total` and the first
+// maxReportedSkips in `rows`, so the number is never quietly wrong and the
+// response never grows with a hostile file.
+func importSkippedPayload(d importData) map[string]any {
+	rows := d.skipped
+	if rows == nil {
+		rows = []skippedRow{}
+	}
+	return map[string]any{
+		"total":    d.skippedEntries + d.skippedWeights,
+		"reported": len(rows),
+		"rows":     rows,
+	}
+}
+
+// dryRunParts mirrors what the real import reports, including user settings, so
+// the rehearsal and the performance describe the same file identically.
+func dryRunParts(entries []importEntry, weights []importWeight, hasUserSettings bool) []string {
+	parts := importParts(len(entries), len(weights))
+	if hasUserSettings {
+		parts = append(parts, "user settings")
+	}
+	return parts
+}
+
 func importMessage(parts []string, skipped int) string {
 	msg := fmt.Sprintf("Imported %s.", strings.Join(parts, " and "))
 	if skipped > 0 {
@@ -432,6 +547,29 @@ func (h *EntriesHandler) Import(w http.ResponseWriter, r *http.Request) {
 
 	if data.isEmpty() {
 		ErrorJSON(w, http.StatusBadRequest, "No valid entries found in import file.")
+		return
+	}
+
+	// Dry run: report exactly what a real import would do, and write nothing
+	// (#409).
+	//
+	// This matters more than the per-row detail below it. The import DELETEs
+	// the account's existing entries before inserting, so by the time a user
+	// reads "Skipped 7 rows" the data those rows would have replaced is
+	// already gone — there is nothing left to diff the file against. A dry run
+	// is the only way to find that out while it is still fixable.
+	//
+	// Deliberately placed after isEmpty: a file with nothing importable is a
+	// 400 whether or not this is a rehearsal, and answering "nothing would be
+	// written" with 200 would read as success.
+	if isTruthyFormValue(r.FormValue("dry_run")) {
+		JSON(w, http.StatusOK, map[string]any{
+			"ok":      true,
+			"dry_run": true,
+			"message": importMessage(dryRunParts(toInsert, weightToInsert, hasUserSettings),
+				data.skippedEntries+data.skippedWeights) + " Nothing was written.",
+			"skipped": importSkippedPayload(data),
+		})
 		return
 	}
 
@@ -548,16 +686,15 @@ func (h *EntriesHandler) Import(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var parts []string
-	if len(toInsert) > 0 {
-		parts = append(parts, fmt.Sprintf("%d entries", len(toInsert)))
-	}
-	if len(weightToInsert) > 0 {
-		parts = append(parts, fmt.Sprintf("%d weight records", len(weightToInsert)))
-	}
+	parts := importParts(len(toInsert), len(weightToInsert))
 	if hasUserSettings {
 		parts = append(parts, "user settings")
 	}
 
-	JSON(w, http.StatusOK, map[string]any{"ok": true, "message": importMessage(parts, data.skippedEntries+data.skippedWeights)})
+	JSON(w, http.StatusOK, map[string]any{
+		"ok":      true,
+		"dry_run": false,
+		"message": importMessage(parts, data.skippedEntries+data.skippedWeights),
+		"skipped": importSkippedPayload(data),
+	})
 }

--- a/internal/handler/entries_import_dryrun_test.go
+++ b/internal/handler/entries_import_dryrun_test.go
@@ -1,0 +1,187 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// buildImportRequestWithFields is buildImportRequest plus extra form fields, so
+// a test can set dry_run alongside the file.
+func buildImportRequestWithFields(t *testing.T, content string, fields map[string]string) *http.Request {
+	t.Helper()
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	fw, err := mw.CreateFormFile("import_file", "import.json")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := fw.Write([]byte(content)); err != nil {
+		t.Fatalf("write file part: %v", err)
+	}
+	for k, v := range fields {
+		if err := mw.WriteField(k, v); err != nil {
+			t.Fatalf("WriteField %s: %v", k, err)
+		}
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+	r := httptest.NewRequest(http.MethodPost, "/settings/import", &body)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	return r
+}
+
+// A file with one good entry and several unreadable ones, so the dry run has
+// something to both accept and report.
+const dryRunFixture = `{
+  "entries": [
+    {"date": "2026-08-05", "amount": 500, "name": "Good"},
+    {"date": "not-a-date", "amount": 100},
+    {"date": "2026-08-06", "amount": "nonsense"},
+    "not an object"
+  ],
+  "weights": [
+    {"date": "2026-08-05", "weight": 82.4},
+    {"date": "2026-08-06", "weight": "abc"}
+  ]
+}`
+
+// TestImportDryRunWritesNothing is the half of #409 that matters most.
+//
+// The real import DELETEs the account's existing entries before inserting, so
+// by the time a user reads "Skipped 7 rows" the data those rows would have
+// replaced is already gone and there is nothing left to compare the file
+// against. A dry run is the only way to learn that while it is still fixable.
+//
+// Driven with a NIL Pool: the handler would panic on h.Pool.Begin, so a clean
+// 200 is proof the destructive path was never entered. Asserting "no rows
+// changed" against a live database would pass just as well if the DELETE ran
+// and the INSERT restored the same data — this cannot.
+func TestImportDryRunWritesNothing(t *testing.T) {
+	h := &EntriesHandler{} // nil Pool: any DB access panics
+
+	for _, flag := range []string{"1", "true", "TRUE", "yes", "on"} {
+		rec := httptest.NewRecorder()
+		req := buildImportRequestWithFields(t, dryRunFixture, map[string]string{"dry_run": flag})
+
+		h.Import(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("dry_run=%q: status = %d, want 200 (body %s)", flag, rec.Code, rec.Body.String())
+		}
+		var resp struct {
+			OK      bool   `json:"ok"`
+			DryRun  bool   `json:"dry_run"`
+			Message string `json:"message"`
+			Skipped struct {
+				Total    int `json:"total"`
+				Reported int `json:"reported"`
+				Rows     []struct {
+					Kind, Date, Reason string
+					Index              int
+				} `json:"rows"`
+			} `json:"skipped"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("dry_run=%q: response is not JSON: %v", flag, err)
+		}
+		if !resp.DryRun {
+			t.Errorf("dry_run=%q: response does not say it was a dry run", flag)
+		}
+		if resp.Skipped.Total != 4 {
+			t.Errorf("dry_run=%q: skipped.total = %d, want 4", flag, resp.Skipped.Total)
+		}
+		if len(resp.Skipped.Rows) != 4 {
+			t.Fatalf("dry_run=%q: got %d skipped rows, want 4", flag, len(resp.Skipped.Rows))
+		}
+	}
+}
+
+// TestImportDryRunIsOffByDefault: a missing or falsey flag must NOT take the
+// rehearsal path. Getting this backwards would make every real import a no-op
+// while reporting success — silent, total data loss of the import itself.
+func TestImportDryRunIsOffByDefault(t *testing.T) {
+	h := &EntriesHandler{} // nil Pool: reaching the DB panics, which is the signal
+
+	for _, flag := range []string{"", "0", "false", "no", "off", "maybe"} {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("dry_run=%q did not reach the database — it was treated as a dry run", flag)
+				}
+			}()
+			fields := map[string]string{}
+			if flag != "" {
+				fields["dry_run"] = flag
+			}
+			h.Import(httptest.NewRecorder(), buildImportRequestWithFields(t, dryRunFixture, fields))
+		}()
+	}
+}
+
+// TestImportSkippedRowsNameTheRowAndReason pins the diagnostics themselves:
+// which row, and why. "7 rows" tells a user something is wrong; it does not
+// tell them what to fix.
+func TestImportSkippedRowsNameTheRowAndReason(t *testing.T) {
+	data := parseImportData(mustParseImportJSON(t, dryRunFixture))
+
+	if got := data.skippedEntries + data.skippedWeights; got != 4 {
+		t.Fatalf("skipped total = %d, want 4", got)
+	}
+
+	type key struct {
+		kind   string
+		index  int
+		reason string
+	}
+	got := map[key]string{}
+	for _, r := range data.skipped {
+		got[key{r.Kind, r.Index, r.Reason}] = r.Date
+	}
+
+	want := map[key]string{
+		{"entry", 1, "invalid_date"}:    "",           // the date is why it failed: not echoed back
+		{"entry", 2, "invalid_amount"}:  "2026-08-06", // date was readable, so it locates the row
+		{"entry", 3, "not_an_object"}:   "",
+		{"weight", 1, "invalid_weight"}: "2026-08-06",
+	}
+	for k, wantDate := range want {
+		date, ok := got[k]
+		if !ok {
+			t.Errorf("no skipped row for %+v; got %+v", k, data.skipped)
+			continue
+		}
+		if date != wantDate {
+			t.Errorf("%+v: date = %q, want %q", k, date, wantDate)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %d skipped rows, want %d: %+v", len(got), len(want), data.skipped)
+	}
+}
+
+// TestImportSkippedRowsAreCapped: the counters stay truthful past the cap while
+// the list stops growing, so a hostile file cannot turn a 10,000-row rejection
+// into a 10,000-element response.
+func TestImportSkippedRowsAreCapped(t *testing.T) {
+	var b bytes.Buffer
+	b.WriteString(`{"entries":[{"date":"2026-08-05","amount":500}`)
+	for i := 0; i < maxReportedSkips*3; i++ {
+		b.WriteString(`,{"date":"nope","amount":1}`)
+	}
+	b.WriteString(`]}`)
+
+	data := parseImportData(mustParseImportJSON(t, b.String()))
+
+	if data.skippedEntries != maxReportedSkips*3 {
+		t.Errorf("skippedEntries = %d, want %d — the counter must not be capped",
+			data.skippedEntries, maxReportedSkips*3)
+	}
+	if len(data.skipped) != maxReportedSkips {
+		t.Errorf("reported rows = %d, want the cap of %d", len(data.skipped), maxReportedSkips)
+	}
+}


### PR DESCRIPTION
Closes #409

`parseImportData` counted dropped rows and the response said *"Skipped 7 rows that could not be read."* With a 500-row export that is enough to know something is wrong and not enough to fix it.

## Per-row diagnostics

`skipped.rows` now carries `kind`, `index` in the file's array, the row's `date` when it had a readable one, and a stable `reason` code: `not_an_object`, `invalid_date`, `invalid_amount`, `invalid_weight`, `row_limit`.

A row dropped **because of** its date reports no date — echoing an unparseable one back would suggest it had been read.

The list is capped at 50 while `skipped.total` stays the true count, so a hostile file can't turn a 10,000-row rejection into a 10,000-element response.

## Dry run — the more valuable half

The import `DELETE`s the account's existing entries before inserting. By the time a user reads a skip count, the data those rows would have replaced is **already gone** — there is nothing left to compare the file against. `dry_run=true` parses and reports without writing, which is the only way to learn that while it's still fixable.

It sits *after* the `isEmpty` guard: a file with nothing importable is a 400 either way, and answering "nothing would be written" with a 200 would read as success.

The dry run and the real import build their summary through the same helper, so the rehearsal cannot describe the file differently from the performance.

## How the tests prove it

Driven with a **nil Pool** — the handler would panic on `Pool.Begin`, so a clean 200 is proof the destructive path was never entered.

Asserting "no rows changed" against a live database would have passed just as well if the `DELETE` ran and the `INSERT` restored the same data. This cannot.

`TestImportDryRunIsOffByDefault` inverts it and *requires* the panic for `""`, `0`, `false`, `no`, `off` and an unrecognised value — because getting the flag backwards would make every real import a silent no-op that reports success.

## Verification

```
go vet ./...          # clean
go test ./...         # ok, 11/11 (real Postgres 18)
tsc -b                # clean
vitest run            # 144/144
npm run i18n:drift    # no files updated
npm run i18n:check    # parity passed
```

Both client i18n gates run: parity checks which keys exist, drift runs the extractor and fails if it reorders anything. They are independent, and a change can pass one and fail the other.
