### PR TITLE
fix(health): add shallow /api/livez liveness endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,9 +122,11 @@ schautrack/
 - Runs as non-root `appuser`
 
 ### Kubernetes / Health Checks
+- **Liveness endpoint:** `GET /api/livez` - shallow, unconditional 200 whenever the HTTP server can serve; never touches the database or any other dependency (`handler.Livez`)
 - **Health endpoint:** `GET /api/health` - checks database connectivity, returns 200 with app info or 503 on failure
-- **Liveness probe:** Use HTTP GET to `/api/health` - restarts container if app is unresponsive
+- **Liveness probe:** Use HTTP GET to `/api/livez` - restarts container if the process itself is wedged
 - **Readiness probe:** Use HTTP GET to `/api/health` - removes pod from service if DB connection fails
+- **Why the split matters:** liveness must never depend on an external service. If liveness pinged the database like readiness does, a single Postgres blip would fail the check on every replica at once and kubelet would restart them all simultaneously — a recoverable dependency outage becoming a cluster-wide crashloop that slows recovery instead of helping it. Readiness pulling a pod out of the Service on the same failure is the correct, non-destructive response.
 - **Deployment strategy:** RollingUpdate with `maxUnavailable: 0` ensures zero-downtime deployments (old pod stays until new pod is ready)
 - **Helm chart:** Includes probes and strategy by default
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -157,6 +157,10 @@ func main() {
 
 	// API routes
 	r.Route("/api", func(r chi.Router) {
+		// /livez is the liveness probe (process alive, no dependency check);
+		// /health is readiness (also pings the database). Keep them split —
+		// see handler.Livez for why a DB check must never gate liveness.
+		r.Get("/livez", handler.Livez)
 		r.Get("/health", handler.Health(pool, cfg.BuildVersion))
 		r.Get("/latest-version", handler.LatestVersion(updateProvider, cfg.UpdateCheckEnabled))
 		r.Get("/csrf", handler.CsrfToken)

--- a/internal/handler/health.go
+++ b/internal/handler/health.go
@@ -14,6 +14,21 @@ func MarkShuttingDown() {
 	shuttingDown.Store(true)
 }
 
+// Livez handles GET /api/livez — the liveness probe. It answers only "is
+// this process still able to serve HTTP", never "are my dependencies up":
+// the handler takes no pool and touches no external resource, so it cannot
+// fail because Postgres blipped. That distinction matters operationally —
+// Health (readiness) pings the database and legitimately returns 503 when it
+// can't reach it, which is correct for pulling a pod out of the Service. If
+// the same check gated liveness, every replica would fail it simultaneously
+// on a single DB hiccup and kubelet would restart all of them at once,
+// turning a recoverable dependency outage into a cluster-wide crashloop.
+// Deliberately allocation-light: no JSON encoding, just a status and a body.
+func Livez(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}
+
 func Health(pool *pgxpool.Pool, buildVersion string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/handler/health_test.go
+++ b/internal/handler/health_test.go
@@ -1,11 +1,82 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// unreachablePool builds a pool pointing at a TCP port nothing is listening
+// on. Grabbing a real ephemeral port and closing it immediately (rather than
+// guessing a fixed one) means the target is guaranteed free and connection
+// attempts fail fast with "connection refused" instead of a slow timeout.
+// pgxpool.NewWithConfig never dials on its own — the pool is created lazily —
+// so building it here does no I/O; only a later Ping (or query) touches the
+// network.
+func unreachablePool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	dsn := fmt.Sprintf("postgres://user:pass@%s/db?sslmode=disable&connect_timeout=2", addr)
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("new pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// TestLivezReturnsOK is the baseline: the liveness probe must succeed with no
+// setup at all — no pool, no session, no config.
+func TestLivezReturnsOK(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/livez", nil)
+	w := httptest.NewRecorder()
+	Livez(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+// TestLivezIgnoresDatabaseOutage is the entire point of this endpoint: a dead
+// database must never fail liveness. It proves this by first confirming
+// Health — the DB-aware readiness endpoint — really does fail against an
+// unreachable database (otherwise the test would prove nothing), then showing
+// Livez still reports healthy against that same outage.
+func TestLivezIgnoresDatabaseOutage(t *testing.T) {
+	pool := unreachablePool(t)
+
+	h := Health(pool, "test")
+	hr := httptest.NewRequest("GET", "/api/health", nil)
+	hw := httptest.NewRecorder()
+	h(hw, hr)
+	if hw.Code != http.StatusServiceUnavailable {
+		t.Fatalf("Health status = %d, want 503 (database must be unreachable for this test to prove anything)", hw.Code)
+	}
+
+	lr := httptest.NewRequest("GET", "/api/livez", nil)
+	lw := httptest.NewRecorder()
+	Livez(lw, lr)
+	if lw.Code != http.StatusOK {
+		t.Errorf("Livez status = %d, want 200 — liveness must not depend on the database, and Health above just proved it is down", lw.Code)
+	}
+}
 
 func TestHealthEndpointShuttingDown(t *testing.T) {
 	// Mark shutting down

--- a/internal/middleware/accesslog.go
+++ b/internal/middleware/accesslog.go
@@ -23,8 +23,8 @@ import (
 //
 // The path is logged without its query string on purpose: query strings carry
 // OIDC authorization codes and other short-lived secrets that must not land in
-// logs. The health endpoint is skipped so Kubernetes liveness/readiness probes
-// do not drown the access log.
+// logs. The health and liveness endpoints are skipped so Kubernetes
+// liveness/readiness probes do not drown the access log.
 //
 // It does not recover panics, which is what lets Recovery's deliberate
 // re-panic of http.ErrAbortHandler reach net/http and close the connection.
@@ -35,7 +35,7 @@ import (
 func AccessLog(trustProxy bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/api/health" {
+			if r.URL.Path == "/api/health" || r.URL.Path == "/api/livez" {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/middleware/accesslog_test.go
+++ b/internal/middleware/accesslog_test.go
@@ -92,6 +92,18 @@ func TestAccessLogSkipsHealth(t *testing.T) {
 	}
 }
 
+func TestAccessLogSkipsLivez(t *testing.T) {
+	h := AccessLog(false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	recs := captureLogs(t, func() {
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/livez", nil))
+	})
+	if len(recs) != 0 {
+		t.Fatalf("liveness probe should not be logged, got %d records", len(recs))
+	}
+}
+
 // flushRecorder is an httptest.ResponseRecorder that also reports whether Flush
 // was called, so we can assert the wrapper forwards flushes (required for SSE).
 type flushRecorder struct {


### PR DESCRIPTION
## Summary
- Adds `GET /api/livez` — an unconditional 200 whenever the HTTP server can serve. It takes no DB pool and touches no external dependency, so it cannot fail because Postgres blipped.
- `GET /api/health` is unchanged: still DB-aware, still the correct target for a **readiness** probe.
- Extends the access-log health-check skip (`internal/middleware/accesslog.go`) to `/api/livez` too, so it doesn't drown the log once probe traffic moves to it.
- Updates `CLAUDE.md`'s Kubernetes/Health Checks section to recommend `/api/livez` for liveness and `/api/health` for readiness, with a short explanation of the cascade-restart risk.

## Why
Liveness is currently wired to `/api/health`, which pings Postgres and returns 503 when the DB is unreachable. That couples process liveness to an external dependency: a single Postgres blip fails the check on **every replica simultaneously**, so kubelet restarts them all at once — a recoverable dependency outage becomes a cluster-wide crashloop that slows recovery instead of helping it. Liveness should only answer "is this process wedged, would a restart help?" — dependency checks belong in readiness, which just pulls a pod out of the Service instead of killing it.

## Scope
Go + docs only, per the current cross-cutting split of work: **this PR does not touch `helm/`**. A separate PR owns the chart change to point the liveness probe at `/api/livez` — until that lands, this endpoint is purely additive and changes no runtime behavior.

`/api/livez` is not under `/api/v1` (same as `/api/health`), so no OpenAPI spec entry is needed — confirmed against `TestV1RoutesMatchSpec`, which only walks the `/api/v1` router.

## Test plan
- [x] `go build ./cmd/server/` passes
- [x] `go test ./...` passes, 0 skips (dbtest auto-started a throwaway Postgres 18 container since `TEST_DATABASE_URL` wasn't preset)
- [x] New unit tests: `TestLivezReturnsOK`, `TestLivezIgnoresDatabaseOutage` (proves Health 503s against an unreachable DB while Livez still 200s against that same outage), `TestAccessLogSkipsLivez`
- [x] Manual end-to-end verification via an isolated `docker compose -f compose.dev.yml` stack:
  - DB up: `GET /api/health` → 200, `GET /api/livez` → 200
  - DB stopped (`docker stop <db-container>`): `GET /api/health` → **503**, `GET /api/livez` → **200** (the core proof)
  - Test stack torn down afterward; the separately-running dev stack was never touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)