### PR TITLE
test: drive the background loops with testing/synctest

### DIFF
--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -70,7 +71,7 @@ func NewRateLimiter(max int, window time.Duration, trustProxy bool) *RateLimiter
 		trustProxy: trustProxy,
 		reject:     rejectJSON,
 	}
-	go rl.cleanup()
+	go rl.cleanup(context.Background())
 	return rl
 }
 
@@ -129,18 +130,30 @@ func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
 	})
 }
 
-func (rl *RateLimiter) cleanup() {
+// cleanup evicts entries whose window has fully elapsed, once a minute, until
+// its context is cancelled.
+//
+// The context exists so the loop has a shutdown path and so it can be tested:
+// a loop that only ever returns when the process exits cannot be driven by a
+// test that has to wait for every goroutine it started to finish. The
+// constructors pass context.Background(), which is the previous behaviour.
+func (rl *RateLimiter) cleanup(ctx context.Context) {
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
-	for range ticker.C {
-		rl.mu.Lock()
-		now := time.Now()
-		for ip, entry := range rl.entries {
-			if now.Sub(entry.windowStart) > rl.window {
-				delete(rl.entries, ip)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			rl.mu.Lock()
+			now := time.Now()
+			for ip, entry := range rl.entries {
+				if now.Sub(entry.windowStart) > rl.window {
+					delete(rl.entries, ip)
+				}
 			}
+			rl.mu.Unlock()
 		}
-		rl.mu.Unlock()
 	}
 }
 

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -114,47 +115,122 @@ func TestRateLimiter_DifferentIPsIndependent(t *testing.T) {
 	}
 }
 
+// TestRateLimiter_ResetsAfterWindow runs under synctest so it can use the real
+// production window (RATE_LIMIT_AUTH defaults to 10 attempts per 15 minutes)
+// instead of the 50ms stand-in it used before, and still finish instantly.
+//
+// That matters for more than speed. The old test slept 60ms for a 50ms window,
+// which asserts "somewhere in that 10ms of slack the window reopened" — it
+// could not tell a window that resets at exactly `window` from one that resets
+// at `window + 9ms`, and on a loaded runner a 60ms sleep that lands late is a
+// flake. With a fake clock the boundary is exact, so the two assertions below
+// pin the actual contract: still blocked AT the window, open just past it.
 func TestRateLimiter_ResetsAfterWindow(t *testing.T) {
-	rl := &RateLimiter{
-		entries:    make(map[string]*rateLimitEntry),
-		max:        1,
-		window:     50 * time.Millisecond,
-		maxEntries: defaultMaxEntries,
-	}
+	synctest.Test(t, func(t *testing.T) {
+		const window = 15 * time.Minute
+		rl := &RateLimiter{
+			entries:    make(map[string]*rateLimitEntry),
+			max:        1,
+			window:     window,
+			maxEntries: defaultMaxEntries,
+		}
 
-	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+		handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
 
-	// First request succeeds
-	r1 := httptest.NewRequest("GET", "/", nil)
-	r1.RemoteAddr = "10.0.0.1:12345"
-	w1 := httptest.NewRecorder()
-	handler.ServeHTTP(w1, r1)
-	if w1.Code != http.StatusOK {
-		t.Errorf("first request: status = %d, want %d", w1.Code, http.StatusOK)
-	}
+		do := func() int {
+			r := httptest.NewRequest("GET", "/", nil)
+			r.RemoteAddr = "10.0.0.1:12345"
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, r)
+			return w.Code
+		}
 
-	// Second request is blocked
-	r2 := httptest.NewRequest("GET", "/", nil)
-	r2.RemoteAddr = "10.0.0.1:12345"
-	w2 := httptest.NewRecorder()
-	handler.ServeHTTP(w2, r2)
-	if w2.Code != http.StatusTooManyRequests {
-		t.Errorf("second request: status = %d, want %d", w2.Code, http.StatusTooManyRequests)
-	}
+		if got := do(); got != http.StatusOK {
+			t.Errorf("first request: status = %d, want %d", got, http.StatusOK)
+		}
+		if got := do(); got != http.StatusTooManyRequests {
+			t.Errorf("second request: status = %d, want %d", got, http.StatusTooManyRequests)
+		}
 
-	// Wait for window to expire
-	time.Sleep(60 * time.Millisecond)
+		// The reset test is `now.Sub(windowStart) > rl.window`, strictly
+		// greater — so at exactly the window boundary the caller is still
+		// blocked. Asserting this direction is what stops the comparison being
+		// silently loosened to >=, which would let a caller through a full
+		// window early on every cycle.
+		time.Sleep(window)
+		if got := do(); got != http.StatusTooManyRequests {
+			t.Errorf("at exactly the window boundary: status = %d, want %d — the window reopened early",
+				got, http.StatusTooManyRequests)
+		}
 
-	// Third request should succeed (window reset)
-	r3 := httptest.NewRequest("GET", "/", nil)
-	r3.RemoteAddr = "10.0.0.1:12345"
-	w3 := httptest.NewRecorder()
-	handler.ServeHTTP(w3, r3)
-	if w3.Code != http.StatusOK {
-		t.Errorf("post-window request: status = %d, want %d", w3.Code, http.StatusOK)
-	}
+		// One nanosecond past it, the window is genuinely over. A fake clock
+		// makes a one-nanosecond assertion meaningful; a real one could not
+		// resolve it.
+		time.Sleep(time.Nanosecond)
+		if got := do(); got != http.StatusOK {
+			t.Errorf("just past the window: status = %d, want %d — the window never reopened",
+				got, http.StatusOK)
+		}
+	})
+}
+
+// TestRateLimiterCleanupEvictsElapsedEntries covers the eviction loop, which
+// had no test before: it is a bare `for range ticker.C` on a one-minute
+// ticker, so driving even a single iteration meant a one-minute test.
+//
+// It is the only thing bounding the limiter's memory below maxEntries. If it
+// stopped running, entries would accumulate one per unique client IP until the
+// 10k cap, at which point NewRateLimiter starts rejecting *unseen* IPs
+// outright — a slow drift into refusing legitimate traffic that no
+// single-request test would notice.
+func TestRateLimiterCleanupEvictsElapsedEntries(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const window = 15 * time.Minute
+		rl := &RateLimiter{
+			entries:    make(map[string]*rateLimitEntry),
+			max:        1,
+			window:     window,
+			maxEntries: defaultMaxEntries,
+		}
+
+		go rl.cleanup(t.Context())
+
+		handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		r := httptest.NewRequest("GET", "/", nil)
+		r.RemoteAddr = "10.0.0.1:12345"
+		handler.ServeHTTP(httptest.NewRecorder(), r)
+
+		entries := func() int {
+			rl.mu.Lock()
+			defer rl.mu.Unlock()
+			return len(rl.entries)
+		}
+
+		if got := entries(); got != 1 {
+			t.Fatalf("tracked entries after one request = %d, want 1", got)
+		}
+
+		// A tick while the entry's window is still open must not evict it —
+		// otherwise the limiter would forget callers mid-window and the cap
+		// would not hold.
+		time.Sleep(time.Minute)
+		synctest.Wait()
+		if got := entries(); got != 1 {
+			t.Fatalf("entry evicted while its window was still open: %d entries, want 1", got)
+		}
+
+		// Once the window has fully elapsed, the next tick must drop it.
+		time.Sleep(window)
+		synctest.Wait()
+		if got := entries(); got != 0 {
+			t.Fatalf("entry survived %v past its window: %d entries, want 0 — "+
+				"the map grows without bound if eviction stops", window, got)
+		}
+	})
 }
 
 func TestRateLimiter_XForwardedFor(t *testing.T) {

--- a/internal/session/prune_test.go
+++ b/internal/session/prune_test.go
@@ -1,0 +1,106 @@
+package session
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+// The prune loop had no tests at all before these, and the reason was purely
+// mechanical: PruneInterval is five minutes, so asserting that a second tick
+// happens meant a ten-minute test. Under synctest the clock is fake and only
+// advances once every goroutine in the bubble is durably blocked, so the same
+// assertions run instantly and — more importantly — deterministically. There
+// is no sleep-and-hope margin to tune, and nothing to go flaky on a loaded CI
+// runner.
+//
+// What is being protected: expired rows are what stop the "session" table
+// growing without bound. Every cookie-less request that does write session
+// data leaves a row behind, and only this loop removes them. If it silently
+// stopped ticking, nothing would fail — the table would just grow until
+// queries against it slowed down in production.
+
+func TestPruneLoopDeletesExpiredSessionsOnEveryTick(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		db := &fakeDB{}
+		s := &Store{pool: db}
+
+		go s.pruneLoop(t.Context())
+
+		// Nothing may be deleted before the first interval elapses. Wait for
+		// the loop to reach its blocking select first, otherwise this asserts
+		// against a goroutine that has not started yet and would pass even if
+		// the loop pruned immediately.
+		synctest.Wait()
+		if got := len(db.recorded()); got != 0 {
+			t.Fatalf("prune ran %d times before the first interval elapsed, want 0", got)
+		}
+
+		// Advancing to exactly the interval is enough: the fake clock fires
+		// the ticker at PruneInterval, not at PruneInterval+ε.
+		time.Sleep(PruneInterval)
+		synctest.Wait()
+
+		execs := db.recorded()
+		if len(execs) != 1 {
+			t.Fatalf("after one interval the loop ran %d times, want exactly 1: %v", len(execs), execs)
+		}
+		if !strings.Contains(execs[0], `DELETE FROM "session"`) {
+			t.Errorf("statement = %q, want a DELETE against the session table", execs[0])
+		}
+		if !strings.Contains(execs[0], "expire < NOW()") {
+			t.Errorf("statement = %q, want it bounded by expire < NOW() — an unbounded DELETE "+
+				"would sign out every logged-in user", execs[0])
+		}
+
+		// A ticker that fires once and stops looks identical to a working one
+		// in any single-tick test, so assert the loop keeps going.
+		time.Sleep(3 * PruneInterval)
+		synctest.Wait()
+		if got := len(db.recorded()); got != 4 {
+			t.Fatalf("after four intervals the loop ran %d times, want 4 — the ticker stopped firing", got)
+		}
+	})
+}
+
+// A cancelled context must stop the loop. This is what lets the bubble above
+// finish (synctest.Test waits for every goroutine to exit, and a loop that
+// ignored cancellation would deadlock the test rather than leak silently), and
+// in production it is the shutdown path the loop previously did not have.
+func TestPruneLoopStopsOnContextCancel(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		db := &fakeDB{}
+		s := &Store{pool: db}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			s.pruneLoop(ctx)
+		}()
+
+		time.Sleep(PruneInterval)
+		synctest.Wait()
+		if got := len(db.recorded()); got != 1 {
+			t.Fatalf("prune ran %d times before cancellation, want 1", got)
+		}
+
+		cancel()
+		synctest.Wait()
+
+		select {
+		case <-done:
+		default:
+			t.Fatal("pruneLoop is still running after its context was cancelled")
+		}
+
+		// No further pruning after cancellation, however much time passes.
+		time.Sleep(10 * PruneInterval)
+		synctest.Wait()
+		if got := len(db.recorded()); got != 1 {
+			t.Fatalf("prune ran %d times after cancellation, want it to stay at 1", got)
+		}
+	})
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -152,7 +152,7 @@ type Store struct {
 
 func NewStore(pool *pgxpool.Pool, secret string) *Store {
 	s := &Store{pool: pool, secret: secret}
-	go s.pruneLoop()
+	go s.pruneLoop(context.Background())
 	return s
 }
 
@@ -312,15 +312,28 @@ func (s *Store) setCookie(w http.ResponseWriter, r *http.Request, sess *Session)
 	})
 }
 
