### PR TITLE
test(ci): add a golangci-lint gate and fix what it found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,37 @@ jobs:
         run: npm run i18n:check
         working-directory: client
 
+  # A real gate from the first commit, not `continue-on-error` like `e2e`: the
+  # tree is lint-clean as of this change, so there is no red-by-default period
+  # to wait out. It is in `compute-version`'s `needs:` for the same reason
+  # gofmt and go vet already are — those hard-gate the release chain today from
+  # inside the `test` job, and a linter that can be ignored is one nobody fixes.
+  #
+  # Separate job rather than another step in `test` so it runs in parallel with
+  # the tests (both take minutes, and a lint failure is usually the faster and
+  # clearer of the two answers) and reports as its own check.
+  lint:
+    runs-on: ${{ github.ref == 'refs/heads/staging' && 'arc-runner' || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          # The action manages its own analysis cache; setup-go's build cache
+          # on top of it only adds restore time here.
+          cache: false
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          # Pinned rather than floating: a linter that silently gains checks on
+          # its own release schedule turns an unrelated PR red for reasons its
+          # author did not introduce. Renovate bumps this deliberately.
+          version: v2.12.2
+
   e2e:
     # NOTE: deliberately NOT the
     # `${{ github.ref == 'refs/heads/staging' && 'arc-runner' || 'ubuntu-latest' }}`
@@ -294,7 +325,7 @@ jobs:
 
   compute-version:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, lint]
     # Deliberately not serialised: this job only *reads* git state. A group here
     # would be theatre — it is released the moment the job ends, several jobs
     # before create-tag writes anything. Job-level concurrency cannot span a

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,139 @@
+version: "2"
+
+# The CI job already enforces `gofmt -l` and `go vet ./...` separately, and both
+# stay there: they are the two checks worth running before the tests, and they
+# must not depend on this file parsing correctly.
+#
+# What this adds on top is the class neither catches — code that compiles, vets
+# clean, and is still wrong: an error dropped on the floor, a response body
+# never closed, a function nobody calls any more.
+
+linters:
+  # `standard` is errcheck + govet + ineffassign + staticcheck + unused.
+  default: standard
+
+  disable:
+    # TEMPORARY, and the only linter here that is off because of findings
+    # rather than fit. errcheck reports 19 unchecked errors in non-test code,
+    # and they are not noise — the notable ones are four unchecked `rows.Scan`
+    # calls in the todos handlers (a failed scan appends a row of zero values
+    # to the response instead of erroring), both `Store.Save` calls in the
+    # session middleware (a session that fails to persist looks like a
+    # successful login until the next request), and both `Destroy` calls on
+    # logout (a failed destroy leaves the row alive while the client is told it
+    # is signed out).
+    #
+    # Every one of those is a behaviour change to fix properly, with tests.
+    # Doing it here would bury three real bug fixes inside a config change and
+    # make this diff unreviewable. Re-enable in the follow-up that fixes them.
+    - errcheck
+
+  enable:
+    # Every one of these is here because the repo actually does the thing it
+    # catches, not for completeness.
+    - bodyclose # http.Response.Body leaks: barcode lookups + release checks
+    - copyloopvar # loop-variable capture, now that Go 1.22+ changed semantics
+    - durationcheck # time.Duration multiplied by a Duration — silently ns²
+    - errorlint # == on errors; breaks the moment anything wraps them
+    - makezero # append to a make([]T, n) slice, producing n leading zeros
+    - sqlclosecheck # rows/stmt never closed
+    - usetesting # t.Context()/t.Chdir over the hand-rolled equivalents
+
+  # Two linters were considered and deliberately left off:
+  #
+  #   nilerr — fires three times on session.Store.Load, where returning a fresh
+  #   session when the cookie lookup errors is the whole design: an unreadable
+  #   or expired cookie must yield a new anonymous session, not a 500. The
+  #   linter cannot tell that apart from a swallowed error, and silencing it
+  #   per-site would put three nolint directives on correct code.
+  #
+  #   noctx — ten findings, eight of them in tests where an unbounded request
+  #   to a local httptest server is fine. The one real finding (the SMTP dial
+  #   in service/email.go having no context, so a black-holed SMTP host hangs
+  #   the sending goroutine) is worth fixing, but it is a behaviour change to
+  #   the email path and belongs in its own reviewed commit, not smuggled in
+  #   under a lint config.
+
+  settings:
+    errcheck:
+      exclude-functions:
+        # Deferred rollback after a successful commit returns ErrTxClosed by
+        # design; the transaction is already resolved either way. Not covered
+        # by the std-error-handling preset below, which only knows `Close`.
+        - (github.com/jackc/pgx/v5.Tx).Rollback
+        # Writes to the client. By the time these fail the status line is long
+        # sent and the body is partly on the wire; the only honest response to
+        # a disconnected client is to stop, which returning already does.
+        - (*encoding/json.Encoder).Encode
+
+  exclusions:
+    generated: lax
+    # Covers the `.Close` / `.Flush` / `fmt.Print*` family — deferred cleanup
+    # whose failure is unactionable because the resource is being discarded
+    # regardless. Using the maintained preset rather than hand-listing every
+    # concrete Closer type keeps this from rotting each time a new one appears.
+    presets:
+      - std-error-handling
+    rules:
+      # These sentinels are the API's user-facing copy, surfaced verbatim to
+      # the client — see the comment above the var block in validate.go. Go's
+      # "no capital, no trailing period" convention is about error prose that
+      # gets wrapped and concatenated, which is the opposite of what these are.
+      - path: internal/handler/validate\.go
+        linters: [staticcheck]
+        text: "ST1005"
+
+      # This test deliberately parses the package's own source to assert a
+      # structural property of it. go/packages, the suggested replacement, does
+      # not apply: the test wants the raw AST of files on disk, not a loaded
+      # and type-checked package, and pulling in a type-checker to replace ten
+      # lines of parser call would make the test slower and no more correct.
+      - path: internal/middleware/links_test\.go
+        linters: [staticcheck]
+        text: "SA1019.*ParseDir"
+
+      # Test helpers routinely ignore errors from setup they have just asserted
+      # on, and a test that drops a real error fails on the assertion anyway.
+      - path: _test\.go
+        linters: [errcheck]
+
+      # All six findings in tests are false positives, in two flavours, and
+      # both are shapes bodyclose structurally cannot see through:
+      #
+      #   * v1_bodylimit_test.go closes via `t.Cleanup(func() {
+      #     resp.Body.Close() })` inside the shared `post` helper. The close is
+      #     real, it is just deferred into a closure the analysis does not
+      #     follow.
+      #   * store_test.go returns `httptest.ResponseRecorder.Result()`, whose
+      #     Body is a NopCloser over an in-memory buffer. There is no
+      #     connection to leak and Close does nothing.
+      #
+      # bodyclose stays enabled for non-test code, which is where a leaked
+      # response body actually exhausts the connection pool.
+      - path: _test\.go
+        linters: [bodyclose]
+
+      # `recover()` yields an `any`, not an `error`, so errors.Is does not even
+      # typecheck against it without an intervening assertion. Identity
+      # comparison is also precisely what net/http itself does with this
+      # sentinel (`err != ErrAbortHandler` in conn.serve), and an abort is
+      # panicked as the bare value — there is no wrapping for errors.Is to see
+      # through. Rewriting these would add an assertion that can only ever
+      # succeed, in the panic path, to satisfy a linter that is right in
+      # general and wrong here.
+      - path: internal/middleware/recovery(_test)?\.go
+        linters: [errorlint]
+        source: "ErrAbortHandler"
+
+issues:
+  # golangci-lint defaults to reporting at most 50 issues per linter and 3
+  # occurrences of the same issue. Both are display caps, not analysis limits:
+  # with them in place the run prints a plausible-looking summary while
+  # silently hiding the rest, which is exactly how a gate ends up green over
+  # code it never showed anyone. Report everything.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+formatters:
+  enable:
+    - gofmt

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -290,8 +290,7 @@ func main() {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
-		ctx := context.WithValue(r.Context(), "sseUserID", user.ID)
-		sseBroker.ServeHTTP(w, r.WithContext(ctx))
+		sseBroker.ServeHTTP(w, r.WithContext(sse.WithUserID(r.Context(), user.ID)))
 	})
 
 	// Todo routes

