### PR TITLE
feat(client): introduce ESLint flat config as a CI gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,6 +217,14 @@ jobs:
         run: npm run typecheck
         working-directory: client
 
+      # tsc accepts plenty that is still wrong — an `any` crossing a boundary,
+      # a hook called conditionally — so type-aware ESLint gates here right
+      # behind it. Every rule that is tuned or off is justified in
+      # client/eslint.config.js, the same contract .golangci.yml makes for Go.
+      - name: Lint client
+        run: npm run lint
+        working-directory: client
+
       - name: Run client tests
         run: npm test
         working-directory: client

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,0 +1,167 @@
+// ESLint flat config for the client, run in CI directly after the typecheck.
+//
+// tsc already rejects what the type system can see, so everything here is
+// chosen for the class of mistake it does not catch: an `any` smuggled
+// through a boundary, a hook called conditionally, an async handler wired
+// where a void return is required. Type-aware rules get their type
+// information from the project service against tsconfig.json.
+//
+// NOTE: typescript-eslint needs the classic JS compiler API, which the native
+// TS 7 npm package no longer ships — that is why package.json pins
+// `typescript` below 6.1 (and renovate.json holds it there).
+
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  // Build output only; everything else in the tree is hand-written.
+  { ignores: ['dist'] },
+
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.strictTypeChecked,
+      tseslint.configs.stylisticTypeChecked,
+      reactHooks.configs.flat.recommended,
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      globals: globals.browser,
+      parserOptions: {
+        projectService: {
+          // vite.config.ts, i18next.config.ts and the node-side tests sit
+          // outside tsconfig.json's `include: ["src"]`. Lint them against a
+          // default project rather than widening the tsconfig, which would
+          // change what `tsc -b` typechecks.
+          allowDefaultProject: [
+            '*.config.ts',
+            'tests/*.ts',
+            'tests/fixtures/setup.ts',
+          ],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // — tuned, not disabled —
+
+      // `onX={() => doThing()}` arrow-shorthand handlers are the pervasive
+      // idiom here (186 findings). The confusion the rule guards against —
+      // accidentally relying on a void return value — cannot arise when JSX
+      // discards the result. Non-shorthand cases stay checked.
+      '@typescript-eslint/no-confusing-void-expression': [
+        'error',
+        { ignoreArrowShorthand: true },
+      ],
+
+      // Async submit/click handlers are idiomatic React, and every one in
+      // this tree try/catches its own awaits. `properties` covers the same
+      // handlers when they travel through options objects (swipe-action
+      // menus). Other void-return positions stay checked.
+      '@typescript-eslint/no-misused-promises': [
+        'error',
+        { checksVoidReturn: { attributes: false, properties: false } },
+      ],
+
+      // Numbers interpolate deterministically; banning them would wrap every
+      // `${count}` in String() for no safety gain. Everything else (objects,
+      // arrays, nullish) is still rejected.
+      '@typescript-eslint/restrict-template-expressions': [
+        'error',
+        { allowNumber: true },
+      ],
+
+      // The `_`-prefix is the codebase's existing marker for "accepted but
+      // deliberately unused" (kept destructured props document a component's
+      // full interface).
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+
+      // — deliberately off —
+      //
+      // Each of these fought an established idiom wholesale rather than
+      // catching mistakes; the reasoning is recorded so the decision can be
+      // revisited instead of re-litigated.
+
+      // 85 findings, all the same shape: fire-and-forget calls whose errors
+      // are handled elsewhere by design — queryClient.invalidateQueries
+      // (settles through React Query, rejections surface in query state),
+      // router navigate(), i18n.changeLanguage, and local async helpers that
+      // try/catch internally (authStore.fetchUser, the handleSave family).
+      // Prefixing every call site with `void` would be a wholesale reformat
+      // that documents nothing.
+      '@typescript-eslint/no-floating-promises': 'off',
+
+      // The `||` fallbacks here are deliberate about falsiness: empty strings
+      // from the API must fall through (`dashboard?.timeZone || 'UTC'`,
+      // `data.unit || user?.weightUnit || 'kg'`). Converting to `??` is a
+      // per-site semantic change, not a mechanical fix, so the rule mostly
+      // proposes behaviour changes.
+      '@typescript-eslint/prefer-nullish-coalescing': 'off',
+
+      // Flags exactly the defensive guards this codebase wants to keep:
+      // optional chains over Record lookups (tsconfig has no
+      // noUncheckedIndexedAccess, so the type system believes every index
+      // hit), fallbacks on API payload fields, `window.EventSource` feature
+      // checks. Types lie at precisely those boundaries; deleting the guards
+      // would trade runtime resilience for lint silence.
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+
+      // Every empty function in the tree is a deliberate no-op: best-effort
+      // `.catch(() => {})` on prefetches, a controlled-input onChange stub,
+      // the intentionally never-settling Promise in lazyRoute's reload path.
+      '@typescript-eslint/no-empty-function': 'off',
+
+      // Every `=== true` / `!== false` on a boolean-typed value in this tree
+      // is a runtime guard, not a tautology: macrosEnabled comes off the wire
+      // typed Record<string, boolean> but can carry missing keys or 1/'yes',
+      // and `!== false` vs `=== true` is how default-on vs default-off is
+      // expressed (macros.test.ts pins this). All four findings were such
+      // guards, and the rule's autofix silently inverted the calories
+      // default — an actively dangerous fix for zero safety gain.
+      '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off',
+
+      // React-compiler-era rules that flag two pre-compiler idioms used
+      // throughout: state synchronised from props/storage inside effects
+      // (modal open/reset flows) and render-time reads of refs in custom
+      // hooks. The fixes are per-component restructurings, not lint fixes —
+      // revisit when the React Compiler is actually adopted.
+      'react-hooks/set-state-in-effect': 'off',
+      'react-hooks/refs': 'off',
+    },
+  },
+
+  // Tests drive untyped surfaces on purpose: quagga2's decode callbacks,
+  // package-lock JSON spelunking, hand-rolled module mocks, DOM nodes that
+  // are known to exist. The unsafe-`any` family and `!` assertions there add
+  // casts, not safety.
+  {
+    files: ['tests/**/*.ts', 'src/**/*.test.{ts,tsx}', 'src/test/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+
+  // Plain JS at the edges: this config file and the maintenance scripts in
+  // scripts/. No type information to lint against, so only the core set.
+  {
+    files: ['**/*.{js,mjs}'],
+    extends: [js.configs.recommended],
+    languageOptions: { globals: globals.node },
+  },
+);

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -32,16 +32,23 @@
         "zustand": "^5.0.5"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.3",
+        "@types/node": "^26.2.0",
         "@types/react": "^19.1.6",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^6.0.0",
+        "eslint": "^10.8.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "eslint-plugin-react-refresh": "^0.5.3",
+        "globals": "^17.9.0",
         "i18next-cli": "^1.67.3",
         "jsdom": "^28.1.0",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^7.0.0",
+        "typescript": "^6.0.2",
+        "typescript-eslint": "^8.66.0",
         "vite": "^8.0.0",
         "vitest": "^4.1.10"
       }
