### PR TITLE
fix(e2e): run the destructive re-seed in `setup`, not in a racing sibling project

### DIFF
--- a/e2e/admin-setup.ts
+++ b/e2e/admin-setup.ts
@@ -1,18 +1,20 @@
 import { test as setup, expect } from '@playwright/test';
-import { psql, detectAdminEmail } from './fixtures/helpers';
+import { detectAdminEmail } from './fixtures/helpers';
 
 const AUTH_FILE = 'e2e/.auth/admin.json';
 
 const ADMIN_EMAIL = detectAdminEmail();
 const ADMIN_PASSWORD = 'admin1234test';
 
+// The admin user this logs in as is seeded by the `setup` project, which this
+// project depends on. The re-seed used to be invoked from HERE, and that was
+// #461: `admin-setup` is an ordinary sibling of `2fa`, `auth`, `stepup`,
+// `passkey` and `chromium` — they all just declare `dependencies: ['setup']` —
+// so a destructive, suite-wide rewrite of every shared user ran concurrently
+// with the specs that own those rows. Nothing destructive and global belongs in
+// a project that has siblings; see the comment on seedTestUsers() in
+// global-setup.ts.
 setup('authenticate as admin', async ({ page }) => {
-  // Ensure the admin user exists in the DB with the correct password
-  const { execSync } = require('child_process');
-  try {
-    execSync(`npx tsx e2e/setup-test-user.ts`, { stdio: 'pipe', timeout: 30000 });
-  } catch { /* setup may have already run */ }
-
   await page.goto('/login');
   await page.waitForLoadState('domcontentloaded');
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,8 +1,61 @@
 import { test as setup, expect } from '@playwright/test';
+import { execSync } from 'child_process';
 
 const AUTH_FILE = 'e2e/.auth/user.json';
 
+/**
+ * Re-seed the shared test users.
+ *
+ * This is DESTRUCTIVE and GLOBAL: setup-test-user.ts rewrites the password hash
+ * of test@test.com, link-test@test.com, admin@test.com, florian@schauer.to and
+ * 2fa@test.com, forces `email_verified`, sets `totp_enabled = false` and
+ * `totp_secret = NULL`, drops every row in totp_backup_codes for those users,
+ * wipes test@test.com's entries / weights / todos / notes, deletes the account
+ * links between them and resets the enable_registration and enable_barcode
+ * admin settings. Every project in the suite owns some of that state.
+ *
+ * It therefore has to run where nothing can observe it half-applied, and the
+ * `setup` project is the only such place: `dependencies` makes Playwright run a
+ * dependency project to completion before any dependent starts, and every other
+ * project depends on `setup` directly or transitively — `shutdown` excepted, and
+ * that one touches no shared user by construction (see its file header).
+ *
+ * It used to live in `admin-setup` instead, which declares `dependencies:
+ * ['setup']` exactly like `2fa`, `auth`, `stepup`, `passkey` and `chromium` do.
+ * Sibling projects are not ordered against each other, so the re-seed ran
+ * CONCURRENTLY with the specs that own the rows it was rewriting. two-factor.spec
+ * is `mode: 'serial'` — it enables 2FA in one test and logs back in in the next —
+ * so a re-seed landing between the two flipped `totp_enabled` back to false, the
+ * server took the non-2FA branch of POST /api/auth/login, the client went
+ * straight to /dashboard, and `getByLabel('2FA Code')` matched nothing at all.
+ * That is #461. The same window could equally wipe an entry, a todo or a link
+ * out from under the project that had just written it.
+ *
+ * Running it here also keeps the safety net it was added for: `scripts/e2e.sh`
+ * and `npm run test:e2e:setup` both seed before Playwright starts, but a bare
+ * `npx playwright test` against an already-running stack does not, and that is
+ * still a normal way to iterate on a spec.
+ *
+ * A failure is reported and swallowed rather than fatal. The seed needs `docker
+ * exec` against the DB container, which a run driven at a remote E2E_BASE_URL
+ * cannot do even though its users are already seeded; failing hard there would
+ * break a working setup. When the seed genuinely was needed, the login below
+ * fails immediately and points at the same problem.
+ */
+function seedTestUsers() {
+  try {
+    execSync('npx tsx e2e/setup-test-user.ts', { stdio: 'pipe', timeout: 60000 });
+  } catch (err) {
+    const e = err as { stderr?: Buffer; stdout?: Buffer; message?: string };
+    const detail = (e.stderr?.toString() || e.stdout?.toString() || e.message || '').trim();
+    console.warn(`[setup] seeding test users failed, continuing with the database as-is:\n${detail}`);
+  }
+}
+
 setup('authenticate', async ({ page }) => {
+  // Before the login, not after: the seed rewrites this user's password hash.
+  seedTestUsers();
+
   await page.goto('/login');
   await page.waitForLoadState('domcontentloaded');
 

--- a/e2e/two-factor.spec.ts
+++ b/e2e/two-factor.spec.ts
@@ -15,10 +15,27 @@ let capturedBackupCodes: string[] = [];
 /**
  * Both steps of the login — credentials and 2FA code — POST to this one
  * endpoint, so both are awaited the same way.
+ *
+ * The 403 is skipped because it is never an answer: api/client.ts treats a 403
+ * on a mutating request as a stale CSRF token, refetches /api/csrf and re-POSTs
+ * once, so the 403 is the first half of a request that has not finished yet.
+ * Resolving on it would hand the caller a reply the app has already discarded —
+ * submit2faCode would assert `expect(403).toBe(200)` and fail a login that in
+ * fact succeeded, and loginAs2faUser would return before the real round-trip,
+ * making the next assertion pay for an argon2id verification out of its own
+ * budget. Only 403 is filtered, and only because handler.Login cannot produce
+ * one: its own rejections are 400, 401 and 429, and those must still resolve
+ * here so a genuine failure surfaces as a status assertion instead of a wait.
+ *
+ * Hardening, not a fix for anything observed — no run has been traced to this
+ * path.
  */
 function loginPosted(page: import('@playwright/test').Page) {
   return page.waitForResponse(
-    (res) => res.url().includes('/api/auth/login') && res.request().method() === 'POST',
+    (res) =>
+      res.url().includes('/api/auth/login') &&
+      res.request().method() === 'POST' &&
+      res.status() !== 403,
     { timeout: 30000 },
   );
 }

--- a/internal/e2eguard/seed_invocation_test.go
+++ b/internal/e2eguard/seed_invocation_test.go
@@ -1,0 +1,137 @@
+// Package e2eguard holds no production code. It exists to host a build-time
+// assertion about the Playwright suite that Go's test runner can enforce, so it
+// rides the existing `go test ./...` CI job instead of needing a JS lint
+// toolchain this repo does not otherwise have. internal/ui does the same thing
+// for the TypeScript client and internal/config/readme_env_test.go for the
+// README's environment-variable table.
+package e2eguard
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// e2eDir is the tree this assertion reads, relative to this package.
+var e2eDir = filepath.Join("..", "..", "e2e")
+
+// seedOwner is the one file allowed to invoke the seed: the spec behind the
+// `setup` project, which every other project depends on directly or
+// transitively.
+const seedOwner = "global-setup.ts"
+
+// seedScript is the destructive script. setup-test-user.ts rewrites the password
+// hash, `email_verified`, `totp_enabled` and `totp_secret` of every shared test
+// user, drops their backup codes, wipes the main user's entries / weights /
+// todos / notes, deletes the links between them and resets two admin settings.
+const seedScript = "setup-test-user"
+
+// blockComment and lineComment strip commentary before scanning. Both are
+// needed for correctness, not tidiness: fixtures/helpers.ts explains in a line
+// comment why bcryptHash lives where it does "so setup-test-user.ts can use
+// it", and onboarding.spec.ts names the script in a JSDoc block. A scan that
+// skipped this step would fail on prose.
+//
+// lineComment refuses to match a "//" preceded by a colon so that a URL inside
+// a string ("https://...") does not swallow the rest of its line. The residual
+// risk is a bare "//" inside a string literal, which would truncate that line
+// early — a false negative (a missed violation), never a false positive (a
+// wrongly failed build). That asymmetry is the right one here.
+var (
+	blockComment = regexp.MustCompile(`(?s)/\*.*?\*/`)
+	lineComment  = regexp.MustCompile(`(^|[^:])//[^\n]*`)
+)
+
+// stripComments blanks commentary so only executable code is scanned. Comments
+// are replaced by the newlines they spanned rather than deleted, so line
+// numbers after a multi-line comment still map to the original file.
+func stripComments(src string) string {
+	src = blockComment.ReplaceAllStringFunc(src, func(m string) string {
+		return strings.Repeat("\n", strings.Count(m, "\n"))
+	})
+	// The leading capture is the character before "//"; it is part of the match
+	// and has to survive. Line comments cannot span newlines, so none are lost.
+	return lineComment.ReplaceAllStringFunc(src, func(m string) string {
+		if len(m) > 0 && m[0] != '/' {
+			return m[:1]
+		}
+		return ""
+	})
+}
+
+// TestSeedIsInvokedOnlyFromGlobalSetup pins the ordering invariant that #461
+// broke.
+//
+// Playwright's only cross-project ordering primitive is `dependencies`, and it
+// orders a project against its ancestors — never against its siblings. Every
+// project bar `setup` and `shutdown` is a sibling of some other project, so a
+// destructive global write placed in any of them runs CONCURRENTLY with specs
+// that own the rows it rewrites. The seed used to be invoked from
+// admin-setup.ts, whose only dependency is `setup` — exactly like `2fa`,
+// `auth`, `stepup`, `passkey` and `chromium`. A re-seed landing between the two
+// halves of two-factor.spec's serial group reset `totp_enabled` to false, so
+// the login took the non-2FA branch and `getByLabel('2FA Code')` matched
+// nothing at all for its whole 10s budget.
+//
+// Nothing about that is specific to 2FA: the same window could delete an entry,
+// a todo, a note or an account link out from under the project that had just
+// written it. So the rule is positional rather than per-symptom — the seed runs
+// in `setup`, which everything else waits on, or it races something.
+func TestSeedIsInvokedOnlyFromGlobalSetup(t *testing.T) {
+	var offenders []string
+	scanned := 0
+	ownerFound := false
+
+	err := filepath.WalkDir(e2eDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".ts") {
+			return nil
+		}
+		base := filepath.Base(path)
+		// The script may of course name itself.
+		if base == seedScript+".ts" {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		scanned++
+		if !strings.Contains(stripComments(string(src)), seedScript) {
+			return nil
+		}
+		if base == seedOwner {
+			ownerFound = true
+			return nil
+		}
+		rel, relErr := filepath.Rel(e2eDir, path)
+		if relErr != nil {
+			rel = path
+		}
+		offenders = append(offenders, rel)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", e2eDir, err)
+	}
+
+	// A scan that found nothing proves nothing. Guard against the whole test
+	// silently passing because the tree moved or the walk matched no files.
+	if scanned == 0 {
+		t.Fatalf("scanned no .ts files under %s — the guard is not looking at the suite", e2eDir)
+	}
+	if !ownerFound {
+		t.Errorf("%s no longer invokes %s.ts: the destructive seed has to run in the `setup` project, "+
+			"which every other project depends on. If it moved, move this guard with it.", seedOwner, seedScript)
+	}
+	for _, f := range offenders {
+		t.Errorf("e2e/%s invokes %s.ts. That seed is destructive and suite-wide, and Playwright's "+
+			"`dependencies` orders a project against its ancestors but never against its siblings, so "+
+			"running it anywhere except the `setup` project races the specs that own the rows it "+
+			"rewrites (#461). Invoke it from e2e/%s only.", f, seedScript, seedOwner)
+	}
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,12 +28,28 @@ export default defineConfig({
   },
 
   projects: [
-    // Setup: login as main test user, save session
+    // Setup: re-seed the shared test users, then log in as the main one and
+    // save the session.
+    //
+    // This project is the ONLY place a destructive, suite-wide database write
+    // may live, and everything below is what makes that true: `dependencies`
+    // runs a dependency project to completion before any dependent starts, and
+    // every other project depends on `setup` directly or transitively —
+    // `shutdown` excepted, and that one signals a throwaway container clone and
+    // touches no shared user. So a write here cannot be observed half-applied.
+    //
+    // The corollary is the maintenance rule: a seed, a truncate or any other
+    // rewrite of state a spec elsewhere owns belongs HERE and nowhere else.
+    // Putting it in a project that has siblings — anything that merely declares
+    // `dependencies: ['setup']`, i.e. admin-setup, auth, 2fa, stepup, passkey
+    // and chromium — makes it race by design, because siblings are not ordered
+    // against each other. That is exactly what #461 was. Enforced by
+    // TestSeedIsInvokedOnlyFromGlobalSetup in internal/e2eguard.
     {
       name: 'setup',
       testMatch: /global-setup\.ts/,
     },
-    // Admin setup: login as admin user, save session
+    // Admin setup: login as admin user, save session. Seeds nothing — see above.
     {
       name: 'admin-setup',
       testMatch: /admin-setup\.ts/,


### PR DESCRIPTION
## The issue's diagnosis was wrong, and the real cause is worse

#461 proposed a client-side render race after the login POST, to be fixed with hydration-aware waits. That was investigated and **disproven**. The credentials→challenge transition is a plain `useState` flip inside the already-mounted, statically-imported `Login` component (`client/src/pages/Login/Login.tsx:74-84`) — no route change, no `React.lazy` chunk, no Suspense boundary, no refetch, no second request. The post-POST window is a `res.json()` plus one React commit, which is precisely what `toBeVisible`'s auto-retry absorbs.

The tell is in the error text the issue itself quotes:

```
Error: element(s) not found
```

Zero matching nodes for the full 10s. A hydration race renders the field *eventually*. Zero nodes forever means the app was never showing a 2FA challenge at all.

## What actually happened

`e2e/admin-setup.ts` invoked `npx tsx e2e/setup-test-user.ts` from inside the `admin-setup` project. That script is destructive across every shared test user — it rewrites password hashes, forces `email_verified`, sets `totp_enabled = false` and `totp_secret = NULL`, deletes the matching `totp_backup_codes` rows, wipes `test@test.com`'s entries / weights / todos / notes, deletes the account links, and resets the `enable_registration` and `enable_barcode` admin settings.

`dependencies` is Playwright's only cross-project ordering primitive, and it orders a project against its **ancestors — never against its siblings**. `admin-setup` declares `dependencies: ['setup']`, exactly like `auth`, `2fa`, `stepup`, `passkey` and `chromium`. All six become runnable in the same phase, so the re-seed ran concurrently with the specs that own the rows it was rewriting.

`two-factor.spec.ts` is `mode: 'serial'`: one test enables 2FA, a later one logs back in. A re-seed landing between the two put `totp_enabled` back to false → `handler.Login` took its non-2FA branch and answered a plain `{"ok":true}` → the client called `fetchUser()` and navigated to `/dashboard` → the challenge was never rendered.

**The blast radius was never 2FA-specific.** Any project depending only on `setup` could equally have an entry, a todo, a note or a link deleted out from under it. 2FA is just where a serial group made the damage legible instead of merely odd.

## The fix

The seed moves to `e2e/global-setup.ts` — the `setup` project — before its login, since it rewrites that user's password hash. Every other project depends on `setup` directly or transitively except `shutdown`, which signals a throwaway container clone and touches no shared user. So the write cannot be observed half-applied.

The safety net the call was originally added for is kept: a bare `npx playwright test` against an already-running stack still seeds. This matters on CI too — `.github/workflows/build.yml` runs `npx playwright test` bare after `test:e2e:setup`.

`TestSeedIsInvokedOnlyFromGlobalSetup` in the new `internal/e2eguard` package fails `go test ./...` if the seed is ever invoked from another spec, following the `internal/ui` precedent for build-time assertions about non-Go trees.

Separately, `loginPosted` now ignores a 403 — `api/client.ts` retries a mutating request once after a CSRF 403, so that 403 is the first half of a request that has not finished. Resolving on it would make `submit2faCode` assert `expect(403).toBe(200)` against a login that in fact succeeded. **Hardening, not a fix for anything observed.**

## Verification

The race was **reproduced deterministically on the unmodified pre-fix tree**, 3/3, by steering the seed into the serial 2FA group. Byte-identical symptom:

```
✘ [2fa] › two-factor.spec.ts › 4. Regenerate backup codes (15.5s)
    Error: expect(locator).toBeVisible() failed
    Locator: getByLabel('2FA Code')
    Timeout: 10000ms
    Error: element(s) not found
        at submit2faCode (e2e/two-factor.spec.ts:58:27)
  1 failed / 2 did not run / 5 passed
```

It landed on test 4 rather than test 2 — same helper, same assertion, same mechanism. That it moves with timing is itself confirmation the failure is "wherever the seed lands".

| Run | Result |
|---|---|
| `npx playwright test --list` | `Total: 266 tests in 66 files` |
| Pre-fix + steering harness, ×3 | **3/3 failed**, `element(s) not found` |
| Post-fix + same forced concurrency, ×3 | **3/3 green** |
| `--project=2fa --project=admin-setup` | `8 passed (14.4s)` |
| `--project=auth --project=2fa --project=stepup --project=passkey --project=admin-setup` | `22 passed (20.0s)` |
| `npm run test:e2e` (full suite) ×2 | `266 passed (2.9m)`, **both times, zero flaky** |
| `go test ./...` | green |

The guard was verified to actually **fail** when the old call site is restored, not merely to pass as written. The safety net was proven directly: `admin@test.com`'s hash was corrupted in the DB, then a bare `npx playwright test --project=admin-setup` was run, and it passed.

**Not verified:** the original naturally-occurring flake was not reproduced unsteered — the repro deliberately widens the window. This claims a proven mechanism, not a proven frequency.

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRz8xo2j5onYzoo7Tjg3hs
