### PR TITLE
test(api): property-test /api/v1 against its own OpenAPI document

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ on:
       - 'playwright.config.ts'
       - 'package.json'
       - 'package-lock.json'
+      # The contract suite lives here; same reasoning as the e2e paths above.
+      - 'scripts/**'
+      - 'api/openapi.json'
     tags:
       - 'v*'
   pull_request:
@@ -49,6 +52,8 @@ on:
       - 'playwright.config.ts'
       - 'package.json'
       - 'package-lock.json'
+      - 'scripts/**'
+      - 'api/openapi.json'
 
 # One concurrency group per COMMIT, not per ref.
 #
@@ -182,6 +187,34 @@ jobs:
       - name: Check i18n catalog parity
         run: npm run i18n:check
         working-directory: client
+
+  contract:
+    # Same runner reasoning as `e2e` below: this builds and runs the compose
+    # stack, which the memory-limited single-slot arc-runner cannot host
+    # without serialising the whole pipeline behind it.
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      # No Go or Node step: the script talks to the stack over HTTP and seeds
+      # its token with psql inside the db container. Everything it needs is
+      # docker, curl and uv.
+      - name: Run OpenAPI contract tests
+        run: npm run test:contract
+
+      - name: Upload contract report
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: contract-report
+          path: contract-report.xml
+          retention-days: 14
+          if-no-files-found: ignore
 
   e2e:
     # NOTE: deliberately NOT the

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ blob-report/
 /server
 
 .superpowers/
+
+# Schemathesis contract-test report
+contract-report.xml
+.schemathesis/

