### PR TITLE
test(e2e): fix the races behind the chronically flaky specs

### DIFF
--- a/e2e/desktop-shell.spec.ts
+++ b/e2e/desktop-shell.spec.ts
@@ -90,14 +90,22 @@ test.describe('Desktop shell', () => {
     await expect(page.getByText('Desktop undo overlap')).toBeVisible({ timeout: 10000 });
 
     await page.getByRole('button', { name: 'Delete entry' }).first().click();
-    const undo = page.getByRole('button', { name: 'Undo' });
+    // Scope Undo to the toast and match its label exactly. Accessible-name
+    // matching is substring-based and case-insensitive, so a bare
+    // `{ name: 'Undo' }` on the page also matches the entry button named
+    // "Desktop undo overlap" this test just created — and the two genuinely
+    // coexist, because handleDelete() shows the toast before the invalidated
+    // entry query has refetched the row away. That is a strict-mode violation,
+    // not a wait: the locator resolves to 2 elements.
+    const toast = page.locator('[role="status"] > div').first();
+    const undo = toast.getByRole('button', { name: 'Undo', exact: true });
     await expect(undo).toBeVisible({ timeout: 10000 });
 
-    const fab = await page.getByRole('button', { name: 'Add food' }).boundingBox();
-    const toast = await page.locator('[role="status"] > div').first().boundingBox();
-    expect(fab).not.toBeNull();
-    expect(toast).not.toBeNull();
-    expect(toast!.y + toast!.height).toBeLessThanOrEqual(fab!.y);
+    const fabBox = await page.getByRole('button', { name: 'Add food' }).boundingBox();
+    const toastBox = await toast.boundingBox();
+    expect(fabBox).not.toBeNull();
+    expect(toastBox).not.toBeNull();
+    expect(toastBox!.y + toastBox!.height).toBeLessThanOrEqual(fabBox!.y);
 
     psql(`DELETE FROM calorie_entries WHERE user_id = ${user.id}`);
     await ctx.close();

--- a/e2e/fixtures/helpers.ts
+++ b/e2e/fixtures/helpers.ts
@@ -140,12 +140,37 @@ export async function clearMailpit(): Promise<void> {
 const DEFAULT_PASSWORD = 'test1234test';
 
 /**
+ * Playwright runs `beforeAll` once per *worker process*, and `fullyParallel`
+ * spreads the tests of a single file across every worker. A spec that seeds its
+ * account in `beforeAll` therefore re-enters this function — destructive
+ * cleanup and all — while its own sibling tests are already mid-flight in the
+ * other workers, deleting the entries/todos/notes they just created.
+ *
+ * That is not a UI race, but it is indistinguishable from one at the assertion:
+ * the entry is gone, so `POST /entries/:id/update` 404s ("Entry not found"),
+ * `/entries/day` no longer lists it, and an SSE peer never sees the completion
+ * or note it is waiting for. It hit entry-edit, sse-realtime, macro-colors and
+ * the two shell specs alike.
+ *
+ * Partitioning the account by TEST_PARALLEL_INDEX fixes it at the source:
+ * Playwright keeps at most one live worker per parallel index, so each worker
+ * owns a private row and its cleanup can only ever touch data it created
+ * itself. Nothing is serialised, so the suite keeps its parallelism.
+ *
+ * The suffix is omitted outside a worker (setup scripts, ad-hoc `tsx` runs) so
+ * those keep addressing the unsuffixed account.
+ */
+const WORKER_SUFFIX = process.env.TEST_PARALLEL_INDEX ? `-w${process.env.TEST_PARALLEL_INDEX}` : '';
+
+/**
  * Create or reset an isolated test user for a specific spec file.
  * Returns { email, password, id }. Call in beforeAll() for test isolation.
  * The user gets all features enabled (macros, todos, notes) and clean data.
+ *
+ * The account is per worker, not per spec file — see WORKER_SUFFIX above.
  */
 export function createIsolatedUser(specName: string, opts: { features?: boolean } = {}): { email: string; password: string; id: string } {
-  const email = `e2e-${specName}@test.local`;
+  const email = `e2e-${specName}${WORKER_SUFFIX}@test.local`;
   const password = DEFAULT_PASSWORD;
   const hash = bcryptHash(password);
   const features = opts.features !== false;
@@ -159,14 +184,16 @@ export function createIsolatedUser(specName: string, opts: { features?: boolean 
      RETURNING id`,
     { email, hash }
   );
-  psql(`DELETE FROM totp_backup_codes WHERE user_id = ${id}`);
-  // Clean all data
-  psql(`DELETE FROM calorie_entries WHERE user_id = ${id}`);
-  psql(`DELETE FROM weight_entries WHERE user_id = ${id}`);
-  psql(`DELETE FROM todo_completions WHERE todo_id IN (SELECT id FROM todos WHERE user_id = ${id})`);
-  psql(`DELETE FROM todos WHERE user_id = ${id}`);
-  psql(`DELETE FROM daily_notes WHERE user_id = ${id}`);
-  psql(`DELETE FROM ai_usage WHERE user_id = ${id}`);
+  // Clean all data. One round-trip: every `psql()` is its own `docker exec`,
+  // and this ran seven of them on every call, in every worker, for every spec.
+  psql(`DELETE FROM totp_backup_codes WHERE user_id = ${id};
+    DELETE FROM calorie_entries WHERE user_id = ${id};
+    DELETE FROM weight_entries WHERE user_id = ${id};
+    DELETE FROM todo_completions WHERE todo_id IN (SELECT id FROM todos WHERE user_id = ${id});
+    DELETE FROM todos WHERE user_id = ${id};
+    DELETE FROM daily_notes WHERE user_id = ${id};
+    DELETE FROM ai_usage WHERE user_id = ${id};
+    DELETE FROM saved_foods WHERE user_id = ${id};`);
 
   if (features) {
     psql(`UPDATE users SET

--- a/e2e/mobile-shell.spec.ts
+++ b/e2e/mobile-shell.spec.ts
@@ -218,15 +218,23 @@ test.describe('Mobile shell (redesign)', () => {
     await expect(page.getByText('Undo overlap')).toBeVisible({ timeout: 10000 });
 
     await page.getByRole('button', { name: 'Delete entry' }).first().click();
-    const undo = page.getByRole('button', { name: 'Undo' });
+    // Scope Undo to the toast and match its label exactly. Accessible-name
+    // matching is substring-based and case-insensitive, so a bare
+    // `{ name: 'Undo' }` on the page also matches the entry button named
+    // "Undo overlap" this test just created — and the two genuinely coexist,
+    // because handleDelete() shows the toast before the invalidated entry
+    // query has refetched the row away. That is a strict-mode violation, not a
+    // wait: the locator resolves to 2 elements.
+    const toast = page.locator('[role="status"] > div').first();
+    const undo = toast.getByRole('button', { name: 'Undo', exact: true });
     await expect(undo).toBeVisible({ timeout: 10000 });
 
-    const fab = await page.getByRole('button', { name: 'Add food' }).boundingBox();
-    const toast = await page.locator('[role="status"] > div').first().boundingBox();
-    expect(fab).not.toBeNull();
-    expect(toast).not.toBeNull();
+    const fabBox = await page.getByRole('button', { name: 'Add food' }).boundingBox();
+    const toastBox = await toast.boundingBox();
+    expect(fabBox).not.toBeNull();
+    expect(toastBox).not.toBeNull();
     // The toast stack sits fully above the FAB, so Undo stays tappable.
-    expect(toast!.y + toast!.height).toBeLessThanOrEqual(fab!.y);
+    expect(toastBox!.y + toastBox!.height).toBeLessThanOrEqual(fabBox!.y);
 
     await ctx.close();
   });

--- a/e2e/sse-realtime.spec.ts
+++ b/e2e/sse-realtime.spec.ts
@@ -9,13 +9,36 @@ test.describe('SSE Real-time Updates', () => {
     user = createIsolatedUser('sse');
   });
 
+  /**
+   * Log in and wait until the tab is actually *subscribed* to the event stream.
+   *
+   * The broker fans out only to clients it currently holds a channel for
+   * (internal/sse/broker.go: Subscribe / getTargets). An event broadcast before
+   * a tab's EventSource exists is therefore lost for good — nothing replays it
+   * on connect, so the observing tab waits out its whole timeout on an update
+   * that will never arrive.
+   *
+   * Reaching /dashboard is far too early a signal: `useSSE` only opens
+   * `/events/entries` once App has mounted, several hundred ms of hydration and
+   * initial queries later. Every "propagates via SSE" test was racing that gap,
+   * and the todo test papered over it with `waitForTimeout(2000)`.
+   *
+   * Waiting on the stream's response instead closes the gap deterministically:
+   * the handler flushes those headers and then subscribes the channel with no
+   * I/O in between. Armed before the login so a fast connect cannot slip past.
+   */
   async function loginAndGo(page: import('@playwright/test').Page, targetPath = '/dashboard') {
+    const streamOpen = page.waitForResponse(
+      (res) => res.url().includes('/events/entries') && res.status() === 200,
+      { timeout: 30000 },
+    );
     await page.goto(`${baseURL}/login`);
     await page.waitForLoadState('domcontentloaded');
     await page.getByLabel('Email').fill(user.email);
     await page.getByLabel('Password').fill(user.password);
     await page.getByRole('button', { name: 'Log In' }).click();
     await page.waitForURL(/\/dashboard/, { timeout: 15000 });
+    await streamOpen;
     if (targetPath !== '/dashboard') {
       await page.goto(`${baseURL}${targetPath}`);
       await page.waitForURL(new RegExp(targetPath), { timeout: 10000 });
@@ -78,8 +101,8 @@ test.describe('SSE Real-time Updates', () => {
     await loginAndGo(pageA);
     await loginAndGo(pageB);
 
-    // Allow SSE connections to establish on both pages
-    await pageB.waitForTimeout(2000);
+    // No sleep needed to let the streams settle — loginAndGo already waited for
+    // each tab's /events/entries response, which is what that guessed at.
 
     // Complete the todo on page A
     const todoRowA = pageA.locator('li').filter({ hasText: 'SSE Todo Test' });

--- a/e2e/two-factor.spec.ts
+++ b/e2e/two-factor.spec.ts
@@ -12,12 +12,55 @@ let twoFaUserId = '';
 let capturedSecret = '';
 let capturedBackupCodes: string[] = [];
 
+/**
+ * Both steps of the login — credentials and 2FA code — POST to this one
+ * endpoint, so both are awaited the same way.
+ */
+function loginPosted(page: import('@playwright/test').Page) {
+  return page.waitForResponse(
+    (res) => res.url().includes('/api/auth/login') && res.request().method() === 'POST',
+    { timeout: 30000 },
+  );
+}
+
+/**
+ * Submit the credentials form and wait for the server's answer before
+ * returning.
+ *
+ * Callers used to click and immediately assert on the UI, which quietly made
+ * every one of those assertions pay for the request as well: the 10s allowed
+ * for "the 2FA prompt rendered" was really "bcrypt compared the password while
+ * three other workers hammered the same container, *and* the prompt rendered".
+ * That is what timed out under load. Awaiting the POST separates the two, so
+ * the render assertion gets its own full budget without anything being
+ * lengthened.
+ */
 async function loginAs2faUser(page: import('@playwright/test').Page) {
   await page.goto('/login');
   await page.waitForLoadState('domcontentloaded');
   await page.getByLabel('Email').fill(EMAIL);
   await page.getByLabel('Password').fill(PASSWORD);
+  const posted = loginPosted(page);
   await page.getByRole('button', { name: 'Log In' }).click();
+  await posted;
+}
+
+/**
+ * Enter a TOTP or backup code and land on the dashboard.
+ *
+ * Checking the verify response before waiting for the URL turns the one
+ * failure that actually matters here — the server rejecting the code — into
+ * "expected 200, received 401" instead of a 15s wait for a navigation that was
+ * never coming, which is how it used to present.
+ */
+async function submit2faCode(page: import('@playwright/test').Page, code: string) {
+  const codeInput = page.getByLabel('2FA Code');
+  await expect(codeInput).toBeVisible({ timeout: 10000 });
+  await codeInput.fill(code);
+  const posted = loginPosted(page);
+  await page.getByRole('button', { name: /verify/i }).click();
+  expect((await posted).status()).toBe(200);
+  await page.waitForURL('/dashboard', { timeout: 15000 });
 }
 
 async function logout(page: import('@playwright/test').Page) {
@@ -26,7 +69,9 @@ async function logout(page: import('@playwright/test').Page) {
   // which is why this needed visibility-aware matching to stay unambiguous.
   await page.goto('/account');
   await page.getByRole('button', { name: 'Logout' }).click();
-  await page.waitForURL(/\/login|\//, { timeout: 10000 });
+  // useLogout() navigates to /login. The old /\/login|\// matched any URL with
+  // a slash in it, so this returned before the logout had happened at all.
+  await page.waitForURL(/\/login/, { timeout: 10000 });
 }
 
 test.describe('Two-Factor Authentication', () => {
@@ -112,16 +157,8 @@ test.describe('Two-Factor Authentication', () => {
     // Start from settings (already logged in from previous test — need fresh login)
     await loginAs2faUser(page);
 
-    // Should see TOTP prompt (not redirect to dashboard yet)
-    const totpInput = page.getByLabel('2FA Code');
-    await expect(totpInput).toBeVisible({ timeout: 10000 });
-
-    // Generate code and verify
-    const totpCode = generateTOTP(capturedSecret);
-    await totpInput.fill(totpCode);
-    await page.getByRole('button', { name: /verify/i }).click();
-
-    await page.waitForURL('/dashboard', { timeout: 15000 });
+    // Should see the TOTP prompt (not redirect to dashboard yet), then verify.
+    await submit2faCode(page, generateTOTP(capturedSecret));
     await expect(page).toHaveURL(/\/dashboard/);
 
     await logout(page);
@@ -134,18 +171,9 @@ test.describe('Two-Factor Authentication', () => {
 
     await loginAs2faUser(page);
 
-    // Should see 2FA prompt — same input accepts both TOTP and backup codes
-    const codeInput = page.getByLabel('2FA Code');
-    await expect(codeInput).toBeVisible({ timeout: 10000 });
-
-    // Enter a backup code (the login page accepts it in the same field)
+    // The same input accepts both TOTP and backup codes.
     expect(capturedBackupCodes.length).toBeGreaterThan(0);
-    const backupCodeToUse = capturedBackupCodes[0];
-    await codeInput.fill(backupCodeToUse);
-
-    await page.getByRole('button', { name: /verify/i }).click();
-
-    await page.waitForURL('/dashboard', { timeout: 15000 });
+    await submit2faCode(page, capturedBackupCodes[0]);
     await expect(page).toHaveURL(/\/dashboard/);
 
     await logout(page);
@@ -158,11 +186,7 @@ test.describe('Two-Factor Authentication', () => {
 
     // Login with TOTP
     await loginAs2faUser(page);
-    const totpInput = page.getByLabel('2FA Code');
-    await expect(totpInput).toBeVisible({ timeout: 10000 });
-    await totpInput.fill(generateTOTP(capturedSecret));
-    await page.getByRole('button', { name: /verify/i }).click();
-    await page.waitForURL('/dashboard', { timeout: 15000 });
+    await submit2faCode(page, generateTOTP(capturedSecret));
 
     await page.goto('/account');
     await page.waitForURL('/account');
@@ -209,11 +233,7 @@ test.describe('Two-Factor Authentication', () => {
 
     // Login with TOTP
     await loginAs2faUser(page);
-    const totpInput = page.getByLabel('2FA Code');
-    await expect(totpInput).toBeVisible({ timeout: 10000 });
-    await totpInput.fill(generateTOTP(capturedSecret));
-    await page.getByRole('button', { name: /verify/i }).click();
-    await page.waitForURL('/dashboard', { timeout: 15000 });
+    await submit2faCode(page, generateTOTP(capturedSecret));
 
     await page.goto('/account');
     await page.waitForURL('/account');


### PR DESCRIPTION
## Result

| | failed | flaky | did not run | passed |
|---|---|---|---|---|
| before (staging) | 0–1 | 6–7 | 0–13 | 245–260 |
| **after** | **0** | **0** | **0** | **266** |

Two consecutive full-suite runs at 266/266, no retries used at all. Five specs needed a retry most runs before this; four separate root causes, none of them a timeout that was merely too short.

## 1. Worker-shared accounts — the big one

Playwright runs `beforeAll` once per **worker process**, and `fullyParallel` spreads a single file's tests across every worker. So `createIsolatedUser` re-entered its destructive cleanup while that same file's sibling tests were mid-flight in other workers, deleting the entries, todos and notes they had just created.

It presents exactly like a UI race: the entry is gone, so the update 404s, `/entries/day` no longer lists it, and an SSE peer waits out its timeout for a change it will never see. It hit `entry-edit`, `sse-realtime`, `macro-colors` and both shell specs.

The account is now partitioned by `TEST_PARALLEL_INDEX` — Playwright keeps at most one live worker per index, so a worker's cleanup can only touch rows it created. Nothing is serialised, so the suite keeps its parallelism. (The seven separate `docker exec psql` calls per seed also became one.)

## 2. A strict-mode violation, not a wait

```ts
const undo = page.getByRole('button', { name: 'Undo' });
```
Accessible-name matching is substring-based, so this also matched the entry the test had just created and named **"Undo overlap"** — and the two genuinely coexist, because the toast appears before the invalidated entry query refetches the row away. The locator resolved to two elements. Now scoped to the toast and matched with `exact: true`.

## 3. SSE subscription race

The broker only fans out to clients it currently holds a channel for, and nothing replays events on connect — so an event broadcast before a tab's `EventSource` exists is lost for good. Reaching `/dashboard` is far too early a signal: `useSSE` opens the stream several hundred ms later, and the todo test papered over the gap with `waitForTimeout(2000)`. Both now wait for the `/events/entries` response, which the handler flushes immediately before subscribing.

## 4. A logout helper that never waited for the logout

```ts
await page.waitForURL(/\/login|\//, { timeout: 10000 });
```
`/\/login|\//` matches **any** URL containing a slash, so this returned immediately, on the page it started on. Narrowed to `/\/login/`. The 2FA login helpers also await the login POST, so the "prompt rendered" assertion stops sharing its 10s budget with a bcrypt comparison under four-worker load.

## Note on the last one

The final remaining flake — `weight update propagates via SSE` — was **not** a test bug. It was the production race fixed in #454: a tab receiving an SSE event during its first fetch never refetched. With #454 in, the suite goes from 1 flaky to 0. The test was racing the same window users do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRz8xo2j5onYzoo7Tjg3hs