-func (s *Store) pruneLoop() {
+// pruneLoop deletes expired session rows every PruneInterval until stopped.
+//
+// It takes a context rather than looping forever so it has a shutdown path:
+// NewStore passes context.Background(), preserving the previous
+// runs-for-the-process-lifetime behaviour, while tests can pass a context they
+// cancel. Without that, the loop is untestable — a bubbled test would wait on
+// a goroutine that never exits, and an unbubbled one would wait five real
+// minutes for the first tick.
+func (s *Store) pruneLoop(ctx context.Context) {
 	ticker := time.NewTicker(PruneInterval)
 	defer ticker.Stop()
-	for range ticker.C {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		if _, err := s.pool.Exec(ctx, `DELETE FROM "session" WHERE expire < NOW()`); err != nil {
-			slog.Error("failed to prune expired sessions", "error", err)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			execCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			if _, err := s.pool.Exec(execCtx, `DELETE FROM "session" WHERE expire < NOW()`); err != nil {
+				slog.Error("failed to prune expired sessions", "error", err)
+			}
+			cancel()
 		}
-		cancel()
 	}
 }
 


### PR DESCRIPTION
## Why

Two background loops had **no tests at all**, for the same mechanical reason: both are `for range ticker.C` on intervals of minutes, so asserting one iteration meant a test that waits minutes, and asserting a *second* one meant a test nobody would ever run.

| Loop | Interval | What it is the only guard against |
|---|---|---|
| `session.Store.pruneLoop` | 5 min | expired rows accumulating in the `"session"` table |
| `middleware.RateLimiter.cleanup` | 1 min | the limiter's IP map growing until the 10k `maxEntries` cap |

Both failure modes are silent. If the prune loop stops, nothing goes red — the table just grows until queries slow down in production. If the cleanup loop stops, entries accumulate one per unique client IP until the cap, at which point the limiter starts rejecting **unseen** IPs outright: a slow drift into refusing legitimate traffic that no single-request test would notice.

`testing/synctest` (stable since Go 1.25) makes both testable. The clock inside a bubble is fake and only advances once every goroutine is durably blocked, so a 20-minute span asserts in 0.00s and — more importantly — deterministically.

## The production change, and why it's needed

Both loops now take a `context.Context` instead of looping forever:

```go
func (s *Store) pruneLoop(ctx context.Context) {
	for {
		select {
		case <-ctx.Done():
			return
		case <-ticker.C:
			...
```

This is not test-only scaffolding. `synctest.Test` waits for every goroutine in the bubble to exit, so a loop with no exit **deadlocks the test** rather than leaking quietly — the untestability and the missing shutdown path are the same defect. The constructors pass `context.Background()`, so runtime behaviour is unchanged.

## A better assertion, not just a faster one

`TestRateLimiter_ResetsAfterWindow` used to configure a 50ms window and sleep 60ms. That asserts only *"somewhere in that 10ms of slack the window reopened"* — it cannot distinguish a window resetting at exactly `window` from one resetting 9ms later, and a 60ms sleep landing late on a loaded runner is a flake.

It now uses the **real 15-minute production window** and pins the boundary exactly:

- at exactly `window` → still `429` (the check is `>`, strictly greater)
- one nanosecond later → `200`

A one-nanosecond assertion is meaningful against a fake clock and impossible against a real one. It also stops the comparison being silently loosened to `>=`, which would let every caller through a full window early on each cycle.

## Verification

Every new assertion was **mutation-tested** — each of these fails the corresponding test:

| Mutation | Caught by |
|---|---|
| prune loop returns after one tick | `after four intervals the loop ran 1 times, want 4` |
| remove the `ctx.Done()` case | `still running after its context was cancelled` + bubble deadlock |
| window comparison `>` → `>=` | `at exactly the window boundary: status = 200, want 429` |
| eviction threshold 1000× too large | `entry survived 15m0s past its window` |

Full suite: `go test -race ./...` against Postgres 18 — all 14 packages pass. `gofmt -l` and `go vet ./...` clean. The four new tests run in 0.00s.

## Not included

The settings cache TTL (`internal/database/settings.go`, 1 minute) is the obvious third candidate, but `SettingsCache` holds a concrete `*pgxpool.Pool` and returns early when it is nil, so there is no seam to test expiry through without introducing an interface. That is a production refactor rather than a test change, so I left it out — happy to do it separately if you want the coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRz8xo2j5onYzoo7Tjg3hs