### PR TITLE
test(ci): run Go tests under -race, publish coverage, add govulncheck

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,10 +141,55 @@ jobs:
           fi
           go vet ./...
 
+      # -race is the point of this step, not a nicety. Almost everything this
+      # app does concurrently is invisible to a serial test run: the SSE broker
+      # fans out per-user channels while Postgres LISTEN/NOTIFY writes into the
+      # same maps, the settings cache mutates shared state on a 1-minute TTL,
+      # and the rate limiters and login-failure tracker are touched from every
+      # request goroutine at once. A data race there is not a test failure, it
+      # is a wrong number served to a user or a nil-map panic that takes the pod
+      # down — and it reproduces roughly never on a developer laptop.
+      #
+      # -covermode=atomic rather than the default `set` because the race
+      # detector requires it. The profile is uploaded below rather than gated on
+      # a threshold: a number to look at during review, not a hurdle that makes
+      # honest work fail.
       - name: Run Go tests
-        run: go test ./...
+        run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
         env:
           TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
+
+      - name: Summarize coverage
+        if: always()
+        run: |
+          [ -f coverage.out ] || exit 0
+          go tool cover -func=coverage.out > coverage.txt
+          {
+            echo "### Go coverage"
+            echo
+            echo '```'
+            tail -n 1 coverage.txt
+            echo '```'
+            echo
+            echo "<details><summary>Per-function coverage</summary>"
+            echo
+            echo '```'
+            cat coverage.txt
+            echo '```'
+            echo
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage profile
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: go-coverage
+          path: |
+            coverage.out
+            coverage.txt
+          retention-days: 14
+          if-no-files-found: ignore
 
       # Client type errors were previously caught only inside the Docker build
       # (client "build" is "tsc -b && vite build"), which runs after
@@ -182,6 +227,45 @@ jobs:
       - name: Check i18n catalog parity
         run: npm run i18n:check
         working-directory: client
+
+  # Deliberately NOT in the `needs` chain of compute-version / build-and-push.
+  # govulncheck fails on vulnerabilities published upstream, which happens on
+  # the Go team's schedule and not this repo's: wiring it into the release path
+  # would mean a stdlib CVE announced at 03:00 blocks an unrelated hotfix from
+  # shipping, with nothing this repo can do about it until a patch release
+  # exists. As a standalone check it still shows a red X on the PR (and can be
+  # made a required check in branch protection) without holding deploys hostage.
+  vuln:
+    runs-on: ${{ github.ref == 'refs/heads/staging' && 'arc-runner' || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      # GOTOOLCHAIN=local is load-bearing, not tidiness. For `go install
+      # pkg@version` the toolchain is chosen from the *target* module's `go`
+      # directive, not from this repo's: x/vuln declares `go 1.25.0`, so the
+      # default `auto` announces "requires go >= 1.25.0; switching to go1.25.12"
+      # and builds govulncheck with Go 1.25. That binary then cannot load this
+      # module at all — every package fails with "requires newer Go version
+      # go1.26" and the step exits non-zero having scanned nothing, which is the
+      # worst failure mode available: a security gate that is red for a reason
+      # unrelated to security. `local` pins both the build and govulncheck's own
+      # `go list` subprocess to the toolchain setup-go installed from go.mod.
+      #
+      # govulncheck is call-graph aware: it reports only vulnerabilities that
+      # are actually reachable from this code, so a finding here is a genuine
+      # exposure rather than a transitive-dependency scare.
+      - name: Check for known vulnerabilities
+        env:
+          GOTOOLCHAIN: local
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+          govulncheck ./...
 
   e2e:
     # NOTE: deliberately NOT the

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,8 @@ blob-report/
 # Go binary
 /server
 
+# Coverage profiles, written by the same `go test` invocation CI runs
+coverage.out
+coverage.txt
+
 .superpowers/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ COPY client/ ./
 
 RUN npm run build
 
-FROM golang:1.26-alpine AS server
+# Pinned to the exact patch `go.mod` requires. With a floating `1.26-alpine`
+# tag, an image lagging that patch makes `go build` download a second toolchain
+# mid-build; a pinned tag keeps the builder hermetic. Renovate bumps this.
+FROM golang:1.26.5-alpine AS server
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module schautrack
 
-go 1.26.0
+go 1.26.5
 
 require (
 	github.com/alexedwards/argon2id v1.0.0


### PR DESCRIPTION
## Why

Three gaps in the Go side of CI, in descending order of how much they matter.

**1. `go test ./...` ran without `-race`.** Nearly everything concurrent in this app is invisible to a serial run: the SSE broker mutates per-user channel maps while Postgres `LISTEN`/`NOTIFY` delivery writes into the same structures, the settings cache flips shared state on its 1-minute TTL, and the rate limiters plus the login-failure tracker are touched from every request goroutine at once. A race there is not a red test — it is a wrong number served to a user, or a nil-map panic that fails a pod's readiness probe.

The suite passes clean under `-race` today, so this locks in a property that currently holds rather than papering over known breakage.

**2. No vulnerability scanning.** For an app doing WebAuthn, OIDC, TOTP, argon2 and session crypto, that is the gap worth closing first.

**3. No coverage signal at all.** Now uploaded as an artifact and summarised in the job summary. Deliberately **not** gated on a threshold — a number to look at during review, not a hurdle that makes honest work fail. Current total is **46.5%**.

## What govulncheck found

19 reachable stdlib vulnerabilities, all already fixed in patch releases that the pinned `go 1.26.0` predated:

| Package | Reachable via |
|---|---|
| `crypto/x509` | `StepUpHandler.PasskeyFinish` → `webauthn.FinishLogin` → `x509.Certificate.Verify` |
| `net/url` | `OIDCHandler.Callback` → `http.Redirect` |
| `net/http` | `server.main` → `ListenAndServe` |

govulncheck is call-graph aware, so these are paths this code actually reaches, not transitive noise.

`go.mod` moves `1.26.0` → `1.26.5`, which clears all 19 (verified: `No vulnerabilities found`). The `Dockerfile` builder is pinned from the floating `golang:1.26-alpine` to `golang:1.26.5-alpine` so the image cannot lag `go.mod` and silently download a second toolchain mid-build.

Note this only ever affected CI and the image builder, not a running deployment — `setup-go` installs exactly the `go.mod` version, which is what made 1.26.0 sticky.

## Two decisions worth a second opinion

- **`vuln` is a standalone job, not in the `needs` chain of `compute-version` / `build-and-push`.** Upstream CVEs land on the Go team's schedule, not this repo's; gating the release path would mean a stdlib CVE announced overnight blocks an unrelated hotfix, with nothing actionable here until a patch exists. It still shows a red X on the PR and can be made a required check in branch protection. Say the word if you'd rather it hard-gate.
- **`GOTOOLCHAIN: local` on that job is load-bearing.** For `go install pkg@version`, Go picks the toolchain from the *target* module's `go` directive — x/vuln declares `go 1.25.0`, so the default `auto` prints `switching to go1.25.12` and builds a govulncheck that then cannot load this 1.26 module at all, failing the step having scanned nothing. That is the worst failure mode for a security gate: red for a reason unrelated to security. `local` pins it to the toolchain `setup-go` installed.

## Verification

Run locally against Postgres 18, with the base toolchain and `PATH` arranged to match what `setup-go` provides:

- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test -race -covermode=atomic ./...` — all 14 packages pass, no races
- `go mod tidy` — no diff
- `govulncheck ./...` under the exact CI recipe — `No vulnerabilities found`
- `golang:1.26.5-alpine` — confirmed to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRz8xo2j5onYzoo7Tjg3hs