--- a/internal/handler/api.go
+++ b/internal/handler/api.go
@@ -222,13 +222,6 @@ func Settings(pool *pgxpool.Pool, adminEmail string, settingsCache *database.Set
 	}
 }
 
-func nilStr(s string) any {
-	if s == "" {
-		return nil
-	}
-	return s
-}
-
 func getTimezones() []string {
 	// Common IANA timezone list
 	zones := []string{

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -534,11 +534,6 @@ func (h *SettingsHandler) RegenerateBackupCodes(w http.ResponseWriter, r *http.R
 	JSON(w, http.StatusOK, map[string]any{"ok": true, "backupCodes": plainCodes})
 }
 
-// verifyAndUseBackupCode checks a backup code against stored hashes and marks it used atomically.
-func (h *SettingsHandler) verifyAndUseBackupCode(r *http.Request, userID int, code string) bool {
-	return verifyAndMarkBackupCode(r, h.Pool, userID, code)
-}
-
 // --- Links handler ---
 
 type LinksHandler struct {

--- a/internal/handler/v1_entries.go
+++ b/internal/handler/v1_entries.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -194,7 +195,7 @@ func (h *V1Handler) GetEntryV1(w http.ResponseWriter, r *http.Request) {
 
 	e, err := scanEntry(row, tgt.tz())
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			apierr.Write(w, r, apierr.NotFound("No entry with that id."))
 			return
 		}
@@ -472,7 +473,7 @@ func (h *V1Handler) UpdateEntryV1(w http.ResponseWriter, r *http.Request) {
 	tz := v1Tz(r)
 	e, err := scanEntry(tx.QueryRow(r.Context(), q, args...), tz)
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			apierr.Write(w, r, apierr.NotFound("No entry with that id."))
 			return
 		}

--- a/internal/handler/v1_foods.go
+++ b/internal/handler/v1_foods.go
@@ -308,7 +308,7 @@ func (h *V1Handler) UpdateSavedFoodV1(w http.ResponseWriter, r *http.Request) {
 		"UPDATE saved_foods SET %s WHERE id = $%d AND user_id = $%d RETURNING %s",
 		strings.Join(sets, ", "), len(args)-1, len(args), savedFoodSelect), args...))
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			apierr.Write(w, r, apierr.NotFound("No saved food with that id."))
 			return
 		}
