### PR TITLE
ci(lint): enable gosec and bring the tree clean under it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - copyloopvar # loop-variable capture, now that Go 1.22+ changed semantics
     - durationcheck # time.Duration multiplied by a Duration — silently ns²
     - errorlint # == on errors; breaks the moment anything wraps them
+    - gosec # sessions, tokens, cookies, taint tracking — most of this repo is attack surface
     - makezero # append to a make([]T, n) slice, producing n leading zeros
     - sqlclosecheck # rows/stmt never closed
     - usetesting # t.Context()/t.Chdir over the hand-rolled equivalents
@@ -51,6 +52,14 @@ linters:
         # net/http itself logs the connection error, so nothing is lost.
         - (*encoding/json.Encoder).Encode
         - (net/http.ResponseWriter).Write
+
+    gosec:
+      excludes:
+        # G104 is errcheck again — unhandled errors — minus the curated
+        # exclude list above, so it re-reports every deliberately dropped
+        # ResponseWriter.Write that errcheck was just told about. One linter
+        # owns dropped errors, and it is errcheck.
+        - G104
 
   exclusions:
     generated: lax
@@ -99,6 +108,16 @@ linters:
       - path: _test\.go
         linters: [bodyclose]
 
+      # gosec models production code handling untrusted input, which is the
+      # opposite of a test. These write world-readable fixtures into
+      # t.TempDir, read the package's own source off disk, attach bare
+      # cookies to requests they serve to themselves, and in one case
+      # (recovery_test.go) hardcode a "secret" precisely to assert it never
+      # reaches the response. Sixteen findings, every one the test working
+      # as designed. gosec stays on for the code under test.
+      - path: _test\.go
+        linters: [gosec]
+
       # `recover()` yields an `any`, not an `error`, so errors.Is does not even
       # typecheck against it without an intervening assertion. Identity
       # comparison is also precisely what net/http itself does with this
@@ -110,6 +129,94 @@ linters:
       - path: internal/middleware/recovery(_test)?\.go
         linters: [errorlint]
         source: "ErrAbortHandler"
+
+      # A repo-local generator, run by hand or by CI on the repo itself: it
+      # rebuilds the committed API artifacts from constants in this file and
+      # reads back only the two paths it writes. The 0o755/0o644 modes gosec
+      # wants tightened are the point — the output is committed and
+      # world-readable by definition — and there is no untrusted input for
+      # G304's taint to arrive from.
+      - path: cmd/apidocs/main\.go
+        linters: [gosec]
+
+      # The SPA fallback stats every candidate path against an os.DirFS
+      # before serving it — io/fs rejects any path containing a ".." element
+      # outright — and http.ServeFile independently refuses URL paths
+      # containing "..". The taint analysis sees r.URL.Path flow into
+      # ServeFile and neither of the two guards standing in front of it.
+      - path: cmd/server/main\.go
+        linters: [gosec]
+        text: "G703"
+
+      # dbtest exists to shell out: it starts the throwaway postgres
+      # container the DB-backed tests run against, and every argv it builds
+      # is assembled from constants in the same file. Only TestMain
+      # functions import it, so none of this is compiled into the server.
+      - path: internal/dbtest/
+        linters: [gosec]
+        text: "G204"
+
+      # The one variable in the outbound URL is the barcode, matched against
+      # ^\d{8,13}$ (and then check-digit-verified) before the request is
+      # built; the scheme and host are literals in the format string. A run
+      # of digits cannot steer a request to another origin — the taint
+      # analysis just sees a URL built from a path parameter.
+      - path: internal/handler/barcode\.go
+        linters: [gosec]
+        text: "G704"
+
+      # robots.txt. The "tainted" values are the request's own Host and
+      # X-Forwarded-Proto echoed into a text/plain body: there is no HTML
+      # context for XSS to exist in, and the only party who can vary the
+      # input is the requester, reading their own robots.txt back.
+      - path: internal/handler/legal\.go
+        linters: [gosec]
+        text: "G705"
+
+      # Both goroutines are detached from the request on purpose: the
+      # bcrypt→argon2id rehash after a successful login and the API token
+      # last-used UPDATE must survive the response being written, which is
+      # the moment r.Context() would cancel them. The token path bounds
+      # itself with its own five-second timeout; the rehash does one hash
+      # and one UPDATE. Tying either to the request would break them,
+      # quietly, on every fast response.
+      - path: internal/(handler/auth|middleware/apiauth)\.go
+        linters: [gosec]
+        text: "G118"
+
+      # Every flagged conversion narrows a value back into the type it was
+      # born as: user IDs come from SERIAL (int4) primary keys, so int →
+      # int32/uint64 cannot overflow unless the database already has, and a
+      # passkey's SignCount arrived from the authenticator as a uint32
+      # before it was stored. A bounds check here would guard a state the
+      # schema cannot represent.
+      - path: internal/handler/(passkeys|settings)\.go
+        linters: [gosec]
+        text: "G115"
+
+      # Both Set-Cookie sites set HttpOnly and SameSite, and compute Secure
+      # from the request (TLS here or terminated at the proxy) because a
+      # hardcoded `true` would break plain-HTTP local dev. A Secure flag
+      # that is a variable is exactly what this check cannot prove.
+      - path: internal/session/store\.go
+        linters: [gosec]
+        text: "G124"
+
+      # The timezone cookie stores a validated IANA zone name — a display
+      # preference, not a credential. HttpOnly and SameSite are set; Secure
+      # deliberately is not, for the same plain-HTTP-dev reason as the
+      # session cookie, and there is nothing in it worth stealing.
+      - path: internal/middleware/timezone\.go
+        linters: [gosec]
+        text: "G124"
+
+      # Two hits from the credential-name heuristic, neither a credential:
+      # an OpenAPI securityScheme whose job is to document what a bearer
+      # token looks like, and a SQL const that counts rows in api_tokens
+      # and mentions "token" for that reason alone.
+      - path: internal/(openapi/spec|service/apitoken)\.go
+        linters: [gosec]
+        text: "G101"
 
 issues:
   # golangci-lint defaults to reporting at most 50 issues per linter and 3

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -251,6 +251,7 @@ func (s *Store) Destroy(w http.ResponseWriter, r *http.Request, sess *Session) e
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
+		Secure:   requestSecure(r),
 		SameSite: http.SameSiteLaxMode,
 	})
 	// Mark so the middleware's deferred-save doesn't undo the destroy when
