### PR TITLE
fix(client): revalidate SSE queries that are still on their first fetch

### DIFF
--- a/client/src/hooks/useSSE.test.tsx
+++ b/client/src/hooks/useSSE.test.tsx
@@ -1,0 +1,163 @@
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSSE } from './useSSE';
+
+// The stores and i18n are stubbed because none of them participate in the
+// behaviour under test — `entry-change` only revalidates queries — and
+// importing the real ones drags in network calls and catalog loading.
+vi.mock('@/stores/toastStore', () => ({
+  useToastStore: (sel: (s: { addToast: () => void }) => unknown) => sel({ addToast: () => {} }),
+}));
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: (sel: (s: { fetchUser: () => void }) => unknown) => sel({ fetchUser: () => {} }),
+}));
+vi.mock('@/i18n', () => ({ default: { t: (k: string) => k } }));
+
+// Minimal EventSource stand-in. jsdom has none, and the real one would need a
+// server; all the hook needs is addEventListener plus a way for the test to
+// deliver an event.
+class FakeEventSource {
+  static last: FakeEventSource | null = null;
+  listeners = new Map<string, ((e: MessageEvent) => void)[]>();
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(public url: string) {
+    FakeEventSource.last = this;
+  }
+  addEventListener(type: string, fn: (e: MessageEvent) => void) {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), fn]);
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(type: string, data: unknown = {}) {
+    for (const fn of this.listeners.get(type) ?? []) {
+      fn(new MessageEvent(type, { data: JSON.stringify(data) }));
+    }
+  }
+}
+
+describe('useSSE revalidation during an initial fetch', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { EventSource: unknown }).EventSource = FakeEventSource;
+    FakeEventSource.last = null;
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as { EventSource?: unknown }).EventSource;
+  });
+
+  // The regression. query-core's Query.fetch() only honours cancelRefetch once
+  // the query holds data:
+  //
+  //   if (this.state.data !== undefined && fetchOptions?.cancelRefetch) {
+  //     this.cancel({ silent: true });
+  //   } else if (this.#retryer) {
+  //     return this.#retryer.promise;   // deduped into the in-flight request
+  //   }
+  //
+  // So an invalidation that lands while a query is still running its FIRST
+  // request is folded into that already-issued request, and its success then
+  // clears isInvalidated — leaving the tab on pre-event data with no refetch
+  // pending. A second tab hits this whenever an event arrives during its first
+  // render, which is exactly when a realtime update matters most.
+  //
+  // Reverting useSSE to a bare invalidateQueries() fails this test with
+  // "dashboard v1", the value fetched before the event.
+  it('refetches a query whose very first request is still in flight', async () => {
+    let resolveFirst: ((v: string) => void) | undefined;
+    let call = 0;
+
+    const queryFn = vi.fn(() => {
+      call += 1;
+      if (call === 1) {
+        return new Promise<string>((res) => {
+          resolveFirst = res;
+        });
+      }
+      return Promise.resolve(`dashboard v${call}`);
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    function Dashboard() {
+      useSSE();
+      const { data } = useQuery({ queryKey: ['dashboard'], queryFn });
+      return <div data-testid="value">{data ?? 'loading'}</div>;
+    }
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Dashboard />
+      </QueryClientProvider>,
+    );
+
+    // The stream is open and the first request is still outstanding — the exact
+    // window a second tab sits in while it hydrates.
+    await waitFor(() => expect(FakeEventSource.last).not.toBeNull());
+    expect(queryFn).toHaveBeenCalledTimes(1);
+
+    FakeEventSource.last!.emit('entry-change');
+
+    // Only now does the pre-event request come back. Its value is stale by
+    // definition: it was issued before the event that invalidated it.
+    resolveFirst!('dashboard v1');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('value')).toHaveTextContent('dashboard v2');
+    });
+    expect(queryFn).toHaveBeenCalledTimes(2);
+
+    queryClient.clear();
+  });
+
+  it('still revalidates a query that already holds data', async () => {
+    const queryFn = vi.fn().mockResolvedValueOnce('first').mockResolvedValueOnce('second');
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    function Dashboard() {
+      useSSE();
+      const { data } = useQuery({ queryKey: ['dashboard'], queryFn });
+      return <div data-testid="value">{data ?? 'loading'}</div>;
+    }
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Dashboard />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('value')).toHaveTextContent('first'));
+    await waitFor(() => expect(FakeEventSource.last).not.toBeNull());
+
+    FakeEventSource.last!.emit('entry-change');
+
+    await waitFor(() => expect(screen.getByTestId('value')).toHaveTextContent('second'));
+    queryClient.clear();
+  });
+
+  it('closes the stream on unmount', async () => {
+    const queryClient = new QueryClient();
+    const { unmount } = render(
+      <QueryClientProvider client={queryClient}>
+        <SseOnly />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(FakeEventSource.last).not.toBeNull());
+    const source = FakeEventSource.last!;
+    unmount();
+    expect(source.closed).toBe(true);
+  });
+});
+
+function SseOnly() {
+  useSSE();
+  return null;
+}

--- a/client/src/hooks/useSSE.ts
+++ b/client/src/hooks/useSSE.ts
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef } from 'react';
+import { useQueryClient, type QueryKey } from '@tanstack/react-query';
 import { useToastStore } from '@/stores/toastStore';
 import { useAuthStore } from '@/stores/authStore';
 import i18n from '@/i18n';