--- a/internal/handler/v1_common.go
+++ b/internal/handler/v1_common.go
@@ -263,8 +263,8 @@ func pathDate(r *http.Request) (string, *apierr.Problem) {
 
 // pathID reads and validates a positive integer path parameter.
 func pathID(r *http.Request) (int, *apierr.Problem) {
-	id, err := strconv.Atoi(chi.URLParam(r, "id"))
-	if err != nil || id <= 0 {
+	id, ok := model.ParseID(chi.URLParam(r, "id"))
+	if !ok {
 		return 0, apierr.BadRequest("The id must be a positive integer.")
 	}
 	return id, nil
@@ -333,8 +333,8 @@ func decodeCursor(s string) (cursor, error) {
 	if !ok || !isValidDate(date) {
 		return cursor{}, errors.New("malformed cursor")
 	}
-	id, err := strconv.Atoi(idStr)
-	if err != nil || id <= 0 {
+	id, ok := model.ParseID(idStr)
+	if !ok {
 		return cursor{}, errors.New("malformed cursor")
 	}
 	return cursor{Date: date, ID: id}, nil

--- a/internal/handler/v1_common_fuzz_test.go
+++ b/internal/handler/v1_common_fuzz_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"schautrack/internal/apierr"
+	"schautrack/internal/model"
 )
 
 // FuzzDecodeCursor drives the keyset pagination cursor through both
@@ -75,7 +76,12 @@ func FuzzDecodeCursor(f *testing.F) {
 		// these are round-trippable — encodeCursor has no validation of its
 		// own, and a caller that fabricates an invalid one is out of contract.
 		c := cursor{Date: date, ID: id}
-		if !isValidDate(c.Date) || c.ID <= 0 {
+		// model.MaxID bounds the round-trippable domain for the same reason
+		// c.ID <= 0 does: a cursor id names a row, every id column is int4, so
+		// an id beyond that names nothing the encoder could have produced. It
+		// is now rejected at decode rather than reaching pgx, which used to
+		// turn a fabricated cursor into a 500.
+		if !isValidDate(c.Date) || c.ID <= 0 || c.ID > model.MaxID {
 			return
 		}
 		back, err := decodeCursor(encodeCursor(c))

--- a/internal/handler/v1_common_test.go
+++ b/internal/handler/v1_common_test.go
@@ -701,7 +701,11 @@ func TestCursorRoundTrip(t *testing.T) {
 		"1900-01-01", "1999-12-31", "2000-01-01", "2024-02-29",
 		"2026-01-01", "2026-07-03", "2026-12-31", "2200-12-31",
 	}
-	ids := []int{1, 2, 9, 42, 999, 100000, math.MaxInt32, math.MaxInt}
+	// math.MaxInt32 is the top of the range, not math.MaxInt: a cursor id names
+	// a row, and every id column in this schema is int4. decodeCursor now
+	// rejects anything larger rather than passing it to pgx, which turned a
+	// fabricated cursor into a 500 instead of a 400.
+	ids := []int{1, 2, 9, 42, 999, 100000, math.MaxInt32 - 1, math.MaxInt32}
 
 	for _, d := range dates {
 		for _, id := range ids {

--- a/internal/handler/v1_idempotency.go
+++ b/internal/handler/v1_idempotency.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -92,6 +94,22 @@ func (h *V1Handler) withIdempotency(next http.HandlerFunc) http.HandlerFunc {
 		if len(key) > maxIdempotencyKeyLen {
 			apierr.Write(w, r, apierr.BadRequest(
 				"The Idempotency-Key header is too long (maximum 255 characters)."))
+			return
+		}
+
+		// The same defect #378 fixed for JSON bodies, on the one input path
+		// that fix did not cover. The key goes straight into a TEXT column, and
+		// Postgres TEXT holds neither invalid UTF-8 nor a NUL — either one
+		// fails the INSERT with SQLSTATE 22021, which dbFail turns into a 500
+		// for a request that is entirely the caller's fault.
+		//
+		// Headers are raw bytes, so unlike a JSON body there is no decoder in
+		// front of this to reject the input first: Go hands over whatever
+		// arrived on the wire. Found by the contract fuzzer, which sends
+		// arbitrary bytes in every header the document declares.
+		if !utf8.ValidString(key) || strings.ContainsRune(key, 0) {
+			apierr.Write(w, r, apierr.BadRequest(
+				"The Idempotency-Key header must be valid UTF-8 and cannot contain NUL characters."))
 			return
 		}
 

--- a/internal/handler/v1_links.go
+++ b/internal/handler/v1_links.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -118,8 +117,8 @@ func (h *V1Handler) resolveTarget(r *http.Request, category string) (target, *ap
 		return target{User: user, IsSelf: true}, nil
 	}
 
-	id, err := strconv.Atoi(raw)
-	if err != nil || id <= 0 {
+	id, ok := model.ParseID(raw)
+	if !ok {
 		return target{}, apierr.BadRequest(`"user" must be the user_id of a linked account, from GET /api/v1/links.`)
 	}
 	if id == user.ID {
@@ -132,7 +131,7 @@ func (h *V1Handler) resolveTarget(r *http.Request, category string) (target, *ap
 	}
 
 	var shared bool
-	err = h.Pool.QueryRow(r.Context(), `
+	err := h.Pool.QueryRow(r.Context(), `
 		SELECT COALESCE(
 			(CASE WHEN requester_id = $2 THEN requester_shares ELSE target_shares END ->> $3)::boolean,
 			false)

--- a/internal/middleware/links.go
+++ b/internal/middleware/links.go
@@ -47,6 +47,7 @@ func RequireLinkAuth(pool *pgxpool.Pool, category string) func(http.Handler) htt
 			// it means is the actual defect. Matching the stricter one costs a
 			// caller one obvious error instead of one wrong answer.
 			targetUserID := currentUser.ID
+			tooLargeForAnyRow := false
 			if userParam := r.URL.Query().Get("user"); userParam != "" {
 				id, err := strconv.Atoi(userParam)
 				if err != nil || id <= 0 {
@@ -58,6 +59,21 @@ func RequireLinkAuth(pool *pgxpool.Pool, category string) func(http.Handler) htt
 					})
 					return
 				}
+				// A positive id larger than an int4 column can hold names no
+				// account that could ever exist — but it is still a well-formed
+				// id from the caller's point of view, so it must be DENIED like
+				// any other unreachable account rather than 400'd. Answering 400
+				// here would hand a caller an oracle for the id space, which is
+				// exactly the distinction "denial is indistinguishable across
+				// causes" exists to prevent.
+				//
+				// It cannot simply be passed through either: pgx would fail to
+				// encode it into int4 and the request would 500 (found by the
+				// contract fuzzer). Flagging it routes it to the same denial
+				// branch without touching the database.
+				if id > model.MaxID {
+					tooLargeForAnyRow = true
+				}
 				targetUserID = id
 			}
 
@@ -66,8 +82,10 @@ func RequireLinkAuth(pool *pgxpool.Pool, category string) func(http.Handler) htt
 			if targetUserID != currentUser.ID {
 				// Load target user
 				var err error
-				targetUser, err = GetUserByID(r.Context(), pool, targetUserID)
-				if err != nil || targetUser == nil {
+				if !tooLargeForAnyRow {
+					targetUser, err = GetUserByID(r.Context(), pool, targetUserID)
+				}
+				if tooLargeForAnyRow || err != nil || targetUser == nil {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusForbidden)
 					json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "Not authorized"})

--- a/internal/model/id.go
+++ b/internal/model/id.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"math"
+	"strconv"
+)
+
+// MaxID is the largest value any id in this schema can hold.
+//
+// Every id column is SERIAL or INTEGER — Postgres int4 — including users.id
+// and every table that references it. pgx encodes a Go int into that column as
+// int4, so a larger value is not a row that does not exist: it is an encoding
+// error from the driver, which surfaces as a 500.
+const MaxID = math.MaxInt32
+
+// ParseID parses a user-supplied identifier, rejecting anything that is not a
+// positive value an int4 column can hold.
+//
+// The bound is the point. strconv.Atoi returns a 64-bit int on every platform
+// this runs on, so "34359738367" parses cleanly and passes a `> 0` check, then
+// reaches the database and fails there with
+//
+//	unable to encode 34359738367 into binary format for int4 (OID 23)
+//
+// turning what should be a 404 for a nonexistent row into a 500 with a stack
+// of driver internals in the log. Found by the OpenAPI contract fuzzer, which
+// generates exactly this kind of boundary value.
+func ParseID(s string) (int, bool) {
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 || n > MaxID {
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/model/id_test.go
+++ b/internal/model/id_test.go
@@ -1,0 +1,50 @@
+package model
+
+import (
+	"strconv"
+	"testing"
+)
+
+// TestParseIDRejectsValuesTooLargeForInt4 is the regression test for the bug
+// the OpenAPI contract fuzzer found: an id above int4's range parsed cleanly,
+// passed a `> 0` check, and only failed at the driver, producing a 500 where a
+// 404 belongs.
+func TestParseIDRejectsValuesTooLargeForInt4(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+		ok   bool
+	}{
+		{"a normal id", "42", 42, true},
+		{"the smallest valid id", "1", 1, true},
+		{"the largest value int4 holds", strconv.Itoa(MaxID), MaxID, true},
+
+		// The regression. Each of these previously reached Postgres and came
+		// back as "unable to encode N into binary format for int4 (OID 23)".
+		{"one past int4", strconv.Itoa(MaxID + 1), 0, false},
+		{"the id from DELETE /entries/{id}", "34359738367", 0, false},
+		{"the user param from GET /todos", "1248349573196321792", 0, false},
+		{"the id from POST /saved-foods/{id}/track", "2403310975", 0, false},
+
+		{"zero", "0", 0, false},
+		{"negative", "-1", 0, false},
+		{"empty", "", 0, false},
+		{"not a number", "abc", 0, false},
+		{"float", "1.5", 0, false},
+		{"leading plus is not an id", "+1", 1, true}, // strconv.Atoi accepts it; harmless
+		{"beyond int64 entirely", "99999999999999999999999", 0, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseID(tc.in)
+			if ok != tc.ok {
+				t.Fatalf("ParseID(%q) ok = %v, want %v", tc.in, ok, tc.ok)
+			}
+			if got != tc.want {
+				t.Errorf("ParseID(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test:e2e": "sh scripts/e2e.sh",
     "test:e2e:ui": "sh scripts/e2e.sh --ui",
     "test:e2e:setup": "docker compose -f compose.test.yml down -v; docker compose -f compose.test.yml up -d --build --wait && npx tsx e2e/setup-test-user.ts",
-    "test:e2e:down": "docker compose -f compose.test.yml down -v"
+    "test:e2e:down": "docker compose -f compose.test.yml down -v",
+    "test:contract": "sh scripts/api-contract-test.sh"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/scripts/api-contract-test.sh
+++ b/scripts/api-contract-test.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# Property-test /api/v1 against its own OpenAPI document with Schemathesis.
+#
+#   npm run test:contract          -> brings the stack up, runs, tears it down
+#   KEEP_STACK=1 npm run test:contract
+#   API_CONTRACT_BASE=... TOKEN=... sh scripts/api-contract-test.sh   (bring your own)
+#
+# Why this exists as a separate suite:
+#
+# The Go tests assert the endpoints this repo thought to write a test for, with
+# the payloads it thought to send. `TestV1RoutesMatchSpec` already guarantees
+# the route table and api/openapi.json describe the same set of endpoints — but
+# agreeing on which endpoints exist says nothing about whether the *responses*
+# match the schemas the document promises. That gap is where a client written
+# against the published spec breaks.
+#
+# Schemathesis reads the committed document and generates requests from it:
+# every parameter at its boundaries, every declared type violated in turn,
+# every optional field present and absent. It then checks each response against
+# the schema the document declares for that status code. What it reliably finds
+# is the class no hand-written test covers — a 500 on input the spec says is
+# legal, a response shape that drifted from its schema, a status code the
+# document never mentions.
+#
+# It runs against the compose.test.yml stack rather than a Go httptest server
+# because the contract belongs to the deployed thing: middleware ordering, the
+# body-size caps, the rate limiters and the problem+json error writer are all
+# part of what a client sees, and none of them are exercised by calling a
+# handler directly.
+
+set -e
+cd "$(dirname "$0")/.." || exit 1
+
+COMPOSE="docker compose -f compose.test.yml"
+BASE="${API_CONTRACT_BASE:-http://localhost:3001}"
+DB_USER="${POSTGRES_USER:-schautrack}"
+DB_NAME="${POSTGRES_DB:-schautrack}"
+OWN_STACK=0
+
+teardown() {
+  if [ "$OWN_STACK" = "1" ] && [ -z "$KEEP_STACK" ]; then
+    echo "==> tearing down the test stack"
+    $COMPOSE down || true
+  fi
+}
+trap teardown EXIT INT TERM
+
+if [ -z "$TOKEN" ]; then
+  if ! curl -fsS "$BASE/api/health" >/dev/null 2>&1; then
+    echo "==> starting the test stack"
+    $COMPOSE down -v >/dev/null 2>&1 || true
+    $COMPOSE up -d --build --wait
+    OWN_STACK=1
+  fi
+
+  DB_CONTAINER=$($COMPOSE ps -q db)
+  [ -n "$DB_CONTAINER" ] || { echo "could not find the db container" >&2; exit 1; }
+
+  psql() { docker exec -i "$DB_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -tA; }
+
+  # Mint the token here rather than through the UI. Token creation is
+  # step-up gated on purpose (a token that could mint another token would turn
+  # one leaked read-only token into a permanent full-scope one), so driving it
+  # over HTTP means a login plus a step-up dance for no benefit — the thing
+  # under test is /api/v1, not the minting flow, which api-tokens.spec.ts
+  # already covers.
+  #
+  # The digest is a bare SHA-256 of the whole raw token, matching
+  # service.HashAPIToken. If that ever changes, this seeds an unusable token
+  # and every request 401s — loudly, not silently.
+  SECRET=$(head -c 32 /dev/urandom | base64 | tr '+/' '-_' | tr -d '=\n')
+  TOKEN="stk_${SECRET}"
+  HASH=$(printf '%s' "$TOKEN" | sha256sum | cut -d' ' -f1)
+  PREFIX="stk_$(printf '%s' "$SECRET" | cut -c1-6)"
+
+  # Every grantable scope: the point is to reach every endpoint, so a 403 is
+  # never the reason coverage stopped. Scopes themselves are covered by the Go
+  # tests.
+  SCOPES="entries:read,entries:write,weight:read,weight:write,todos:read,todos:write,foods:read,foods:write,notes:read,notes:write,plan:read,links:read,settings:read,settings:write"
+
+  echo "==> seeding a contract-test user and token"
+  psql <<SQL >/dev/null
+INSERT INTO users (email, password_hash, email_verified)
+VALUES ('contract@test.com', 'x', true)
+ON CONFLICT (email) DO NOTHING;
+DELETE FROM api_tokens WHERE name = 'schemathesis';
+INSERT INTO api_tokens (user_id, name, token_hash, prefix, scopes)
+SELECT id, 'schemathesis', decode('${HASH}', 'hex'), '${PREFIX}', string_to_array('${SCOPES}', ',')
+FROM users WHERE email = 'contract@test.com';
+SQL
+fi
+
+# CHECKS defaults to the one that is green today, so this can gate from its
+# first commit instead of being a job everyone learns to ignore.
+#
+# not_a_server_error is also the check that matters most: a 500 on input the
+# document says is legal is unambiguously a bug, whereas the others below are
+# mostly the *document* being wrong, which is a different (real, but lower
+# severity) problem.
+#
+# Still failing, and worth turning on one at a time as the spec is tightened —
+# run with `--checks all` to see them:
+#
+#   negative_data_rejection      3 cases the API accepts that the schema forbids
+#   positive_data_acceptance    28 cases the schema permits that the API rejects
+#                                  (validation is stricter than documented —
+#                                  e.g. date and note constraints)
+#   content_type_conformance     2 responses whose Content-Type is undeclared
+#   unsupported_method          14 operations that 405 correctly but do not say
+#                                  so in the document
+#
+# None of those is a crash; all of them are a client being told something the
+# server does not actually do.
+CHECKS="${CHECKS:-not_a_server_error}"
+
+# ai:estimate is deliberately NOT granted above. Every call to it spends real
+# money with the operator's AI provider, and a fuzzer is exactly the caller you
+# do not want holding that scope. The endpoint is excluded below to match.
+echo "==> running Schemathesis against $BASE/api/v1 (checks: $CHECKS)"
+exec uvx --from 'schemathesis>=4,<5' schemathesis run \
+  "$BASE/api/v1/openapi.json" \
+  --url "$BASE/api/v1" \
+  --header "Authorization: Bearer $TOKEN" \
+  --exclude-path-regex '/ai/' \
+  --checks "$CHECKS" \
+  --report junit \
+  --report-junit-path contract-report.xml \
+  "$@"


### PR DESCRIPTION
## Why

`TestV1RoutesMatchSpec` already guarantees the route table and `api/openapi.json` describe the same set of endpoints. But agreeing on *which endpoints exist* says nothing about whether the **responses** match the schemas the document promises — and that gap is exactly where a client written against the published spec breaks.

Schemathesis reads the committed document and generates requests from it: every parameter at its boundaries, every declared type violated in turn, every optional field present and absent.

**The first run found two 500s.** Both the same shape: user input reaching Postgres without a bound.

---

## Bug 1 — any id above int4's range returns 500 instead of 404

```
curl -X DELETE .../api/v1/entries/34359738367
curl      -X GET .../api/v1/todos?user=1248349573196321792
curl     -X POST .../api/v1/saved-foods/2403310975/track
```

`strconv.Atoi` returns a **64-bit** int, so `34359738367` parses cleanly and passes the `> 0` check — then fails at the driver:

```
unable to encode 34359738367 into binary format for int4 (OID 23)
```

Reachable on five endpoints by editing a URL. `model.ParseID` now applies the bound at all four parse sites.

**One deliberate asymmetry:** `?user=` is *not* a 400. A positive id naming no reachable account is denied exactly like an unlinked one — answering 400 would hand a caller an oracle for the id space, which is what the existing `"denial is indistinguishable across causes"` test exists to prevent. So it is flagged before the query and routed to the same denial branch, without touching the database. (My first attempt did return 400 and that test caught it — it's a good test.)

## Bug 2 — a non-UTF-8 `Idempotency-Key` returns 500

```
ERROR: invalid byte sequence for encoding "UTF8": 0xba (SQLSTATE 22021)
```

This is **the same defect #378 fixed for JSON bodies**, on the one input path that fix did not cover. Headers are raw bytes with no decoder in front of them, so an invalid sequence went straight into a `TEXT` column — again a 500 for a request that is entirely the caller's fault.

---

## Result

| | before | after |
|---|---|---|
| Server errors | **7** | **0** |

`CHECKS` defaults to `not_a_server_error`, which is **green — 4284 generated cases, 0 failures**. That lets this gate from its first commit rather than being a job everyone learns to ignore (same principle as the golangci-lint PR, different from `e2e`'s `continue-on-error` trial).

The other checks still fail and are listed in the script to enable one at a time as the document is tightened:

| Check | Failures | What it means |
|---|---|---|
| `positive_data_acceptance` | 28 | the schema permits input the API rejects (validation stricter than documented) |
| `unsupported_method` | 14 | operations that 405 correctly but don't say so in the document |
| `negative_data_rejection` | 3 | the API accepts input the schema forbids |
| `content_type_conformance` | 2 | responses whose Content-Type is undeclared |

**None of those is a crash** — all are the document disagreeing with the server. Run `CHECKS=all npm run test:contract` to see them.

## Notes

- **`ai:estimate` is not granted** to the fuzzer's token and `/ai/` is excluded from the run. Every call there spends real money with the operator's AI provider, and a fuzzer is precisely the caller you don't want holding that scope.
- The token is seeded with `psql` rather than minted over HTTP: token creation is step-up gated on purpose, and the thing under test is `/api/v1`, not the minting flow (which `api-tokens.spec.ts` covers). The digest is a bare SHA-256 matching `service.HashAPIToken` — if that ever changes, every request 401s loudly.
- Fixing bug 1 narrowed the cursor's valid id domain, since a cursor id names a row. The two tests asserting round-trip over the full `int64` range are updated to the range a row can actually have, with the reasoning recorded at each.
- CI `paths` gains `scripts/**` and `api/openapi.json`, for the same reason `e2e/**` was added: otherwise a change to the suite gets no CI at all.

## Verification

- `go test -race ./...` — all 14 packages pass
- `gofmt -l` / `go vet ./...` — clean
- `go run ./cmd/apidocs` — no diff (spec unchanged by these fixes)
- `npm run test:contract` — exit 0, 4284 cases
- New `TestParseIDRejectsValuesTooLargeForInt4` covers each id from the fuzzer's actual findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRz8xo2j5onYzoo7Tjg3hs