@@ -297,15 +298,22 @@ func (s *Store) newSession() *Session {
 	}
 }
 
+// requestSecure reports whether the request arrived over TLS, terminated
+// either here or at the reverse proxy in front. Both Set-Cookie sites use it,
+// so the clearing cookie in Destroy carries the same Secure flag as the
+// session cookie it removes.
+func requestSecure(r *http.Request) bool {
+	return r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
+}
+
 func (s *Store) setCookie(w http.ResponseWriter, r *http.Request, sess *Session) {
-	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 	http.SetCookie(w, &http.Cookie{
 		Name:     CookieName,
 		Value:    sess.ID,
 		Path:     "/",
 		MaxAge:   int(sess.MaxAge.Seconds()),
 		HttpOnly: true,
-		Secure:   secure,
+		Secure:   requestSecure(r),
 		SameSite: http.SameSiteLaxMode,
 	})
 }


### PR DESCRIPTION
Part of #464

## What

Enables `gosec` in `.golangci.yml` and brings the tree clean under it with golangci-lint v2.12.2 (the version CI pins).

## Triage

`gosec` reported **137 findings** on the untouched tree:

| Rule | Count | Disposition |
|------|------:|-------------|
| G104 unhandled errors | 103 | Excluded in `settings.gosec.excludes` — this is errcheck's job, and errcheck (in the `standard` set) already carries the curated exclude list. One linter owns dropped errors. |
| in `_test.go` (G301/G306/G304/G101/G124) | 16 | Blanket test exclusion, mirroring the existing errcheck/bodyclose test rules: fixtures in `t.TempDir`, tests reading their own source, bare cookies on self-served requests, a hardcoded "secret" that exists to assert it never leaks. |
| `cmd/apidocs` (G301/G306/G304) | 3 | Repo-local generator; the committed artifacts are world-readable by design and it only reads back paths it writes. |
| G124 cookie flags | 3 | `Secure` is computed from the request (TLS or `X-Forwarded-Proto`) so plain-HTTP local dev keeps working — a variable flag is unprovable to the analysis. The timezone cookie holds a validated IANA zone name, not a credential. **One real (minor) issue found here — see below.** |
| G115 int conversions | 3 | Round-trips of values born in the narrower type: SERIAL (int4) user IDs, a passkey SignCount that arrived as uint32. |
| G704 SSRF (barcode) | 2 | URL host is a literal; the only variable is a `^\d{8,13}$`-validated, check-digit-verified barcode. |
| G118 detached goroutines | 2 | bcrypt→argon2id rehash and API-token last-used UPDATE must outlive the response; `r.Context()` would cancel them at exactly that moment. |
| G101 hardcoded credentials | 2 | Name-heuristic hits on an OpenAPI securityScheme description and a SQL const that counts `api_tokens` rows. |
| G703 path traversal (SPA fallback) | 1 | Double-guarded upstream: `io/fs` rejects `..` path elements before `fs.Stat` can resolve, and `http.ServeFile` independently refuses URL paths containing `..`. |
| G705 XSS (robots.txt) | 1 | Host/proto echoed into a `text/plain` body the requester reads back; no HTML context exists. |
| G204 subprocess (dbtest) | 1 | Test harness that exists to start the throwaway postgres container; argv built from constants; imported only by `TestMain`. |

**Fixed (1):** the clearing cookie in `session.Store.Destroy` did not carry the `Secure` flag the session cookie is set with. Both `Set-Cookie` sites now share a `requestSecure` helper, so login and logout emit consistent cookie attributes. (This does not silence the G124 — a conditional flag is still unprovable — but it makes the config's justification true at both sites.)

Everything else is a per-path exclusion in `.golangci.yml` with a written justification, following the config's existing style. No inline `#nosec` directives, no existing rules weakened.

Not smuggled in: giving the timezone preference cookie the same conditional `Secure` flag would be a (tiny) behavior change with no secret to protect, so it is documented in the config comment instead, in the same spirit as the existing `noctx` note.

## Verification

- `golangci-lint run ./...` (v2.12.2) — `0 issues.`, exit 0
- `gofmt -l .` — no output
- `go vet ./...` — clean
- `go test ./...` — all packages pass; DB-backed tests ran against dbtest's auto-provisioned postgres (0 skips in `internal/database`), including the session store tests covering `Destroy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)