@@ -10,6 +10,39 @@ export function useSSE() {
   const fetchUser = useAuthStore((s) => s.fetchUser);
   const sourceRef = useRef<EventSource | null>(null);
   const retryDelayRef = useRef(2000);
+
+  /**
+   * Refetch every query under `keys`, including one that is still running its
+   * very first request.
+   *
+   * invalidateQueries() on its own silently loses that case. query-core's
+   * Query.fetch() only honours cancelRefetch once the query holds data:
+   *
+   *   if (this.state.data !== undefined && fetchOptions?.cancelRefetch) {
+   *     this.cancel({ silent: true });
+   *   } else if (this.#retryer) {
+   *     return this.#retryer.promise;   // deduped into the in-flight request
+   *   }
+   *
+   * During an initial fetch (`data === undefined`) the invalidation is folded
+   * into a request that was issued *before* the event, and that request's
+   * success then clears isInvalidated — so the tab settles on pre-event data
+   * with no refetch pending and stays wrong until something else invalidates.
+   *
+   * A second tab hits this whenever an event lands inside its first render,
+   * which is exactly when a realtime update matters most: open the dashboard
+   * twice, tick a todo in one tab while the other is still loading, and the
+   * other never shows it ticked. Cancelling first puts the query back to idle,
+   * so the invalidation that follows starts a genuinely new request. Cancel
+   * reverts rather than discards, so a query that already had data keeps it.
+   */
+  const revalidate = useCallback((...keys: QueryKey[]) => {
+    for (const queryKey of keys) {
+      void queryClient
+        .cancelQueries({ queryKey })
+        .then(() => queryClient.invalidateQueries({ queryKey }));
+    }
+  }, [queryClient]);
 
   useEffect(() => {
     if (!window.EventSource) return;
@@ -26,21 +59,18 @@ export function useSSE() {
       sourceRef.current = source;
 
       source.addEventListener('entry-change', () => {
-        queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-        queryClient.invalidateQueries({ queryKey: ['day-entries'] });
         // The server broadcasts entry-change for weight upserts too.
-        queryClient.invalidateQueries({ queryKey: ['weight'] });
+        revalidate(['dashboard'], ['day-entries'], ['weight']);
       });
 
       source.addEventListener('settings-change', () => {
-        queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+        revalidate(['dashboard']);
         // The current user lives in the auth store, not a query.
         fetchUser();
       });
 
       source.addEventListener('link-change', (e) => {
-        queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-        queryClient.invalidateQueries({ queryKey: ['settings'] });
+        revalidate(['dashboard'], ['settings']);
         fetchUser();
         try {
           const data = JSON.parse((e as MessageEvent).data);
@@ -51,28 +81,25 @@ export function useSSE() {
       });
 
       source.addEventListener('link-label-change', () => {
-        queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+        revalidate(['dashboard']);
       });
 
       source.addEventListener('link-shares-change', () => {
         // A permission change can add/remove whole sections from a linked
         // dashboard. Refresh both the viewer and any other open settings tab.
-        queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-        queryClient.invalidateQueries({ queryKey: ['settings'] });
+        revalidate(['dashboard'], ['settings']);
       });
 
       source.addEventListener('todo-change', () => {
-        queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-        queryClient.invalidateQueries({ queryKey: ['todos'] });
-        queryClient.invalidateQueries({ queryKey: ['todos-day'] });
+        revalidate(['dashboard'], ['todos'], ['todos-day']);
       });
 
       source.addEventListener('note-change', () => {
-        queryClient.invalidateQueries({ queryKey: ['note'] });
+        revalidate(['note']);
       });
 
       source.addEventListener('saved-food-change', () => {
-        queryClient.invalidateQueries({ queryKey: ['savedFoods'] });
+        revalidate(['savedFoods']);
       });
 
       source.onopen = () => {
@@ -97,5 +124,5 @@ export function useSSE() {
       sourceRef.current?.close();
       sourceRef.current = null;
     };
-  }, [queryClient, fetchUser]);
+  }, [revalidate, fetchUser]);
 }


### PR DESCRIPTION
## The bug

A tab that receives an SSE event while a query is running its **very first** request never refetches, and settles on data from before the event.

`query-core`'s `Query.fetch()` only honours `cancelRefetch` once the query holds data — verified in `node_modules/@tanstack/query-core/build/modern/query.js:188`:

```js
if (this.state.data !== void 0 && fetchOptions?.cancelRefetch) {
  this.cancel({ silent: true });
} else if (this.#retryer) {
  return this.#retryer.promise;   // deduped into the in-flight request
}
```

With `data` still `undefined`, `invalidateQueries` is folded into a request that was issued **before** the event — and that request's success then clears `isInvalidated`. The query ends up settled, un-invalidated, and wrong, and stays wrong until something else happens to invalidate it.

The window is a tab's first few hundred ms, which is precisely when a realtime update matters most:

> Open the dashboard in two tabs. Tick a todo in one while the other is still loading. The other never shows it ticked.

Cancelling first returns the query to idle, so the invalidation that follows starts a genuinely new request. `cancel` reverts rather than discards, so a query that already had data keeps it.

## How it was found

Chasing a flaky SSE E2E test. The flake was real — the test was racing the same window users do. Worth noting as a data point: this is the second production bug this round of test work has surfaced, after the two 500s the contract fuzzer found.

## Verification

The regression test drives the real hook against a real `QueryClient` with a controlled first request, using the jsdom + Testing Library setup added in #448.

Reverting `revalidate()` to a bare `invalidateQueries()` fails it with **`dashboard v1`** — the pre-event value — while the fixed version reaches `dashboard v2`. Two further cases cover the paths that must not regress: a query that already holds data still revalidates, and the stream still closes on unmount.

Full client gate: `typecheck` clean, `build` clean, **157 tests pass**, i18n drift and parity unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRz8xo2j5onYzoo7Tjg3hs