@@ -403,7 +403,7 @@ func (h *V1Handler) TrackSavedFoodV1(w http.ResponseWriter, r *http.Request) {
 		`SELECT name, emoji, amount, protein_g, carbs_g, fat_g, fiber_g, sugar_g
 		 FROM saved_foods WHERE id = $1 AND user_id = $2`, id, user.ID,
 	).Scan(&name, &emoji, &amount, &protein, &carbs, &fat, &fiber, &sugar); err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			apierr.Write(w, r, apierr.NotFound("No saved food with that id."))
 			return
 		}

--- a/internal/handler/v1_misc.go
+++ b/internal/handler/v1_misc.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -154,7 +155,7 @@ func (h *V1Handler) GetNoteV1(w http.ResponseWriter, r *http.Request) {
 	err := h.Pool.QueryRow(r.Context(),
 		"SELECT content, updated_at FROM daily_notes WHERE user_id = $1 AND note_date = $2",
 		tgt.User.ID, date).Scan(&out.Content, &out.UpdatedAt)
-	if err != nil && err != pgx.ErrNoRows {
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		apierr.Write(w, r, dbFail("get note", err))
 		return
 	}

--- a/internal/handler/v1_todos.go
+++ b/internal/handler/v1_todos.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -347,7 +348,7 @@ func (h *V1Handler) UpdateTodoV1(w http.ResponseWriter, r *http.Request) {
 		"UPDATE todos SET %s WHERE id = $%d AND user_id = $%d AND archived = FALSE RETURNING %s",
 		strings.Join(sets, ", "), len(args)-1, len(args), todoSelect), args...))
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			apierr.Write(w, r, apierr.NotFound("No todo with that id."))
 			return
 		}

