### PR TITLE
fix: remove SESSION_SECRET, which nothing has read since the Go rewrite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,6 @@
 # PostgreSQL connection string
 DATABASE_URL=postgresql://schautrack:schautrack@db:5432/schautrack
 
-# Random secret for session encryption
-SESSION_SECRET=please-change-me
-
 # =============================================================================
 # GENERAL
 # =============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,7 +275,6 @@ nothing for a KDF to slow down, and argon2 would add ~50 ms of CPU to every requ
 
 Required:
 - `DATABASE_URL`: PostgreSQL connection string
-- `SESSION_SECRET`: Session encryption key
 
 Server / general:
 - `PORT`: Port to listen on (default: `3000`)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ A Helm chart is available for Kubernetes deployments with bundled PostgreSQL.
 helm repo add schautrack https://helm.schautrack.com
 helm repo update
 helm install schautrack schautrack/schautrack \
-  --set config.sessionSecret="$(openssl rand -base64 32)" \
   --set postgresql.auth.password="$(openssl rand -base64 16)"
 ```
 
@@ -120,7 +119,6 @@ Settings follow a strict priority hierarchy: **environment variables** > **admin
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DATABASE_URL` | *(empty)* | PostgreSQL connection string (e.g. `postgresql://user:pass@host:5432/db`) |
-| `SESSION_SECRET` | *(empty)* | Random secret for session encryption |
 
 ### General
 
@@ -222,6 +220,16 @@ WebAuthn-based passwordless login with biometric verification. Users can registe
 **CAPTCHA:** A self-generated SVG CAPTCHA guards against brute-force and abuse. It is always required to complete registration and to resend a verification email, and is triggered on login after 3 failed attempts (counted per session, per account, and per client IP). No third-party CAPTCHA service or key is needed — it works out of the box.
 
 > **`CAPTCHA_BYPASS`** (default: unset) — a **test-only** escape hatch. When set to `true`, `VerifyCaptcha` accepts *any* non-empty answer, disabling CAPTCHA protection entirely. It exists so the end-to-end test suite (`compose.test.yml`) can drive auth flows headlessly. **Never set this in production** — doing so removes all brute-force protection from login and registration.
+
+**Sessions:** there is no session signing or encryption key, and none is needed. Sessions are server-side — the cookie carries only a session ID of 32 bytes from `crypto/rand`, and all session data lives in the `session` table. Authenticity is "this row exists", so there is nothing to sign and no key to rotate. (A signed-cookie design needs one because the cookie carries the session data itself; this one does not.) The cookie is `HttpOnly`, `SameSite=Lax`, and `Secure` whenever the request arrives over TLS or with `X-Forwarded-Proto: https`.
+
+Consequently, **restarting the app or changing configuration does not log anyone out.** Sessions are invalidated by deleting their rows, which the app does automatically on every credential change — password reset and change, disabling or resetting 2FA, email change, and account deletion. A login additionally issues a fresh session ID and deletes the old row, so a session fixed before login cannot survive it. To end every session for an account out of band, delete its rows directly:
+
+```sql
+DELETE FROM "session" WHERE (sess::jsonb->>'userId')::int = <user_id>;
+```
+
+Earlier releases required a `SESSION_SECRET` environment variable. It was a leftover from the Node backend, where `express-session` used it to HMAC-sign the session cookie; the Go rewrite never read it. It has been removed, and setting it now has no effect. The Helm chart still accepts `config.sessionSecret` so existing values files keep validating, but ignores it.
 
 ### Legal Pages
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	// Services
 	settingsCache := database.NewSettingsCache(pool)
-	sessionStore := session.NewStore(pool, cfg.SessionSecret)
+	sessionStore := session.NewStore(pool)
 	emailService := service.NewEmailService(cfg)
 	authLimiter := middleware.NewRateLimiter(cfg.RateLimitAuth, 15*time.Minute, cfg.TrustProxy)
 	strictLimiter := middleware.NewRateLimiter(cfg.RateLimitStrict, 5*time.Minute, cfg.TrustProxy)

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -12,7 +12,6 @@ services:
         condition: service_started
     environment:
       - DATABASE_URL=postgresql://schautrack:testpass@db:5432/schautrack
-      - SESSION_SECRET=e2e-test-session-secret-not-for-production
       - RATE_LIMIT_AUTH=1000
       - RATE_LIMIT_STRICT=1000
       # The public API's limiters, raised for the same reason as the two above:

