### PR TITLE
ci: build arm64 only for main, not on every pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -535,10 +535,32 @@ jobs:
       - name: Determine build platforms
         id: platforms
         run: |
-          if [[ "$GITHUB_REF" == "refs/heads/staging" ]]; then
-            echo 'platforms=["linux/amd64"]' >> "$GITHUB_OUTPUT"
-          else
+          # arm64 is built only for the images anyone actually pulls, i.e. the
+          # releases published from main. It runs under QEMU emulation and costs
+          # ~6.4 min of runner time per pull request (vs ~1.4 min for amd64) to
+          # produce an image that is discarded when the branch merges. It was
+          # already skipped on staging; the condition is inverted here so
+          # multi-arch is opt-in for releases rather than opt-out for one branch,
+          # which is what left pull requests building it by default.
+          #
+          # This saves compute, NOT wall-clock. Measured on runs 31300399561 and
+          # 31300998836: total 8.03 min with both arches, 8.12 min with amd64
+          # alone. The arm64 leg is not on the critical path — it runs alongside
+          # e2e (~6.5 min), which is the longest job and sets the floor. Do not
+          # justify further matrix trimming as a latency win without measuring;
+          # if PR latency is the goal, e2e is the job to attack.
+          #
+          # The exposure this accepts: an arm64-only build failure now surfaces
+          # on main instead of on the PR that caused it. That is a narrow window
+          # for this image — the Go binary is CGO_ENABLED=0 static and the client
+          # build is arch-agnostic — but it is not empty. A native npm addon, or
+          # a base image without an arm64 tag, would be caught one merge later
+          # than before. If that ever bites, build both on staging too rather
+          # than reverting to both on every PR.
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
             echo 'platforms=["linux/amd64","linux/arm64"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'platforms=["linux/amd64"]' >> "$GITHUB_OUTPUT"
           fi
 
   create-tag:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ schautrack/
 ### GitHub Actions
 - **Workflow:** `.github/workflows/build.yml`
 - **Registry:** GitHub Container Registry (ghcr.io)
-- **Architectures:** linux/amd64, linux/arm64
+- **Architectures:** linux/amd64 everywhere; linux/arm64 **only on `main`**. arm64 runs under QEMU and is the slowest job in the workflow (~5m40s vs ~1m20s for amd64), so PRs, `staging` and feature branches build amd64 only. Released images are still multi-arch.
 
 ### Automatic Versioning (Conventional Commits)
 The CI automatically computes semantic versions based on commit message prefixes:


### PR DESCRIPTION
## Staging was never the problem

The platform matrix special-cased `staging` to amd64 and gave **everything else** both architectures:

```bash
if [[ "${{ github.ref }}" == "refs/heads/staging" ]]; then
  echo 'platforms=["linux/amd64"]'
else
  echo 'platforms=["linux/amd64","linux/arm64"]'
fi
```

"Everything else" includes pull requests, whose ref is `refs/pull/N/merge`. So every PR built an arm64 image that nobody pulls and that is discarded when the branch merges.

## What it costs — compute, not latency

An earlier revision of this PR claimed it made PRs ~4 minutes faster. **That was wrong**, and the measurement is worth recording so nobody repeats it:

| | #465 (both arches) | #471 (amd64 only) |
|---|---|---|
| `build-and-push (linux/arm64)` | 6.4m | — |
| `build-and-push (linux/amd64)` | 1.0m | 1.4m |
| **total wall-clock** | **8.03m** | **8.12m** |

Unchanged. The arm64 leg was never on the critical path — it ran in parallel with `e2e`, which sets the floor:

```
6.53m  e2e          <- critical path
2.07m  contract
1.50m  test
1.40m  build-and-push (linux/amd64)
```

So the real benefit is **~6.4 min of billed QEMU runner time reclaimed per PR**, for an artifact that was thrown away. PRs do not come back sooner. If PR latency is the goal, `e2e` is the job to attack — noted in the workflow comment so the next person doesn't mistake matrix trimming for a latency win.

## The change

| Ref | Before | After |
|---|---|---|
| `main` | amd64 + arm64 | amd64 + arm64 *(unchanged)* |
| `staging` | amd64 | amd64 *(unchanged)* |
| **pull requests** | **amd64 + arm64** | **amd64** |
| feature branches | amd64 + arm64 | amd64 |

Released images stay multi-arch, so self-hosters on Raspberry Pi, ARM servers and Apple Silicon are unaffected.

## The tradeoff, stated plainly

An arm64-only build failure now surfaces on `main` rather than on the PR that introduced it. Narrow for this image — `CGO_ENABLED=0` static Go, arch-agnostic client build — but not empty: a native npm addon, or a base image without an arm64 tag, would be caught one merge later.

The workflow comment records the preferred remedy if that bites: build both on `staging`, rather than reverting to both on every PR.

## Verification

- `.github/workflows/build.yml` parses as YAML
- Condition simulated against four ref shapes:

```
refs/heads/main            -> ["linux/amd64","linux/arm64"]
refs/heads/staging         -> ["linux/amd64"]
refs/pull/466/merge        -> ["linux/amd64"]
refs/heads/some-feature    -> ["linux/amd64"]
```

- This PR's own run expanded the matrix into **exactly one** `build-and-push` job — no arm64 leg was created, so it isn't running-and-skipping
- Timings above are from the real runs, not estimates

`CLAUDE.md` claimed "Architectures: linux/amd64, linux/arm64" unqualified, which is now only true of `main`. Corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRz8xo2j5onYzoo7Tjg3hs