--- a/internal/middleware/apiauth.go
+++ b/internal/middleware/apiauth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"time"
@@ -49,7 +50,7 @@ func RequireAPIToken(pool *pgxpool.Pool) func(http.Handler) http.Handler {
 
 			token, err := service.AuthenticateAPIToken(r.Context(), pool, raw)
 			if err != nil {
-				if err != service.ErrTokenInvalid {
+				if !errors.Is(err, service.ErrTokenInvalid) {
 					slog.Error("api token lookup failed", "error", err)
 					apierr.Write(w, r, apierr.Internal("Could not verify the token."))
 					return

--- a/internal/service/captcha.go
+++ b/internal/service/captcha.go
@@ -119,8 +119,8 @@ func renderCaptchaSVG(text string) string {
 	height := 50
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d">`, width, height))
-	sb.WriteString(fmt.Sprintf(`<rect width="%d" height="%d" fill="#1a1a2e"/>`, width, height))
+	fmt.Fprintf(&sb, `<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d">`, width, height)
+	fmt.Fprintf(&sb, `<rect width="%d" height="%d" fill="#1a1a2e"/>`, width, height)
 
 	// Draw noise lines
 	colors := []string{"#4a4a6a", "#3a3a5a", "#5a5a7a", "#2a2a4a"}
@@ -129,8 +129,8 @@ func renderCaptchaSVG(text string) string {
 		y1 := randInt(0, height)
 		x2 := randInt(0, width)
 		y2 := randInt(0, height)
-		sb.WriteString(fmt.Sprintf(`<line x1="%d" y1="%d" x2="%d" y2="%d" stroke="%s" stroke-width="1"/>`,
-			x1, y1, x2, y2, colors[i%len(colors)]))
+		fmt.Fprintf(&sb, `<line x1="%d" y1="%d" x2="%d" y2="%d" stroke="%s" stroke-width="1"/>`,
+			x1, y1, x2, y2, colors[i%len(colors)])
 	}
 
 	// Draw characters
@@ -142,9 +142,9 @@ func renderCaptchaSVG(text string) string {
 		fontSize := 24 + randInt(-4, 4)
 		rotate := randInt(-15, 15)
 		color := charColors[i%len(charColors)]
-		sb.WriteString(fmt.Sprintf(
+		fmt.Fprintf(&sb,
 			`<text x="%d" y="%d" font-family="monospace" font-size="%d" fill="%s" transform="rotate(%d,%d,%d)" text-anchor="middle">%c</text>`,
-			x, y, fontSize, color, rotate, x, y, ch))
+			x, y, fontSize, color, rotate, x, y, ch)
 	}
 
 	sb.WriteString(`</svg>`)

--- a/internal/service/mathparser.go
+++ b/internal/service/mathparser.go
@@ -239,11 +239,11 @@ func (p *parser) parseFactor() float64 {
 func (p *parser) parseTerm() float64 {
 	left := p.parseFactor()
 	for p.err == nil && p.pos < len(p.expr) {
-		op := p.peek()
-		if op == '*' {
+		switch p.peek() {
+		case '*':
 			p.consume()
 			left *= p.parseFactor()
-		} else if op == '/' {
+		case '/':
 			p.consume()
 			right := p.parseFactor()
 			if right == 0 {
@@ -251,8 +251,8 @@ func (p *parser) parseTerm() float64 {
 				return 0
 			}
 			left /= right
-		} else {
-			break
+		default:
+			return left
 		}
 	}
 	return left
@@ -261,15 +261,15 @@ func (p *parser) parseTerm() float64 {
 func (p *parser) parseExpression() float64 {
 	left := p.parseTerm()
 	for p.err == nil && p.pos < len(p.expr) {
-		op := p.peek()
-		if op == '+' {
+		switch p.peek() {
+		case '+':
 			p.consume()
 			left += p.parseTerm()
-		} else if op == '-' {
+		case '-':
 			p.consume()
 			left -= p.parseTerm()
-		} else {
-			break
+		default:
+			return left
 		}
 	}
 	return left

--- a/internal/service/weight.go
+++ b/internal/service/weight.go
@@ -132,7 +132,7 @@ func GetWeightEntry(ctx context.Context, pool *pgxpool.Pool, userID int, dateStr
 		"SELECT "+weightColumns+" FROM weight_entries WHERE user_id = $1 AND entry_date = $2 LIMIT 1",
 		userID, dateStr).Scan(&w.ID, &w.Date, &w.Weight, &w.BodyFat, &w.CreatedAt, &w.UpdatedAt)
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
@@ -152,7 +152,7 @@ func GetLastWeightEntry(ctx context.Context, pool *pgxpool.Pool, userID int, bef
 	var w WeightResult
 	err := pool.QueryRow(ctx, query, args...).Scan(&w.ID, &w.Date, &w.Weight, &w.BodyFat, &w.CreatedAt, &w.UpdatedAt)
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
@@ -177,7 +177,7 @@ func GetLastBodyFatEntry(ctx context.Context, pool *pgxpool.Pool, userID int, be
 	var w WeightResult
 	err := pool.QueryRow(ctx, query, args...).Scan(&w.ID, &w.Date, &w.Weight, &w.BodyFat, &w.CreatedAt, &w.UpdatedAt)
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/service/weightgoal.go
+++ b/internal/service/weightgoal.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -44,7 +45,7 @@ func GetActiveGoal(ctx context.Context, pool *pgxpool.Pool, userID int) (*model.
 		userID)
 	g, err := scanWeightGoal(row)
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/session/deadline_test.go
+++ b/internal/session/deadline_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -45,6 +46,6 @@ func TestDeferredSaveWriterUnwrapReachesWriteDeadline(t *testing.T) {
 	if clearErr != nil {
 		t.Fatalf("SetWriteDeadline through deferredSaveWriter returned %v (ErrNotSupported=%v); "+
 			"the Unwrap chain is broken and SSE streams would be force-closed by WriteTimeout",
-			clearErr, clearErr == http.ErrNotSupported)
+			clearErr, errors.Is(clearErr, http.ErrNotSupported))
 	}
 }

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -147,7 +146,6 @@ type dbExecutor interface {
 type Store struct {
 	pool   dbExecutor
 	secret string
-	mu     sync.Mutex
 }
 
 func NewStore(pool *pgxpool.Pool, secret string) *Store {

--- a/internal/sse/broker.go
+++ b/internal/sse/broker.go
@@ -240,10 +240,26 @@ func (b *Broker) BroadcastLinkSharesChange(linkID, userID int, shares map[string
 	})
 }
 
+// userIDKey is the context key carrying the authenticated user ID into
+// ServeHTTP. It is an unexported zero-width struct type rather than a string:
+// a bare string key lives in the same namespace as every other package's
+// string keys, so any dependency storing "sseUserID" — for its own unrelated
+// purpose — would silently satisfy the type assertion below and hand this
+// handler someone else's user ID. A private type cannot collide by
+// construction.
+type userIDKey struct{}
+
+// WithUserID returns a context carrying the user ID that ServeHTTP will stream
+// events for. Callers must use this rather than setting the key themselves,
+// which is the point of keeping the key type unexported.
+func WithUserID(ctx context.Context, userID int) context.Context {
+	return context.WithValue(ctx, userIDKey{}, userID)
+}
+
 // ServeHTTP is the SSE endpoint handler.
 func (b *Broker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Get user ID from context (set by auth middleware)
-	userID, ok := r.Context().Value("sseUserID").(int)
+	userID, ok := r.Context().Value(userIDKey{}).(int)
 	if !ok {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return

--- a/internal/sse/broker_test.go
+++ b/internal/sse/broker_test.go
@@ -290,7 +290,9 @@ func TestServeHTTPRejectsNilContext(t *testing.T) {
 func TestServeHTTPRejectsWrongContextType(t *testing.T) {
 	b := newTestBroker()
 	req := httptest.NewRequest("GET", "/events", nil)
-	ctx := context.WithValue(req.Context(), "sseUserID", "not-an-int")
+	// Deliberately bypasses WithUserID to store a wrong-typed value under the
+	// real key — the case ServeHTTP's type assertion has to reject.
+	ctx := context.WithValue(req.Context(), userIDKey{}, "not-an-int")
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 


### PR DESCRIPTION
## Why

`gofmt -l` and `go vet ./...` already gate the build. Neither catches the class in between: code that compiles, vets clean, and is still wrong.

This adds `golangci-lint` with a curated set and fixes **every** finding, so the gate is green from its first commit. Unlike the `e2e` job, it is a real gate rather than `continue-on-error` — there is no red-by-default period to wait out, and a gate that starts red is one somebody deletes.

## The findings worth your attention

**1. Context-key collision on the SSE endpoint** (`SA1029`)

```go
ctx := context.WithValue(r.Context(), "sseUserID", user.ID)   // main.go
userID, ok := r.Context().Value("sseUserID").(int)            // broker.go
```

A bare `string` key shares one namespace with every other package in the binary. Any dependency that stores `"sseUserID"` — for its own unrelated purpose — satisfies that type assertion and hands the handler **someone else's user ID**. Replaced with an unexported `userIDKey struct{}` plus an `sse.WithUserID` constructor, which cannot collide by construction.

**2. Three pieces of dead code** (`unused`)

- `handler.nilStr`
- `SettingsHandler.verifyAndUseBackupCode` — a wrapper around `verifyAndMarkBackupCode` that nothing calls
- an unused `sync.Mutex` on `session.Store` (nothing locked it; `-race` agrees there is no shared mutable state to protect)

**3. Nine `err == pgx.ErrNoRows` comparisons** (`errorlint`) that stop working silently the moment anything wraps the error. Converted to `errors.Is`.

## The default caps hide findings

`max-issues-per-linter` and `max-same-issues` default to 50 and **3**. The first run here reported 3 `errorlint` and 3 `bodyclose` findings when the real numbers were **9** and **6**. Both are set to `0`. A summary that truncates is how a gate ends up green over code it never showed anyone — worth knowing if you add linters later.

## errcheck is deliberately disabled, temporarily

It reports **19 unchecked errors in non-test code**, and they are not noise:

| Site | Consequence |
|---|---|
| 4× `rows.Scan` in the todos handlers | a failed scan appends a row of **zero values** to the response instead of erroring |
| 2× `Store.Save` in the session middleware | a session that fails to persist looks like a successful login until the next request |
| 2× `Destroy` on logout | a failed destroy leaves the session row alive while the client is told it is signed out |

Each is a behaviour change that needs tests. Fixing them here would bury three real bug fixes inside a config diff. I'll send that as its own PR and re-enable the linter there — flagging it now so it doesn't look like an oversight.

Two other linters were considered and left off, with reasoning in the config: `nilerr` (fires on `session.Store.Load`, where returning a fresh session on a bad cookie is the whole design) and `noctx` (8 of 10 findings are tests; the one real finding — the SMTP dial having no context, so a black-holed host hangs the sending goroutine — is a behaviour change for its own commit).

Every exclusion in `.golangci.yml` carries its justification inline, including the two false-positive shapes `bodyclose` cannot see through in tests.

## Verification

- `golangci-lint run` — **0 issues**
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test -race ./...` against Postgres 18 — all 14 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRz8xo2j5onYzoo7Tjg3hs