### PR TITLE
ci: add CodeQL code scanning (go + javascript-typescript)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,21 +70,31 @@ jobs:
       # One language's failure says nothing about the other's findings.
       fail-fast: false
       matrix:
-        language:
-          - go
-          - javascript-typescript
+        # Build modes differ per language and neither is a free choice.
+        # javascript-typescript is always analyzed straight from source
+        # (`none` is its only mode). Go does NOT support `none` — the CodeQL
+        # CLI (2.26.2) rejects it outright with "Go does not support the none
+        # build mode", learned from this workflow's own first run — so the go
+        # leg uses `autobuild`, which the analyze step runs implicitly; no
+        # explicit build step is needed below.
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # build-mode: none for BOTH languages, which is why there is no
-      # setup-go/setup-node and no autobuild step here. javascript-typescript
-      # is always analyzed straight from source. Go normally wants a build,
-      # but `none` works in this repo because the binary is a static pure-Go
-      # build — no cgo, no code generated at compile time — so the extractor
-      # sees everything the compiler would. If cgo or build-time codegen ever
-      # enters the tree, switch the go leg to build-mode: autobuild.
-      #
+      # The Go autobuild compiles the module, so give it the toolchain go.mod
+      # asks for instead of gambling on whatever the runner image ships plus a
+      # GOTOOLCHAIN auto-download. Same pin and go-version-file as build.yml.
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
       # The default `code-scanning` query suite on purpose, not
       # security-extended: the extended suite trades precision for recall, and
       # low-precision findings are alerts nobody triages. A check only stays
@@ -93,7 +103,7 @@ jobs:
         uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
         with:
           languages: ${{ matrix.language }}
-          build-mode: none
+          build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,103 @@
+name: CodeQL
+
+# Static analysis for the Go backend and the TypeScript/React client
+# (part of #464).
+#
+# Deliberately a SEPARATE workflow with no place in build.yml's release chain —
+# the same philosophy as build.yml's `vuln` job, for the same reason: CodeQL
+# findings arrive on GitHub's schedule, not this repo's. A new or sharpened
+# query shipped upstream can turn an *unchanged* tree red overnight, and wiring
+# that into the release path would let it block an unrelated hotfix from
+# shipping, with nothing this repo can do about it until the code (or the
+# query) changes. As a standalone check it still shows a red X on the PR — and
+# can be made a required check in branch protection — without holding deploys
+# hostage.
+
+on:
+  # NO path filters, unlike build.yml — deliberate, not an oversight. If this
+  # check is ever required in branch protection, a path-filtered workflow that
+  # does not trigger for (say) a docs-only PR reports no status at all, and the
+  # required check sits "Expected" forever, blocking the merge. CodeQL on this
+  # tree costs a few runner-minutes; scanning every push is cheaper than
+  # debugging a merge that will never unblock.
+  push:
+    branches:
+      - main
+      - staging
+  pull_request:
+    branches:
+      - main
+      - staging
+  # Re-scan the unchanged tree weekly: the query packs improve continuously,
+  # so last month's clean scan says nothing about what this month's queries
+  # would find in the same code. (This is also exactly why the workflow is not
+  # in the release chain — see the header comment.) 04:30 Monday sits clear of
+  # the nightly fuzz run's 04:00 slot only to keep the Actions timeline
+  # readable; they share no runner or cache.
+  schedule:
+    - cron: '30 4 * * 1'
+
+permissions:
+  # Upload SARIF results to the repository's code-scanning tab.
+  security-events: write
+  # Checkout.
+  contents: read
+  # CodeQL packs are fetched from GHCR; the action's docs list this scope for
+  # that fetch. Only the default public packs are used today, but the read
+  # scope is inert and dropping it is the kind of minimalism that breaks the
+  # day a custom pack is added.
+  packages: read
+
+# Same key shape as build.yml, for the same reason (#377): GitHub keeps at most
+# one *pending* run per concurrency group, so a per-ref group on push events
+# throws scans away in a merge burst — and an unscanned tip is exactly the gap
+# this workflow exists to close. Keying pushes on the commit gives every push
+# its own group, which can never be evicted. Pull requests keep one group per
+# PR and DO cancel in progress: a superseded PR scan's results are about to be
+# replaced by the next push anyway, and cancelling it frees the runner.
+concurrency:
+  group: codeql-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    # Both analyses finish in single-digit minutes on this tree; a wedged
+    # extractor must not sit on a runner for the default 6 hours.
+    timeout-minutes: 30
+    strategy:
+      # One language's failure says nothing about the other's findings.
+      fail-fast: false
+      matrix:
+        language:
+          - go
+          - javascript-typescript
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # build-mode: none for BOTH languages, which is why there is no
+      # setup-go/setup-node and no autobuild step here. javascript-typescript
+      # is always analyzed straight from source. Go normally wants a build,
+      # but `none` works in this repo because the binary is a static pure-Go
+      # build — no cgo, no code generated at compile time — so the extractor
+      # sees everything the compiler would. If cgo or build-time codegen ever
+      # enters the tree, switch the go leg to build-mode: autobuild.
+      #
+      # The default `code-scanning` query suite on purpose, not
+      # security-extended: the extended suite trades precision for recall, and
+      # low-precision findings are alerts nobody triages. A check only stays
+      # meaningful while its findings stay actionable.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
+        with:
+          # One category per matrix leg so the two SARIF uploads register as
+          # distinct analyses instead of overwriting each other.
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds `.github/workflows/codeql.yml` — CodeQL code scanning for both languages in this repo.