--- a/compose.yml
+++ b/compose.yml
@@ -3,8 +3,7 @@
 #
 # 1. Copy .env.example to .env
 # 2. Generate a strong POSTGRES_PASSWORD (not the default "schautrack")
-# 3. Set a secure SESSION_SECRET (use: openssl rand -hex 32)
-# 4. Configure SMTP settings for email functionality
+# 3. Configure SMTP settings for email functionality
 # ============================================================================
 
 name: schautrack

--- a/helm/schautrack/README.md
+++ b/helm/schautrack/README.md
@@ -21,7 +21,6 @@ helm repo add schautrack https://helm.schautrack.com
 helm repo update
 
 helm install schautrack schautrack/schautrack \
-  --set config.sessionSecret="$(openssl rand -base64 32)" \
   --set postgresql.auth.password="$(openssl rand -base64 16)"
 ```
 
@@ -32,7 +31,6 @@ git clone https://github.com/schaurian/schautrack.git
 cd schautrack
 
 helm install schautrack ./helm/schautrack \
-  --set config.sessionSecret="$(openssl rand -base64 32)" \
   --set postgresql.auth.password="$(openssl rand -base64 16)"
 ```
 
@@ -42,7 +40,6 @@ Create a `values.yaml` file:
 
 ```yaml
 config:
-  sessionSecret: ""  # Use sealed-secrets or external-secrets
   adminEmail: "admin@example.com"
 
 postgresql:
@@ -90,7 +87,7 @@ For production environments with external secret management (e.g., External Secr
 existingSecret: "my-schautrack-secrets"
 
 # These values are ignored when existingSecret is set:
-# config.sessionSecret, smtp.user, smtp.pass, ai.key, ai.keyEncryptionSecret,
+# smtp.user, smtp.pass, ai.key, ai.keyEncryptionSecret,
 # oidc.clientSecret, postgresql.auth.password, externalDatabase.url
 ```
 
@@ -99,7 +96,6 @@ The referenced Secret must contain these keys:
 | Key | Required | Description |
 |-----|----------|-------------|
 | `DATABASE_URL` | Yes | PostgreSQL connection string |
-| `SESSION_SECRET` | Yes | Session encryption key |
 | `POSTGRES_PASSWORD` | If postgresql.enabled | Password for bundled PostgreSQL |
 | `SMTP_USER` | No | SMTP username |
 | `SMTP_PASS` | No | SMTP password |
@@ -125,10 +121,6 @@ spec:
       remoteRef:
         key: schautrack/database
         property: url