@@ -123,6 +130,164 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
@@ -133,11 +298,99 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -341,6 +594,134 @@
         "sharp": "^0.34.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
@@ -413,6 +794,72 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@img/colour": {
@@ -2852,10 +3299,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2865,6 +3326,17 @@
       "integrity": "sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.18",
@@ -2888,344 +3360,235 @@
         "@types/react": "^19.2.0"
       }
     },
-    "node_modules/@typescript/typescript-aix-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
-      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/type-utils": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
       "engines": {
-        "node": ">=16.20.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.66.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript/typescript-darwin-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
-      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "license": "MIT",
       "engines": {
-        "node": ">=16.20.0"
+        "node": ">= 4"
       }
     },
-    "node_modules/@typescript/typescript-darwin-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
-      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3"
+      },
       "engines": {
-        "node": ">=16.20.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript/typescript-freebsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
+        "debug": "^4.4.3"
+      },
       "engines": {
-        "node": ">=16.20.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript/typescript-freebsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
-      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0"
+      },
       "engines": {
-        "node": ">=16.20.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript/typescript-linux-arm": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
-      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
+      "license": "MIT",
       "engines": {
-        "node": ">=16.20.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript/typescript-linux-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
-      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
       "engines": {
-        "node": ">=16.20.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript/typescript-linux-loong64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
-      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
-      "cpu": [
-        "loong64"
-      ],
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
+      "license": "MIT",
       "engines": {
-        "node": ">=16.20.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript/typescript-linux-mips64el": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
-      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
-      "cpu": [
-        "mips64el"
-      ],
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
       "engines": {
-        "node": ">=16.20.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript/typescript-linux-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
-      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0"
+      },
       "engines": {
-        "node": ">=16.20.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript/typescript-linux-riscv64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
-      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
-      "cpu": [
-        "riscv64"
-      ],
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
       "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-s390x": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
-      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
-      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-sunos-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
-      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
-      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
-      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -3367,6 +3730,30 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3375,6 +3762,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-regex": {
@@ -3442,6 +3846,19 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -3464,6 +3881,62 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -3615,7 +4088,6 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -3703,6 +4175,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3734,6 +4213,13 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.403",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.403.tgz",
+      "integrity": "sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.5",
@@ -3768,6 +4254,205 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
+      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3776,6 +4461,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/execa": {
@@ -3814,6 +4509,27 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -3875,6 +4591,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3887,6 +4654,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -3952,11 +4729,54 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -4121,6 +4941,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -4170,6 +5010,29 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/is-interactive": {
       "version": "2.0.0",
@@ -4295,12 +5158,83 @@
         }
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -4551,6 +5485,22 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/log-symbols": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
@@ -4697,6 +5647,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ndarray": {
       "version": "1.0.19",
       "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
@@ -4729,6 +5686,16 @@
         "ndarray": "^1.0.19",
         "ndarray-ops": "^1.2.2",
         "sharp": "^0.35.0"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/npm-run-path": {
@@ -4791,6 +5758,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/ora": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
@@ -4809,6 +5794,38 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4838,6 +5855,16 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -4919,6 +5946,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/pretty-format": {
@@ -5236,8 +6273,8 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5571,6 +6608,19 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5587,40 +6637,56 @@
         "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
-        "tsc": "bin/tsc"
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=16.20.0"
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
+      "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.66.0",
+        "@typescript-eslint/parser": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0"
       },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici": {
@@ -5632,6 +6698,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
@@ -5652,6 +6725,47 @@
       "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
@@ -6204,6 +7318,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -6221,6 +7345,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -6237,6 +7368,19 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/yoctocolors": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
@@ -6248,6 +7392,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "typecheck": "tsc -b --force",
+    "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
     "i18n:extract": "i18next-cli extract",
@@ -43,16 +44,23 @@
     "ndarray-pixels": "^5.2.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.3",
+    "@types/node": "^26.2.0",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^6.0.0",
+    "eslint": "^10.8.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-react-refresh": "^0.5.3",
+    "globals": "^17.9.0",
     "i18next-cli": "^1.67.3",
     "jsdom": "^28.1.0",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^7.0.0",
+    "typescript": "^6.0.2",
+    "typescript-eslint": "^8.66.0",
     "vite": "^8.0.0",
     "vitest": "^4.1.10"
   }

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -10,9 +10,9 @@ export function setOn401(callback: () => void) {
 async function fetchCsrfToken(): Promise<string> {
   const res = await fetch('/api/csrf');
   if (!res.ok) throw new Error('Failed to fetch CSRF token');
-  const data = await res.json();
+  const data = await res.json() as { token: string };
   csrfToken = data.token;
-  return csrfToken!;
+  return data.token;
 }
 
 export async function getCsrfToken(): Promise<string> {
@@ -58,6 +58,7 @@ export async function api<T = unknown>(
             try {
               resolve(await api<T>(url, options));
             } catch (err) {
+              // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- propagates the retried api() call's own rejection, which is always an ApiError/Error already
               reject(err);
             }
           },
@@ -70,7 +71,7 @@ export async function api<T = unknown>(
     // stale-token 403. A 403 on GET/HEAD is a real authorization failure.
     const method = (options.method || 'GET').toUpperCase();
     if (method === 'GET' || method === 'HEAD') {
-      throw new ApiError(403, body?.error || 'Forbidden', (body ?? {}) as Record<string, unknown>);
+      throw new ApiError(403, body?.error || 'Forbidden', (body ?? {}));
     }
 
     // CSRF failure — refresh token and retry once.
@@ -79,7 +80,7 @@ export async function api<T = unknown>(
     headers.set('X-CSRF-Token', freshToken);
     const retry = await fetch(url, { ...options, headers, credentials: 'same-origin', cache: 'no-store' });
     if (!retry.ok) {
-      const err = await retry.json().catch(() => ({ error: 'Request failed' }));
+      const err = await retry.json().catch(() => ({ error: 'Request failed' })) as { error?: string };
       throw new ApiError(retry.status, err.error || 'Request failed', err);
     }
     return parseBody<T>(retry);
@@ -103,7 +104,7 @@ export async function api<T = unknown>(
   }
 
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: 'Request failed' }));
+    const err = await res.json().catch(() => ({ error: 'Request failed' })) as { error?: string };
     throw new ApiError(res.status, err.error || 'Request failed', err);
   }
 
@@ -114,7 +115,7 @@ export async function api<T = unknown>(
 // of throwing a SyntaxError from res.json().
 function parseBody<T>(res: Response): Promise<T> {
   const contentType = res.headers.get('content-type');
-  if (!contentType || !contentType.includes('application/json')) {
+  if (!contentType?.includes('application/json')) {
     return Promise.resolve({} as T);
   }
   return res.json();

--- a/client/src/api/passkeys.ts
+++ b/client/src/api/passkeys.ts
@@ -1,10 +1,16 @@
 import { api } from './client';
+import type {
+  AuthenticationResponseJSON,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+  RegistrationResponseJSON,
+} from '@simplewebauthn/browser';
 
 // Server uses go-webauthn, which wraps options as {"publicKey": {...}}.
 // SimpleWebAuthn's startRegistration/startAuthentication expects the inner object,
 // so we unwrap here.
 function unwrapPublicKey<T>(res: { publicKey?: T } & T): T {
-  return (res.publicKey ?? res) as T;
+  return (res.publicKey ?? res);
 }
 
 export async function passkeyLoginBegin() {
@@ -12,7 +18,7 @@ export async function passkeyLoginBegin() {
   return unwrapPublicKey(res);
 }
 
-export function passkeyLoginFinish(credential: AuthenticatorAssertionResponseJSON) {
+export function passkeyLoginFinish(credential: AuthenticationResponseJSON) {
   return api<{ ok: boolean }>('/passkeys/login/finish', {
     method: 'POST',
     body: JSON.stringify(credential),
@@ -24,7 +30,7 @@ export async function passkeyRegisterBegin() {
   return unwrapPublicKey(res);
 }
 
-export function passkeyRegisterFinish(credential: AuthenticatorAttestationResponseJSON, name: string) {
+export function passkeyRegisterFinish(credential: RegistrationResponseJSON, name: string) {
   return api<{ ok: boolean }>(`/passkeys/register/finish?name=${encodeURIComponent(name)}`, {
     method: 'POST',
     body: JSON.stringify(credential),
@@ -70,9 +76,3 @@ export interface AuthInfo {
   passkeysEnabled: boolean;
   oidc: OIDCInfo | null;
 }
-
-// WebAuthn type helpers (simplified for browser API)
-type PublicKeyCredentialCreationOptionsJSON = Record<string, unknown>;
-type PublicKeyCredentialRequestOptionsJSON = Record<string, unknown>;
-type AuthenticatorAttestationResponseJSON = Record<string, unknown>;
-type AuthenticatorAssertionResponseJSON = Record<string, unknown>;

--- a/client/src/api/settings.ts
+++ b/client/src/api/settings.ts
@@ -125,7 +125,7 @@ export function importData(file: File, dryRun = false): Promise<ImportResult> {
 // download via a Blob URL; routing through api() is what lets the step-up
 // modal intercept the 403 and retry on success.
 export async function exportData(): Promise<void> {
-  const data = await api<unknown>('/settings/export', { method: 'POST' });
+  const data = await api('/settings/export', { method: 'POST' });
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');

--- a/client/src/api/stepup.ts
+++ b/client/src/api/stepup.ts
@@ -13,7 +13,7 @@ export async function stepUpPasskeyBegin() {
     '/api/auth/step-up/passkey/begin',
     { method: 'POST' },
   );
-  return (res.publicKey ?? res) as Record<string, unknown>;
+  return (res.publicKey ?? res);
 }
 
 export function stepUpPasskeyFinish(credential: Record<string, unknown>) {

--- a/client/src/api/weight.test.ts
+++ b/client/src/api/weight.test.ts
@@ -7,12 +7,13 @@ import { upsertWeight } from './weight';
  * so a key that should not be there is a silent overwrite rather than an error.
  */
 
-type Sent = { url: string; body: Record<string, unknown> };
+interface Sent { url: string; body: Record<string, unknown> }
 
 function stubFetch(): Sent[] {
   const sent: Sent[] = [];
   vi.stubGlobal(
     'fetch',
+    // eslint-disable-next-line @typescript-eslint/require-await -- async without await is the plainest way for this mock to satisfy fetch's Promise<Response> contract
     vi.fn(async (url: string, init?: RequestInit) => {
       if (url === '/api/csrf') {
         return new Response(JSON.stringify({ token: 'test-csrf' }), {
@@ -20,7 +21,7 @@ function stubFetch(): Sent[] {
           headers: { 'Content-Type': 'application/json' },
         });
       }
-      sent.push({ url, body: JSON.parse(String(init?.body ?? '{}')) });
+      sent.push({ url, body: JSON.parse((init?.body ?? '{}') as string) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },

--- a/client/src/components/StepUpModal.tsx
+++ b/client/src/components/StepUpModal.tsx
@@ -52,7 +52,7 @@ export default function StepUpModal() {
     clear();
   };
 
-  const submitPassword = async (e: React.FormEvent) => {
+  const submitPassword = async (e: React.SubmitEvent) => {
     e.preventDefault();
     if (!pending) return;
     setError('');
@@ -143,7 +143,7 @@ export default function StepUpModal() {
             >
               {authInfo.oidc.logo && (
                 <img src={authInfo.oidc.logo} alt="" className="inline-block w-5 h-5 mr-2 align-middle"
-                  onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }} />
+                  onError={(e) => { (e.currentTarget).style.display = 'none'; }} />
               )}
               {t('stepUp.continueWith', { provider: authInfo.oidc.label })}
             </Button>

--- a/client/src/components/ui/MacroPill.tsx
+++ b/client/src/components/ui/MacroPill.tsx
@@ -2,6 +2,7 @@ import { cn } from '@/lib/utils';
 
 export type MacroPillKey = 'kcal' | 'protein' | 'carbs' | 'fat' | 'fiber' | 'sugar';
 
+// eslint-disable-next-line react-refresh/only-export-components -- the style map is colocated with the pill by design; a full reload on HMR here is acceptable
 export const MACRO_PILL_STYLES: Record<MacroPillKey, { bg: string; border: string; label: string }> = {
   kcal:    { bg: 'bg-macro-kcal/10',    border: 'border-macro-kcal/20',    label: 'text-macro-kcal/70' },
   protein: { bg: 'bg-macro-protein/10', border: 'border-macro-protein/20', label: 'text-macro-protein/70' },

--- a/client/src/components/ui/Toaster.tsx
+++ b/client/src/components/ui/Toaster.tsx
@@ -44,7 +44,7 @@ export default function Toaster() {
               className="bg-transparent border border-current/50 rounded-md px-2 py-0.5 text-xs font-semibold uppercase tracking-wider cursor-pointer hover:bg-current/10 transition-colors"
               onClick={(e) => {
                 e.stopPropagation();
-                toast.action!.onClick();
+                toast.action?.onClick();
                 removeToast(toast.id);
               }}
             >

--- a/client/src/hooks/useAutosave.ts
+++ b/client/src/hooks/useAutosave.ts
@@ -51,6 +51,7 @@ export function useAutosave<T>(
   }, [saveFn, addToast]);
 
   const saveRef = useRef(save);
+  // eslint-disable-next-line react-hooks/immutability -- latest-ref pattern: the armed timer must call the newest save without re-arming on every render
   saveRef.current = save;
 
   useEffect(() => {
@@ -67,7 +68,7 @@ export function useAutosave<T>(
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+
   }, [data, delay, enabled]);
 
   // Save immediately (for blur events etc)

--- a/client/src/hooks/useSSE.ts
+++ b/client/src/hooks/useSSE.ts
@@ -73,7 +73,7 @@ export function useSSE() {
         revalidate(['dashboard'], ['settings']);
         fetchUser();
         try {
-          const data = JSON.parse((e as MessageEvent).data);
+          const data = JSON.parse(e.data as string) as { type?: string; email?: string };
           if (data.type === 'request' && data.email) {
             addToast('info', i18n.t('notifications.linkRequestWantsToLink', { ns: 'common', email: data.email }));
           }
@@ -124,5 +124,5 @@ export function useSSE() {
       sourceRef.current?.close();
       sourceRef.current = null;
     };
-  }, [revalidate, fetchUser]);
+  }, [revalidate, fetchUser, addToast]);
 }

--- a/client/src/hooks/useVersionInfo.ts
+++ b/client/src/hooks/useVersionInfo.ts
@@ -39,15 +39,15 @@ export function useVersionInfo(): VersionInfo {
     (async () => {
       let current: string | null = null;
       try {
-        const health = await fetch('/api/health').then((r) => r.json());
-        current = health?.version ?? null;
+        const health = await fetch('/api/health').then((r) => r.json() as Promise<{ version?: string }>);
+        current = health.version ?? null;
       } catch {
         // Health unreachable — leave current null; the card/footer just hide the version.
       }
 
       let rel: Partial<LatestVersionInfo> = {};
       try {
-        rel = await fetch('/api/latest-version').then((r) => r.json());
+        rel = await fetch('/api/latest-version').then((r) => r.json() as Promise<Partial<LatestVersionInfo>>);
       } catch {
         // Release source unreachable — URLs fall back to null, outdated stays false.
       }

--- a/client/src/i18n/catalogs.test.ts
+++ b/client/src/i18n/catalogs.test.ts
@@ -12,17 +12,14 @@ import { createInstance, type i18n } from 'i18next';
 
 type Catalog = Record<string, unknown>;
 
-const modules = import.meta.glob('./locales/*/*.json', { eager: true }) as Record<
-  string,
-  { default: Catalog }
->;
+const modules = import.meta.glob('./locales/*/*.json', { eager: true });
 
 const catalogs: Record<string, Record<string, Catalog>> = {};
 for (const path in modules) {
-  const match = path.match(/\.\/locales\/([^/]+)\/([^/]+)\.json$/);
+  const match = /\.\/locales\/([^/]+)\/([^/]+)\.json$/.exec(path);
   if (!match) continue;
   const [, lng, ns] = match;
-  (catalogs[lng] ??= {})[ns] = modules[path].default;
+  (catalogs[lng] ??= {})[ns] = (modules[path] as { default: Catalog }).default;
 }
 
 const LOCALES = Object.keys(catalogs).sort();

--- a/client/src/i18n/index.ts
+++ b/client/src/i18n/index.ts
@@ -20,16 +20,13 @@ export function isSupportedLanguage(code: string): boolean {
 }
 
 // Eagerly load every locale/namespace JSON so adding a file needs no wiring here.
-const modules = import.meta.glob('./locales/*/*.json', { eager: true }) as Record<
-  string,
-  { default: Record<string, unknown> }
->;
+const modules = import.meta.glob('./locales/*/*.json', { eager: true });
 const resources: Record<string, Record<string, Record<string, unknown>>> = {};
 for (const path in modules) {
-  const match = path.match(/\.\/locales\/([^/]+)\/([^/]+)\.json$/);
+  const match = /\.\/locales\/([^/]+)\/([^/]+)\.json$/.exec(path);
   if (!match) continue;
   const [, lng, ns] = match;
-  (resources[lng] ??= {})[ns] = modules[path].default;
+  (resources[lng] ??= {})[ns] = (modules[path] as { default: Record<string, unknown> }).default;
 }
 
 i18n

--- a/client/src/lib/lazyRoute.ts
+++ b/client/src/lib/lazyRoute.ts
@@ -22,7 +22,7 @@ const RELOAD_COOLDOWN_MS = 30_000;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function lazyRoute<T extends ComponentType<any>>(factory: () => Promise<{ default: T }>) {
   return lazy(() =>
-    factory().catch((err) => {
+    factory().catch((err: unknown) => {
       const last = Number(sessionStorage.getItem(RELOAD_FLAG) ?? 0);
       if (Date.now() - last > RELOAD_COOLDOWN_MS) {
         sessionStorage.setItem(RELOAD_FLAG, String(Date.now()));

--- a/client/src/lib/mathParser.test.ts
+++ b/client/src/lib/mathParser.test.ts
@@ -15,7 +15,7 @@ import { parseAmount } from './mathParser';
 
 describe('parseAmount', () => {
   it('parses simple numbers', () => {
-    const cases: Array<[string, boolean, number]> = [
+    const cases: [string, boolean, number][] = [
       ['123', true, 123],
       ['0', true, 0],
       ['999', true, 999],
@@ -26,7 +26,7 @@ describe('parseAmount', () => {
   });
 
   it('rounds decimals to the nearest integer', () => {
-    const cases: Array<[string, number]> = [
+    const cases: [string, number][] = [
       ['123.7', 124],
       ['123.2', 123],
       ['123.5', 124],
@@ -37,7 +37,7 @@ describe('parseAmount', () => {
   });
 
   it('evaluates arithmetic', () => {
-    const cases: Array<[string, number]> = [
+    const cases: [string, number][] = [
       ['100 + 50', 150],
       ['200 - 30', 170],
       ['10 * 5', 50],
@@ -49,7 +49,7 @@ describe('parseAmount', () => {
   });
 
   it('respects parentheses', () => {
-    const cases: Array<[string, number]> = [
+    const cases: [string, number][] = [
       ['(10 + 20) * 3', 90],
       ['10 + (20 * 3)', 70],
       ['((10 + 5) * 2) - 5', 25],
@@ -60,7 +60,7 @@ describe('parseAmount', () => {
   });
 
   it('normalizes alternative operator symbols', () => {
-    const cases: Array<[string, number]> = [
+    const cases: [string, number][] = [
       ['10 × 5', 50],
       ['10 x 5', 50],
       ['10 X 5', 50],
@@ -75,7 +75,7 @@ describe('parseAmount', () => {
   });
 
   it('strips thousands-separator commas', () => {
-    const cases: Array<[string, number]> = [
+    const cases: [string, number][] = [
       ['1,000', 1000],
       ['1,234 + 500', 1734],
     ];
@@ -120,7 +120,7 @@ describe('parseAmount', () => {
   });
 
   it('handles negatives and unary operators', () => {
-    const cases: Array<[string, number]> = [
+    const cases: [string, number][] = [
       ['-10', -10],
       ['10 + (-5)', 5],
       ['-(10 + 5)', -15],
@@ -131,7 +131,7 @@ describe('parseAmount', () => {
   });
 
   it('respects operator precedence in complex expressions', () => {
-    const cases: Array<[string, number]> = [
+    const cases: [string, number][] = [
       ['100 + 50 * 2 - 10', 190],
       ['(100 + 50) * 2 - 10', 290],
       ['100 / (2 + 3) * 4', 80],
@@ -142,7 +142,7 @@ describe('parseAmount', () => {
   });
 
   it('enforces the maxAbs bound', () => {
-    const cases: Array<[string, number, boolean, number]> = [
+    const cases: [string, number, boolean, number][] = [
       ['9999', 9999, true, 9999],
       ['-9999', 9999, true, -9999],
       ['10000', 9999, false, 0],
@@ -159,7 +159,7 @@ describe('parseAmount', () => {
   // *number*, so for the SPA this parser is the one that decides what gets
   // stored. Keep the two tables in sync.
   it('pins the consequences of the normalization pass', () => {
-    const cases: Array<[string, boolean, number, string]> = [
+    const cases: [string, boolean, number, string][] = [
       // Hex-looking input. "x" -> "*" would make "0x10" read as 0*10 and be
       // silently accepted as 0 — which EntryForm sends as `amount: 0`, an
       // empty entry reported as a success. Rejected instead.

--- a/client/src/lib/mathParser.ts
+++ b/client/src/lib/mathParser.ts
@@ -50,7 +50,7 @@ function safeMathEval(expr: string): number {
   function parseNumber(): number {
     let num = '';
     while (pos < expr.length && /[0-9.]/.test(expr[pos])) {
-      num += consume();
+      num += consume() ?? '';
     }
     if (num === '') throw new Error('Invalid number');
     if (!NUMBER_RE.test(num)) throw new Error('Malformed number: ' + num);
@@ -67,8 +67,8 @@ function safeMathEval(expr: string): number {
     // A leading "." starts a number too — see the matching comment in
     // parseFactor in internal/service/mathparser.go. parseNumber rejects the
     // runs that are not real numbers (".", "..5").
-    if (/[0-9.]/.test(ch!)) return parseNumber();
-    throw new Error('Unexpected: ' + ch);
+    if (ch !== null && /[0-9.]/.test(ch)) return parseNumber();
+    throw new Error('Unexpected: ' + String(ch));
   }
 
   function parseTerm(): number {
@@ -94,7 +94,7 @@ function safeMathEval(expr: string): number {
   }
 
   const result = parseExpression();
-  if (pos < expr.length) throw new Error('Unexpected at ' + pos);
+  if (pos < expr.length) throw new Error(`Unexpected at ${pos}`);
   return result;
 }
 

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -26,6 +26,7 @@ export const queryClient = new QueryClient({
   },
 });
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index.html always ships #root; if it is missing, crashing at boot is the honest failure
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ErrorBoundary>

--- a/client/src/pages/Admin/Admin.tsx
+++ b/client/src/pages/Admin/Admin.tsx
@@ -52,7 +52,7 @@ export default function Admin() {
 const INITIAL_USERS = 25;
 const LOAD_MORE_BATCH = 25;
 
-function UserList({ users, onDelete }: { users: Array<{ id: number; email: string; email_verified: boolean; created_at: string }>; onDelete: (id: number) => void }) {
+function UserList({ users, onDelete }: { users: { id: number; email: string; email_verified: boolean; created_at: string }[]; onDelete: (id: number) => void }) {
   const { t } = useTranslation('settings');
   const [search, setSearch] = useState('');
   const [shown, setShown] = useState(INITIAL_USERS);
@@ -177,9 +177,11 @@ function AdminSettingsForm({
         t('admin.dangerousPrompt', { envVar: meta.envVar, help: meta.help, phrase }),
       );
       if (typed !== phrase) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- removing a declined key from a fresh local copy; keys come from our own settings map, not user input
         delete editable[k];
         setValues((prev) => {
           const next = { ...prev };
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- same: copy-minus-key state update on our own keys
           delete next[k];
           return next;
         });
@@ -191,6 +193,7 @@ function AdminSettingsForm({
     await saveAdminSettings(editable);
     setValues((prev) => {
       const next = { ...prev };
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- clearing saved drafts out of a fresh copy; keys are our own setting names
       for (const k of Object.keys(editable)) delete next[k];
       return next;
     });
@@ -278,7 +281,9 @@ function SettingField({
   const isEnv = meta.source === 'env';
   const isBool = ['enable_legal', 'enable_barcode', 'oidc_require_invite', 'smtp_secure', 'trust_proxy', 'robots_index'].includes(settingKey);
   const isRegistrationMode = settingKey === 'enable_registration';
-  const value = isDirty ? draft! : meta.value;
+  // isDirty === `key in values`, so a dirty row always has a draft string;
+  // `??` encodes that invariant without a non-null assertion.
+  const value = draft ?? meta.value;
 
   // Secrets: don't pre-populate the input. Show a "set" indicator + Replace
   // button. Once revealing, show an empty input the user types into.
@@ -365,7 +370,7 @@ function InviteManager() {
   const [creating, setCreating] = useState(false);
   const [copiedId, setCopiedId] = useState<number | null>(null);
 
-  const handleCreate = async (e: React.FormEvent) => {
+  const handleCreate = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setCreating(true);
     try {

--- a/client/src/pages/Dashboard/AIPhotoModal.tsx
+++ b/client/src/pages/Dashboard/AIPhotoModal.tsx
@@ -167,7 +167,7 @@ export default function AIPhotoModal({ isOpen, onClose, onResult, enabledMacros:
       if (res.ok && res.calories != null) {
         // Auto-fill the entry form and close
         onResult({
-          calories: res.calories!,
+          calories: res.calories,
           name: res.food || '',
           macros: res.macros,
         });

--- a/client/src/pages/Dashboard/BarcodeScanModal.tsx
+++ b/client/src/pages/Dashboard/BarcodeScanModal.tsx
@@ -170,7 +170,7 @@ export default function BarcodeScanModal({ isOpen, onClose, onResult, enabledMac
     }
   }, [isOpen, stopScanner]);
 
-  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
     setErrorMsg('');
@@ -201,7 +201,7 @@ export default function BarcodeScanModal({ isOpen, onClose, onResult, enabledMac
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
-  const handleManualSubmit = (e: React.FormEvent) => {
+  const handleManualSubmit = (e: React.SubmitEvent) => {
     e.preventDefault();
     const code = manualCode.trim();
     if (/^\d{8,13}$/.test(code)) {
@@ -395,7 +395,7 @@ export default function BarcodeScanModal({ isOpen, onClose, onResult, enabledMac
                       <button
                         type="button"
                         className={`rounded-md px-2.5 py-2 text-xs font-medium transition-colors cursor-pointer border ${parseFloat(grams) === product.servingQuantity ? 'border-primary bg-primary/10 text-primary' : 'border-border bg-transparent text-muted-foreground hover:text-foreground hover:border-primary/50'}`}
-                        onClick={() => handleServingPreset(product.servingQuantity!)}
+                        onClick={() => handleServingPreset(product.servingQuantity ?? 0)}
                       >
                         {product.servingSize || `${product.servingQuantity}g`}
                       </button>

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -47,7 +47,7 @@ export default function Dashboard() {
       selectUser(dashboard.user.id, t('store.you'), true);
       selectDay(dashboard.selectedDate);
     }
-  }, [dashboard, currentUserId, selectUser, selectDay]);
+  }, [dashboard, currentUserId, selectUser, selectDay, t]);
 
   const effectiveUserId = currentUserId || dashboard?.user.id;
   const activeView = dashboard?.sharedViews.find((v) => v.userId === effectiveUserId);
@@ -58,6 +58,7 @@ export default function Dashboard() {
   // Fetch entries for selected day
   const { data: dayData } = useQuery({
     queryKey: ['day-entries', effectiveUserId, selectedDate],
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `enabled` below gates this queryFn on effectiveUserId being set
     queryFn: () => getDayEntries(effectiveUserId!, selectedDate),
     enabled: !!effectiveUserId && !!selectedDate,
     placeholderData: keepPreviousData,
@@ -72,11 +73,13 @@ export default function Dashboard() {
   });
 
   // Compute selected day's totals from entries
+  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- deps are optional-chained subpaths, finer-grained than the compiler can verify
   const selectedTotal = useMemo(() => {
     if (!dayData?.entries) return dashboard?.todayTotal ?? 0;
     return dayData.entries.reduce((sum, e) => sum + (e.amount || 0), 0);
   }, [dayData?.entries, dashboard?.todayTotal]);
 
+  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- same: optional-chained deps
   const selectedMacroTotals = useMemo(() => {
     if (!dayData?.entries) return dashboard?.todayMacroTotals ?? {};
     const totals: Record<string, number> = {};

--- a/client/src/pages/Dashboard/EntryForm.tsx
+++ b/client/src/pages/Dashboard/EntryForm.tsx
@@ -90,7 +90,7 @@ export default function EntryForm({ selectedDate, caloriesEnabled, autoCalcCalor
     setMacros((prev) => ({ ...prev, [key]: value }));
   }, []);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setLoading(true);
 

--- a/client/src/pages/Dashboard/PlanCard.tsx
+++ b/client/src/pages/Dashboard/PlanCard.tsx
@@ -31,7 +31,7 @@ export default function PlanCard({ weightUnit: contextUnit }: Props) {
     insufficient_data: { label: t('plan.card.trend.insufficientData'), classes: 'bg-surface border-white/6 text-muted-foreground' },
   };
 
-  if (!data?.goal || data.goal.status !== 'active') return null;
+  if (data?.goal?.status !== 'active') return null;
 
   const { goal } = data;
 

--- a/client/src/pages/Dashboard/TodoList.tsx
+++ b/client/src/pages/Dashboard/TodoList.tsx
@@ -126,7 +126,9 @@ export default function TodoList({ date, userId, canEdit, timezone }: Props) {
   const [addOnOpen, setAddOnOpen] = useState(false);
   const [tick, setTick] = useState(0);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- `tick` is deliberately extra: it forces the per-minute recompute driven by the interval below
   const todayStr = useMemo(() => getTodayStr(timezone), [timezone, tick]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- same: `tick` drives the per-minute recompute
   const currentTime = useMemo(() => getCurrentTime(timezone), [timezone, tick]);
   const isToday = date === todayStr;
 
@@ -293,7 +295,7 @@ function TodoManager({ onClose, initialAdd, onAddShown }: { onClose: () => void;
     queryClient.invalidateQueries({ queryKey: ['todos-day'] });
   };
 
-  const handleCreate = async (e: React.FormEvent) => {
+  const handleCreate = async (e: React.SubmitEvent) => {
     e.preventDefault();
     if (!newName.trim()) return;
     setCreating(true);

--- a/client/src/pages/Dashboard/WeightRow.tsx
+++ b/client/src/pages/Dashboard/WeightRow.tsx
@@ -26,10 +26,10 @@ export default function WeightRow({ weightEntry, lastWeightEntry, weightUnit, ca
 
   const entry = weightEntry || lastWeightEntry;
   const isToday = !!weightEntry;
-  const displayValue = entry ? String(Number(entry.weight)) : '';
+  const displayValue = entry ? String(entry.weight) : '';
   // Only the selected date's own reading, never the last one: a stale body fat
   // is not a useful pre-fill, and showing one would invite saving it to today.
-  const bodyFatValue = weightEntry?.body_fat != null ? String(Number(weightEntry.body_fat)) : '';
+  const bodyFatValue = weightEntry?.body_fat != null ? String(weightEntry.body_fat) : '';
 
   const handleSave = async () => {
     const raw = inputRef.current?.value.trim() || '';
@@ -155,7 +155,7 @@ export default function WeightRow({ weightEntry, lastWeightEntry, weightUnit, ca
           </span>
         ) : (
           <span className={`text-lg font-semibold tabular-nums ${colorClass}`}>
-            {entry ? Number(entry.weight).toFixed(1) : '—'}
+            {entry ? entry.weight.toFixed(1) : '—'}
             <span className="text-sm text-muted-foreground font-normal ml-1">{weightUnit}</span>
           </span>
         )}

--- a/client/src/pages/ForgotPassword/ForgotPassword.tsx
+++ b/client/src/pages/ForgotPassword/ForgotPassword.tsx
@@ -20,9 +20,10 @@ export default function ForgotPassword() {
 
   useEffect(() => {
     getCaptcha().then((data) => { setCaptchaSvg(data.svg); setCaptchaQuestion(data.question || ''); }).catch(() => setError(t('forgotPassword.failedToLoadCaptcha')));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only captcha fetch; re-running on language change (t) would swap the captcha under the user
   }, []);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setError('');
     setLoading(true);

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -48,15 +48,15 @@ export default function Login() {
     const next = new URLSearchParams(searchParams);
     next.delete('error');
     setSearchParams(next, { replace: true });
-  }, [searchParams, setSearchParams]);
+  }, [searchParams, setSearchParams, t]);
 
   const handlePasskeyLogin = async () => {
     setPasskeyLoading(true);
     setError('');
     try {
       const options = await passkeyLoginBegin();
-      const credential = await startAuthentication({ optionsJSON: options as any });
-      await passkeyLoginFinish(credential as any);
+      const credential = await startAuthentication({ optionsJSON: options });
+      await passkeyLoginFinish(credential);
       await fetchUser();
       navigate('/dashboard');
     } catch (err) {
@@ -65,7 +65,7 @@ export default function Login() {
     setPasskeyLoading(false);
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setError('');
     setSuccess('');
@@ -95,7 +95,7 @@ export default function Login() {
     }
   };
 
-  const handleResetRequest = async (e: React.FormEvent) => {
+  const handleResetRequest = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setError('');
     setLoading(true);
@@ -110,7 +110,7 @@ export default function Login() {
     setLoading(false);
   };
 
-  const handleResetVerify = async (e: React.FormEvent) => {
+  const handleResetVerify = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setError('');
     setLoading(true);
@@ -187,7 +187,7 @@ export default function Login() {
                 onClick={() => { window.location.href = '/auth/oidc/login'; }}>
                 {authInfo.oidc.logo && (
                   <img src={authInfo.oidc.logo} alt="" className="inline-block w-5 h-5 mr-2 align-middle"
-                    onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }} />
+                    onError={(e) => { (e.currentTarget).style.display = 'none'; }} />
                 )}
                 {t('login.signInWithProvider', { provider: authInfo.oidc.label })}
               </Button>

--- a/client/src/pages/Plan/Plan.tsx
+++ b/client/src/pages/Plan/Plan.tsx
@@ -109,7 +109,7 @@ export default function Plan() {
     }
   }
 
-  let budgetHelpText = '';
+  let budgetHelpText: string;
   if (!data.goal && !data.metrics.complete) budgetHelpText = t('plan.budgetHelp.needGoalAndMetrics');
   else if (!data.goal) budgetHelpText = t('plan.budgetHelp.needGoal');
   else if (!data.metrics.complete) budgetHelpText = t('plan.budgetHelp.needMetrics');

--- a/client/src/pages/Plan/PlanChart.tsx
+++ b/client/src/pages/Plan/PlanChart.tsx
@@ -215,10 +215,11 @@ export default function PlanChart({
       const fPad = (fMax - fMin) * 0.08;
       const fMinPadded = fMin - fPad;
       const fMaxPadded = fMax + fPad;
-      fatScale = (pct: number) => margin.top + (1 - (pct - fMinPadded) / (fMaxPadded - fMinPadded)) * plotH;
+      const scale = (pct: number) => margin.top + (1 - (pct - fMinPadded) / (fMaxPadded - fMinPadded)) * plotH;
+      fatScale = scale;
       // Same round-step snapping as the weight axis, so the right-hand labels
       // read 24 / 26 / 28 rather than 23.7 / 26.2 / 28.7.
-      fatTicks = niceTicks(fMinPadded, fMaxPadded, FAT_TICK_TARGET).map((v) => ({ v, y: fatScale!(v) }));
+      fatTicks = niceTicks(fMinPadded, fMaxPadded, FAT_TICK_TARGET).map((v) => ({ v, y: scale(v) }));
     }
 
     const candidateTs = [tMin, (tMin + tMax) / 2, tMax];
@@ -232,7 +233,7 @@ export default function PlanChart({
       plotH,
       actualPts: actual.map((p) => ({ x: x(p.t), y: y(p.w) })),
       planPts: plan.map((p) => ({ x: x(p.t), y: y(p.w) })),
-      fatPtsXY: fatScale ? fatPts.map((p) => ({ x: x(p.t), y: fatScale!(p.bf) })) : [],
+      fatPtsXY: fatScale ? fatPts.map((p) => ({ x: x(p.t), y: fatScale(p.bf) })) : [],
       fatTicks,
       targetY: targetWeight != null ? y(targetWeight) : null,
       bandY:

--- a/client/src/pages/Register/Register.tsx
+++ b/client/src/pages/Register/Register.tsx
@@ -44,7 +44,7 @@ export default function Register() {
     getAuthInfo().then(setAuthInfo).catch(() => {});
   }, []);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setError('');
     if (step === 'credentials' && password !== confirmPassword) {
@@ -100,13 +100,13 @@ export default function Register() {
         <h2 className="mb-6 text-xl font-semibold">{t('register.title')}</h2>
         {error && <Alert type="error" message={error} className="mb-4" />}
 
-        {step === 'credentials' && authInfo && authInfo.oidc && (
+        {step === 'credentials' && authInfo?.oidc && (
           <div className="flex flex-col gap-2 mb-2">
             <Button type="button" variant="outline" className="w-full"
               onClick={() => { window.location.href = '/auth/oidc/login'; }}>
               {authInfo.oidc.logo && (
                 <img src={authInfo.oidc.logo} alt="" className="inline-block w-5 h-5 mr-2 align-middle"
-                  onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }} />
+                  onError={(e) => { (e.currentTarget).style.display = 'none'; }} />
               )}
               {t('register.signUpWithProvider', { provider: authInfo.oidc.label })}
             </Button>

--- a/client/src/pages/ResetPassword/ResetPassword.tsx
+++ b/client/src/pages/ResetPassword/ResetPassword.tsx
@@ -19,7 +19,7 @@ export default function ResetPassword() {
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setError('');
     setLoading(true);

--- a/client/src/pages/Settings/EmailSettings.tsx
+++ b/client/src/pages/Settings/EmailSettings.tsx
@@ -19,7 +19,7 @@ export default function EmailSettings({ currentEmail }: Props) {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setError('');
     setLoading(true);

--- a/client/src/pages/Settings/LinkSettings.tsx
+++ b/client/src/pages/Settings/LinkSettings.tsx
@@ -21,7 +21,7 @@ export default function LinkSettings({ incomingRequests, outgoingRequests, accep
   const [loading, setLoading] = useState(false);
   const addToast = useToastStore((s) => s.addToast);
 
-  const handleRequest = async (e: React.FormEvent) => {
+  const handleRequest = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setLoading(true);
     try {

--- a/client/src/pages/Settings/OIDCSettings.tsx
+++ b/client/src/pages/Settings/OIDCSettings.tsx
@@ -20,7 +20,7 @@ export default function OIDCSettings({ linked, onUpdate }: Props) {
     getAuthInfo().then(setAuthInfo).catch(() => {});
   }, []);
 
-  if (!authInfo || !authInfo.oidc) return null;
+  if (!authInfo?.oidc) return null;
   const oidc = authInfo.oidc;
 
   const handleLink = () => {
@@ -62,7 +62,7 @@ export default function OIDCSettings({ linked, onUpdate }: Props) {
           <span className="flex items-center gap-2 text-sm text-foreground">
             {oidc.logo && (
               <img src={oidc.logo} alt="" className="w-5 h-5"
-                onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }} />
+                onError={(e) => { (e.currentTarget).style.display = 'none'; }} />
             )}
             {oidc.label}
           </span>

--- a/client/src/pages/Settings/PasskeySettings.tsx
+++ b/client/src/pages/Settings/PasskeySettings.tsx
@@ -44,8 +44,8 @@ export default function PasskeySettings({ onUpdate }: Props) {
     setRegistering(true);
     try {
       const options = await passkeyRegisterBegin();
-      const credential = await startRegistration({ optionsJSON: options as any });
-      await passkeyRegisterFinish(credential as any, name);
+      const credential = await startRegistration({ optionsJSON: options });
+      await passkeyRegisterFinish(credential, name);
       addToast('success', t('passkey.registered'));
       setNewName('');
       refresh();

--- a/client/src/pages/Settings/PasswordSettings.tsx
+++ b/client/src/pages/Settings/PasswordSettings.tsx
@@ -17,7 +17,7 @@ export default function PasswordSettings() {
   const [loading, setLoading] = useState(false);
   const addToast = useToastStore((s) => s.addToast);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setError('');
     setSuccess('');

--- a/client/src/pages/Settings/TwoFactorSettings.tsx
+++ b/client/src/pages/Settings/TwoFactorSettings.tsx
@@ -37,7 +37,7 @@ export default function TwoFactorSettings({ totpEnabled, onUpdate }: Props) {
     setLoading(false);
   };
 
-  const handleEnable = async (e: React.FormEvent) => {
+  const handleEnable = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setError('');
     setLoading(true);

--- a/client/src/pages/VerifyEmail/VerifyEmail.tsx
+++ b/client/src/pages/VerifyEmail/VerifyEmail.tsx
@@ -19,7 +19,7 @@ export default function VerifyEmail() {
   const navigate = useNavigate();
   const { fetchUser } = useAuthStore();
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setError('');
     setLoading(true);

--- a/client/src/pages/VerifyEmailChange/VerifyEmailChange.tsx
+++ b/client/src/pages/VerifyEmailChange/VerifyEmailChange.tsx
@@ -15,7 +15,7 @@ export default function VerifyEmailChange() {
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault();
     setError('');
     setLoading(true);

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -188,12 +188,12 @@ export interface SettingsData {
 }
 
 export interface AdminData {
-  users: Array<{
+  users: {
     id: number;
     email: string;
     email_verified: boolean;
     created_at: string;
-  }>;
+  }[];
   settings: Record<string, { value: string; source: string }>;
 }
 

--- a/client/tests/barcodeDeps.test.ts
+++ b/client/tests/barcodeDeps.test.ts
@@ -55,7 +55,7 @@ describe('barcode dependency isolation', () => {
     const version = resolvedVersion('sharp');
     expect(version, 'sharp missing from lockfile').toBeDefined();
     expect(
-      compareVersions(version!, '0.35.0'),
+      compareVersions(version, '0.35.0'),
       `sharp resolved to ${version}, which is inside the vulnerable <0.35.0 range`
     ).toBeGreaterThanOrEqual(0);
   });
@@ -64,7 +64,7 @@ describe('barcode dependency isolation', () => {
     const version = resolvedVersion('ndarray-pixels');
     expect(version, 'ndarray-pixels missing from lockfile').toBeDefined();
     expect(
-      compareVersions(version!, '5.0.1'),
+      compareVersions(version, '5.0.1'),
       `ndarray-pixels resolved to ${version}, which is inside the vulnerable range`
     ).toBeGreaterThan(0);
   });

--- a/client/tests/mathParserParity.test.ts
+++ b/client/tests/mathParserParity.test.ts
@@ -35,7 +35,7 @@ import { parseAmount } from '../src/lib/mathParser';
  * `node:fs`, and `tsc -b` covers only `src` and has no `@types/node`.
  */
 
-type SharedCase = { input: string; ok: boolean; value: number; why: string };
+interface SharedCase { input: string; ok: boolean; value: number; why: string }
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixturePath = resolve(here, '../../testdata/parse_amount_cases.json');

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,12 @@
       "matchPackageNames": ["postgres"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Cap TypeScript at typescript-eslint's supported range: the native TS 7 npm package ships no programmatic compiler API (its main export is a version stub), so typescript-eslint's type-aware linting cannot load it and `npm ci` fails on the peer range. Lift the cap when typescript-eslint declares support for TS 7 (expected once the 7.1 API stabilizes).",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<6.1.0"
     }
   ]
 }


### PR DESCRIPTION
Adds a real linter to the client — flat-config ESLint with typescript-eslint's `strictTypeChecked` + `stylisticTypeChecked` presets running type-aware via the project service, `eslint-plugin-react-hooks` recommended (including the compiler-era rules), and `eslint-plugin-react-refresh` for Vite. CI gates on it: a `Lint client` step in the `test` job directly behind the typecheck, so nothing downstream (compute-version → tag → image) can ship past a red lint.

Part of #464.

## The TypeScript 7 wrinkle

typescript-eslint needs the classic JS compiler API. The native TS 7 npm package doesn't ship one (its main export is a version stub — the programmatic API is slated for 7.1), so its peer range tops out below 6.1 and `npm ci` refuses the combination outright. Since the TS 7 pin here was a routine Renovate bump rather than a deliberate choice, `typescript` returns to classic **6.0.x**:

- `tsc -b --force` on this tree takes ~4.5 s with the classic compiler — no meaningful CI cost
- editor tsserver + ESLint extensions work normally (they need the JS API too)
- `renovate.json` caps `typescript` at `<6.1.0` with the reasoning recorded; lift when typescript-eslint supports TS 7

## Findings ledger

First run against the untouched tree: **763 findings**. Where they went:

| Treatment | Count | Detail |
|---|---:|---|
| Option tuning (rule stays on) | ~350 | arrow-shorthand handlers (`no-confusing-void-expression`), async JSX/property handlers (`no-misused-promises`), numbers in templates (`restrict-template-expressions`), `_`-prefix convention (`no-unused-vars`) |
| Autofix | ~60 | `array-type`, redundant type assertions, `prefer-regexp-exec`, `consistent-type-definitions`, … |
| Rules off with recorded justification | ~230 | `no-floating-promises` (fire-and-forget error model: invalidateQueries/navigate/try-catch-inside helpers), `prefer-nullish-coalescing` (deliberate falsy `\|\|` fallbacks), `no-unnecessary-condition` (defensive guards where types lie), `no-empty-function`, `no-unnecessary-boolean-literal-compare` (see below), `react-hooks/set-state-in-effect` + `refs` (pre-compiler idioms) |
| Test-file relaxation | ~65 | unsafe-`any` family + `!` in `tests/**` and `*.test.*` — they drive untyped quagga2/mock surfaces on purpose |
| Fixed by hand | ~55 | see below |
| Inline disables with reasons | 14 | latest-ref pattern, TanStack `enabled`-gated `queryFn`, mount-only effects, copy-minus-key deletes, … |

Real fixes worth review attention:

- **`React.FormEvent` → `React.SubmitEvent`** across all 17 submit handlers (FormEvent is deprecated in React 19 types — it never existed as a DOM event)
- **Typed JSON boundaries**: the api client's CSRF/error paths, SSE `link-change` payloads, `/api/health` + `/api/latest-version` responses
- **Passkey flows now use `@simplewebauthn/browser`'s own types** (`PublicKeyCredentialRequestOptionsJSON`, `AuthenticationResponseJSON`, …) instead of local `Record<string, unknown>` aliases plus `as any` at every call site
- **Dead `Number()` wrappers** removed in WeightRow — the Go server marshals `float64`, confirmed against `internal/service/weight.go`
- `draft!`/`fatScale!`/`toast.action!` non-null assertions replaced with equivalent narrow-safe forms

One autofix was **reverted**: `no-unnecessary-boolean-literal-compare` rewrote the `=== true` / `!== false` runtime guards in `macros.ts`/`MacroSettings.tsx` and silently inverted the calories default — `macros.test.ts` caught it. All four findings of that rule were deliberate guards, so it is off with the story documented in the config.

## Verification (all from a clean `npm ci`)

```
npm ci               # clean — classic TS satisfies typescript-eslint's peer natively
npm run lint         # exit 0, zero errors, zero warnings
npm run typecheck    # exit 0 (classic tsc 6.0.3, ~4.5s)
npm test             # 157/157 passed (16 files)
npm run build        # tsc -b && vite build — built in 441ms
npm run i18n:drift   # no files updated
npm run i18n:check   # parity passed
```

Note for the merge queue: another PR may touch `.github/workflows/build.yml` concurrently — this one only inserts the `Lint client` step between `Typecheck client` and `Run client tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)