Part of #464

## What

- **Matrix over `go` and `javascript-typescript`** with per-language build modes: `autobuild` for go, `none` for javascript-typescript. The original plan was `none` for both, but the PR's own first run refuted it — CodeQL CLI 2.26.2 fails init with **"Go does not support the none build mode"** (only `autobuild`/`manual` exist for Go). The go leg therefore autobuilds, with a pinned `setup-go` feeding it the toolchain go.mod declares; the analyze step runs the autobuilder implicitly, so no explicit build step exists.
- **Triggers**: push + PR on `staging`/`main`, plus a weekly Monday 04:30 UTC scan (query packs improve on GitHub's schedule, so a clean scan of unchanged code goes stale).
- **No path filters**, deliberately: a path-filtered required check that never triggers sits "Expected" forever and blocks the merge. CodeQL runs cost a few minutes here.
- **Not in the release chain**, same philosophy as build.yml's `vuln` job: upstream query updates can turn an unchanged tree red overnight, and that must not block an unrelated hotfix. It still reports its own check on every PR and can be made required in branch protection.
- **Concurrency**: same key shape as build.yml (per-commit for pushes so a merge burst can never evict the scan of the tip — the #377 lesson; one cancelling group per PR).
- **Permissions**: `security-events: write`, `contents: read`, `packages: read` (the scopes the action docs list), nothing else.
- Default `code-scanning` query suite, not `security-extended` — precision over recall; low-precision findings are alerts nobody triages.

## Pinning

Every action pinned to the dereferenced commit SHA with a `# vX.Y.Z` comment, matching the repo convention Renovate maintains:

- `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` — copied from build.yml; `git ls-remote` confirms `refs/tags/v7.0.1` → `3d3c42e5...`
- `actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0` — copied from build.yml
- `github/codeql-action/{init,analyze}@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6` — `git ls-remote` confirms `refs/tags/v3.37.6^{}` → `c4dd10e4...` (annotated tag, commit dereferenced)

## Verification

- `actionlint` v1.7.12 against the workflow (both revisions): **clean**.
- All pinned SHAs resolved against the upstream repos via `git ls-remote`.
- CodeQL **cannot be run end-to-end locally** — the real verification is this PR's own `Analyze (go)` / `Analyze (javascript-typescript)` checks, which the `pull_request` trigger exercises right here. That already earned its keep once: the first run caught the go build-mode assumption being wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)