### PR TITLE
test(e2e): wait on the element, not the document, in link-sharing

### DIFF
--- a/e2e/delete-account.spec.ts
+++ b/e2e/delete-account.spec.ts
@@ -41,7 +41,7 @@ test.describe('Delete Account', () => {
 
     // The delete page now shows just a confirm checkbox + button — credential
     // re-prompt is handled by the step-up modal.
-    await expect(page.getByRole('heading', { name: 'Delete Account' })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('heading', { name: 'Delete Account' })).toBeVisible();
 
     // Expire the step-up grace server-side (deterministic) so the modal triggers.
     expireStepUpGrace(deleteUserId);

--- a/e2e/link-sharing.spec.ts
+++ b/e2e/link-sharing.spec.ts
@@ -93,11 +93,16 @@ test.describe('Granular link sharing', () => {
     await page.getByRole('button', { name: 'Log In' }).click();
     await page.waitForURL(/\/dashboard/, { timeout: 15000 });
     await page.goto(`${baseURL}/settings`);
-    await page.waitForLoadState('domcontentloaded');
     // The label wraps the checkbox — clicking the label toggles it. Addressed
     // by testid, not by text: the visible copy is translated and has changed.
     const notesLabel = page.getByTestId('share-toggle-notes').first();
-    await notesLabel.scrollIntoViewIfNeeded({ timeout: 5000 });
+    // Wait on the element, not the document (#460). The client is a CSR SPA —
+    // #root is still empty at DOMContentLoaded — so the toggle only exists once
+    // the bundle, the React mount and the /settings query have all landed. The
+    // old `scrollIntoViewIfNeeded({ timeout: 5000 })` had to cover that whole
+    // chain within 5s and does not retry; click() auto-scrolls anyway, so the
+    // explicit scroll was a failure point that bought no coverage.
+    await expect(notesLabel).toBeVisible();
     await notesLabel.click();
     // Assert it persisted server-side.
     await expect.poll(() =>


### PR DESCRIPTION
## The wait was on the wrong milestone

```ts
await page.goto(`${baseURL}/settings`);
await page.waitForLoadState('domcontentloaded');
const notesLabel = page.getByTestId('share-toggle-notes').first();
await notesLabel.scrollIntoViewIfNeeded({ timeout: 5000 });
```

`DOMContentLoaded` fires when the HTML document is parsed. For this client that milestone means nothing: `client/src/main.tsx` uses `createRoot`, not `hydrateRoot`; `client/index.html` ships an empty `<div id="root">`; the bundle is a deferred `type="module"` script; and Go serves the lot as static files with an index fallback (`cmd/server/main.go`, `spaFallback`). At `domcontentloaded` the root is literally empty.

So everything that has to happen before the toggle exists — bundle fetch and parse, React mount, route render, the `['settings']` query resolving (`Settings.tsx` renders a spinner while `isLoading`), `LinkSettings` rendering the label — was being charged to the 5s `scrollIntoViewIfNeeded` budget. And `scrollIntoViewIfNeeded` does **not** auto-retry, so overrunning that budget is a hard failure, not a slow pass.

The fix waits on the element with the config's 10s `expect` timeout and drops the scroll entirely — `click()` auto-scrolls as part of its actionability checks, so the explicit scroll was a failure point that bought no coverage. The `waitForLoadState` goes too: `page.goto` already waits for `load`, a superset.

## This is deliberately narrow

The issue suggested grepping the suite for the same shape. That was done — **it does not generalise.**

| shape | count | risk |
|---|---|---|
| `waitForLoadState('domcontentloaded')` total | 109 across 54 files | — |
| …followed by a plain action | 76 | benign — `playwright.config.ts` sets neither `actionTimeout` nor `navigationTimeout`, so these are unbounded and capped only by the 60s test timeout |
| …followed by an auto-retrying `expect` | 35 | benign |
| **…followed by a short-timeout, non-retrying action** | **1** | **this one** |

Likewise there are 87 `scrollIntoViewIfNeeded` calls in the suite, but every other one follows a login helper, a `waitForURL`, or a prior interaction — the app is already mounted by then. No shared hydration helper, no 54-file refactor: the defect is a singleton.

Sibling lines in the same file were left alone on purpose. Lines 42-43 and 89-90 are `goto('/login')` + `domcontentloaded` + an un-timed `fill()`, so they are unbounded and benign. Lines 61 and 71 follow `loginViewer`, which ends in `waitForURL(/\/dashboard/)`. Line 61 in particular is load-bearing in a non-obvious way — it is the guard that makes the `toHaveCount(0)` on the next line non-vacuous, so removing it would silently weaken that test.

## One adjacent line

`delete-account.spec.ts` asserted the `Delete Account` heading with an explicit `{ timeout: 5000 }` directly after a `goto` + `domcontentloaded`. It auto-retries, so it degrades gracefully rather than failing hard — but 5s is *tighter* than the suite's own 10s `expect` default for a wait spanning a full SPA remount. Dropping the override just lets it inherit the default. Nothing else in that file is touched.

## Verification

`npx playwright test --list` collects all three link-sharing tests plus delete-account. (There is no tsconfig covering `e2e/`, so `--list` is the parse check.)

`npm run test:e2e -- --grep "Granular link sharing|Delete Account"`, three times, each against a freshly built and torn-down `compose.test.yml` stack:

```
Running 5 tests using 2 workers
  [setup] › e2e/global-setup.ts:5:6 › authenticate
  [chromium] › e2e/delete-account.spec.ts:26:7 › Delete Account › user can delete their own account
  [chromium] › e2e/link-sharing.spec.ts:56:7 › Granular link sharing › default off: owner card is absent
  [chromium] › e2e/link-sharing.spec.ts:66:7 › Granular link sharing › todos only: viewer sees the todo but not the note
  [chromium] › e2e/link-sharing.spec.ts:84:7 › Granular link sharing › notes toggle persists via the settings UI
  5 passed (7.2s)
```

Runs 2 and 3: `5 passed (7.2s)` and `5 passed (9.4s)`. No retries consumed in any run.

**Not verified:** the rest of the suite was not run on this branch. The change touches two files and nothing outside them.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRz8xo2j5onYzoo7Tjg3hs