-    - secretKey: SESSION_SECRET
-      remoteRef:
-        key: schautrack/session
-        property: secret
     # ... additional keys as needed
 ```
 
@@ -277,7 +269,6 @@ GitLab for `schaurian/schautrack`, which does not exist there.
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `config.port` | Port the application listens on | `3000` |
-| `config.sessionSecret` | Session encryption key (**required**) | `""` |
 | `config.adminEmail` | Email with admin access | `""` |
 | `config.supportEmail` | Support contact email | `""` |
 | `config.enableLegal` | Enable /imprint, /privacy, /terms | `false` |

--- a/helm/schautrack/templates/secret.yaml
+++ b/helm/schautrack/templates/secret.yaml
@@ -8,7 +8,6 @@ metadata:
 type: Opaque
 stringData:
   DATABASE_URL: {{ include "schautrack.databaseUrl" . | quote }}
-  SESSION_SECRET: {{ .Values.config.sessionSecret | quote }}
   {{- if .Values.postgresql.enabled }}
   POSTGRES_PASSWORD: {{ .Values.postgresql.auth.password | quote }}
   {{- end }}

--- a/helm/schautrack/values.schema.json
+++ b/helm/schautrack/values.schema.json
@@ -191,6 +191,7 @@
           "type": "boolean"
         },
         "sessionSecret": {
+          "description": "REMOVED — accepted and ignored. The app never read SESSION_SECRET: sessions are server-side, keyed by a 32-byte crypto/rand session ID looked up in Postgres, so there is nothing to sign or encrypt. This key is retained ONLY so that existing values files keep validating: `config` sets additionalProperties=false, so deleting it here would fail `helm upgrade` for everyone who set it. Safe to drop from your values. Remove this entry in a future major.",
           "type": [
             "string",
             "integer",

--- a/helm/schautrack/values.yaml
+++ b/helm/schautrack/values.yaml
@@ -13,7 +13,6 @@ imagePullSecrets: []
 # Use an existing secret instead of creating one from values
 # The secret must contain these keys:
 #   - DATABASE_URL (required)
-#   - SESSION_SECRET (required)
 #   - POSTGRES_PASSWORD (required if postgresql.enabled)
 #   - SMTP_USER (optional)
 #   - SMTP_PASS (optional)
@@ -121,10 +120,6 @@ config:
   # Any time.ParseDuration value (e.g. "5s", "10m", "1h"). Empty = server
   # default of 30 min.
   stepUpTTL: ""
-  # ⚠️  SECURITY WARNING: Change sessionSecret before production deployment!
-  # Session secret (required) - generate with: openssl rand -base64 32
-  # DO NOT commit real secrets to Git - use existingSecret instead
-  sessionSecret: ""
   # Admin email - gets access to /admin page
   adminEmail: ""
   # Support email shown on support pages

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,11 +9,10 @@ import (
 )
 
 type Config struct {
-	DatabaseURL   string
-	SessionSecret string
-	Port          string
-	AdminEmail    string
-	BuildVersion  string
+	DatabaseURL  string
+	Port         string
+	AdminEmail   string
+	BuildVersion string
 
 	// SEO
 	RobotsIndex bool
@@ -89,11 +88,6 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("FATAL: DATABASE_URL environment variable is required")
 	}
 
-	sessionSecret := os.Getenv("SESSION_SECRET")
-	if sessionSecret == "" {
-		return nil, fmt.Errorf("FATAL: SESSION_SECRET environment variable is required")
-	}
-
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "3000"
@@ -143,11 +137,10 @@ func Load() (*Config, error) {
 	}
 
 	return &Config{
-		DatabaseURL:   dbURL,
-		SessionSecret: sessionSecret,
-		Port:          port,
-		AdminEmail:    os.Getenv("ADMIN_EMAIL"),
-		BuildVersion:  envOr("BUILD_VERSION", "dev"),
+		DatabaseURL:  dbURL,
+		Port:         port,
+		AdminEmail:   os.Getenv("ADMIN_EMAIL"),
+		BuildVersion: envOr("BUILD_VERSION", "dev"),
 
 		RobotsIndex: os.Getenv("ROBOTS_INDEX") == "true",
 		BaseURL:     os.Getenv("BASE_URL"),

--- a/internal/config/readme_env_test.go
+++ b/internal/config/readme_env_test.go
@@ -58,3 +58,114 @@ func TestReadmeDocumentsEveryEnvVar(t *testing.T) {
 			"(or to buildTimeOnly here, with the reason)", name)
 	}
 }
+
+// envTableRow matches the first column of a row in one of the README's
+// environment-variable tables: "| `SOME_VAR` | ...". Scoping to table rows
+// rather than to every backticked token in the section is deliberate — the
+// prose around those tables mentions `POST`, `GET` and similar, which match an
+// UPPER_SNAKE pattern but are not environment variables.
+var envTableRow = regexp.MustCompile("^\\|\\s*`([A-Z][A-Z0-9_]*)`\\s*\\|")
+
+// TestReadmeEnvTableHasNoPhantomVars is the reverse of the test above, and
+// exists because that direction alone is only half a guarantee.
+//
+// TestReadmeDocumentsEveryEnvVar pins code -> docs: every variable config.go
+// reads has a README row. Nothing pinned docs -> code, so a row for a variable
+// that no longer exists survived indefinitely: deleting an env var from the
+// code left its table row behind, still telling operators to set something the
+// binary would ignore. That is not hypothetical — it is what happened when
+// SESSION_SECRET was removed, and the only reason the table got cleaned up is
+// that a human went looking.
+//
+// The check is deliberately loose about *where* the variable is read: it looks
+// for the name as a string literal anywhere under internal/ or cmd/, not just
+// in config.go. Several documented variables are read outside the config
+// package on purpose — ENABLE_LEGAL in handler/legal.go, STEP_UP_TTL in
+// session/store.go, CAPTCHA_BYPASS in service/captcha.go,
+// LOGIN_CAPTCHA_GLOBAL_THRESHOLD in handler/login_failures.go — and requiring
+// them to live in config.go would be a worse rule than the one it enforces.
+//
+// What this does NOT catch, to be explicit: a variable that is read and then
+// ignored. SESSION_SECRET passed this check for five months, because config.go
+// genuinely did read it — the value simply went nowhere. Proving a config value
+// reaches behaviour needs dataflow analysis, not a grep; this guard only stops
+// the docs from describing a variable that does not exist at all.
+func TestReadmeEnvTableHasNoPhantomVars(t *testing.T) {
+	readme, err := os.ReadFile(filepath.Join("..", "..", "README.md"))
+	if err != nil {
+		t.Fatalf("reading README.md: %v", err)
+	}
+
+	// Restrict to the "## Environment Variables" section; the rest of the
+	// README has tables (the API reference) whose first column is not an env var.
+	lines := strings.Split(string(readme), "\n")
+	start := -1
+	for i, l := range lines {
+		if strings.TrimSpace(l) == "## Environment Variables" {
+			start = i
+			break
+		}
+	}
+	if start == -1 {
+		t.Fatal(`README.md has no "## Environment Variables" heading — this test is not reading the real table`)
+	}
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], "## ") {
+			end = i
+			break
+		}
+	}
+
+	var documented []string
+	for _, l := range lines[start:end] {
+		if m := envTableRow.FindStringSubmatch(l); m != nil {
+			documented = append(documented, m[1])
+		}
+	}
+	if len(documented) == 0 {
+		t.Fatal("no environment variables found in the README tables — this test is not reading real docs")
+	}
+
+	// Collect every quoted string literal under internal/ and cmd/.
+	literals := map[string]bool{}
+	lit := regexp.MustCompile(`"([A-Z][A-Z0-9_]*)"`)
+	for _, root := range []string{filepath.Join("..", "..", "internal"), filepath.Join("..", "..", "cmd")} {
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			src, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			for _, m := range lit.FindAllStringSubmatch(string(src), -1) {
+				literals[m[1]] = true
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	if len(literals) == 0 {
+		t.Fatal("no string literals found under internal/ or cmd/ — this test is not reading real code")
+	}
+
+	var phantom []string
+	for _, name := range documented {
+		if !literals[name] {
+			phantom = append(phantom, name)
+		}
+	}
+	sort.Strings(phantom)
+	for _, name := range phantom {
+		t.Errorf("README.md documents %s in an environment-variable table, but no Go file under "+
+			"internal/ or cmd/ mentions it. Either the variable was removed and its row should go "+
+			"too, or the name is misspelled — an operator following this table would be setting "+
+			"something the binary never reads.", name)
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -143,13 +143,25 @@ type dbExecutor interface {
 }
 
 // Store manages sessions in PostgreSQL.
+//
+// There is deliberately no signing or encryption key here. Sessions are
+// server-side: the cookie carries only the session ID, and the ID is 32 bytes
+// of crypto/rand (see generateSID) whose authority is the row it addresses in
+// the "session" table. Authenticity is "this row exists", which needs no key —
+// unlike a signed-cookie design, where the cookie carries the session data
+// itself and an HMAC is what stops the client editing it.
+//
+// The Node backend this replaced used express-session, whose secret HMAC-signed
+// the SID cookie; the Go rewrite kept a SESSION_SECRET env var and a Store
+// field for ~5 months without ever reading either. Both are gone. Rotating a
+// secret never invalidated a session here — invalidateUserSessions does, and it
+// is wired to every credential change.
 type Store struct {
-	pool   dbExecutor
-	secret string
+	pool dbExecutor
 }
 
-func NewStore(pool *pgxpool.Pool, secret string) *Store {
-	s := &Store{pool: pool, secret: secret}
+func NewStore(pool *pgxpool.Pool) *Store {
+	s := &Store{pool: pool}
 	go s.pruneLoop(context.Background())
 	return s
 }


### PR DESCRIPTION
## It was mandatory and completely unused

`config.go` refused to start without `SESSION_SECRET`. `Load()` read it into `Config.SessionSecret`, `main.go` passed it to `session.NewStore`, `NewStore` stored it in `Store.secret` — and **nothing anywhere read that field.** Removing the field, the constructor parameter and the call site compiles and passes the suite untouched, which is the proof it was dead.

## It wasn't always dead

The Node backend used `express-session`, whose `secret` HMAC-signs the session ID cookie (`s:<sid>.<sig>`) and which throws at startup if you don't supply one — hence the identical `FATAL` check that used to live at `src/app.js:15`.

The Go rewrite (`b41a4b83`) replaced express-session with the hand-rolled `internal/session` store, which writes the bare SID as the cookie value. It carried over the env var, the fatal check, the constructor parameter and the struct field — but not the signing those existed to feed.

```
$ git log -S "secret" -- internal/session/store.go
b41a4b83 feat: rewrite backend from Node.js to Go
```

Exactly one commit. The field was born dead and stayed dead for five months.

## Nothing replaces it, because nothing needs to

Sessions are server-side. The cookie holds a 32-byte `crypto/rand` ID and every byte of session state lives in the `session` table, so authenticity is *"this row exists"* rather than *"this signature verifies"*. A signed-cookie design needs a key because the cookie carries the data; this one does not.

| Job a secret would do | What does it here |
|---|---|
| Stop forging a session | 256 bits of `crypto/rand` + the row must exist in Postgres |
| Detect tampering | Contents are never in the cookie |
| Expire sessions | `expire` column + the prune loop |
| Prevent session fixation | `Regenerate` on every login path |
| Invalidate on credential change | `invalidateUserSessions` — password reset/change, 2FA disable/reset, email change, account deletion |

The only thing the signature ever bought that is now gone: rejecting a malformed SID without a database lookup. That's one indexed hit on `session_pkey`.

## The documentation was the actual harm

`README.md` and `helm/schautrack/README.md` both called it a "Session encryption key", `compose.yml` told operators to generate one with `openssl rand -hex 32`, and `values.yaml` carried a ⚠️ SECURITY WARNING about changing it before production.

An operator rotating it during an incident would reasonably conclude they had invalidated every live session. They had done nothing at all. **A control that looks like a kill switch and isn't is worse than no control, because it stops people reaching for the real one.** README.md now documents how sessions are actually invalidated, including the SQL to do it out of band.

## The Helm key is deliberately kept

`config.sessionSecret` stays in `values.schema.json`, marked removed-and-ignored. The `config` object sets `additionalProperties: false`, so deleting the key would fail `helm upgrade` for every user who set it — which is all of them, since the chart README instructed it.

Verified both directions:

```
# key present (this PR) — existing values file still works, no SESSION_SECRET emitted
$ helm template t . --set config.sessionSecret=legacy --set postgresql.auth.password=pw
PASS   SESSION_SECRET occurrences: 0

# key deleted — what would have shipped without this care
Error: values don't meet the specifications of the schema(s) in the following chart(s):
schautrack:
- at '/config': additional properties 'sessionSecret' not allowed
```

## New guard: `TestReadmeEnvTableHasNoPhantomVars`

The existing `TestReadmeDocumentsEveryEnvVar` pins **code → docs**. Nothing pinned **docs → code**, so removing a variable could leave its README row behind, telling operators to set something the binary ignores — which is exactly what this PR would have done unnoticed.

Its doc comment is explicit about the limit: **it would NOT have caught `SESSION_SECRET`.** `config.go` genuinely did read that one; the value just went nowhere. Proving a config value reaches behaviour needs dataflow analysis, not a grep. This only stops the docs describing a variable that doesn't exist at all.

Verified to fail correctly, not merely to pass as written:

```
--- FAIL: TestReadmeEnvTableHasNoPhantomVars (0.01s)
    README.md documents SESSION_SECRET in an environment-variable table, but no Go
    file under internal/ or cmd/ mentions it. ...
```

## Verification

| Check | Result |
|---|---|
| `go build ./...`, `gofmt`, `go vet ./...` | clean |
| `go test ./...` | 13 packages ok, 0 failures |
| Test stack boots with **no** `SESSION_SECRET` set anywhere | `server started` → `/api/health` returns `status: ok` |
| Full Playwright suite | **266 passed (2.7m)** — covers login, 2FA, step-up, passkeys, logout |
| `helm lint` | 0 charts failed |
| Helm upgrade compat, both directions | as shown above |

Removed from: `config.go`, `session/store.go`, `cmd/server/main.go`, `README.md`, `CLAUDE.md`, `.env.example`, `compose.yml`, `compose.test.yml`, `helm/values.yaml`, `helm/README.md`, `helm/templates/secret.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRz8xo2j5onYzoo7Tjg3hs
