### PR TITLE
ci(security): fix the pins and token persistence the new workflows shipped with

### DIFF
--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -51,6 +51,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # No job in this workflow pushes; drop the checkout token from disk
+          # (build.yml documents the policy at its first checkout).
+          persist-credentials: false
 
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -99,6 +103,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Same choice as kubeconform above: hadolint/hadolint-action is a
       # wrapper that fetches this identical static binary, so the

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,6 +85,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # No job in this workflow pushes; drop the checkout token from disk
+          # (build.yml documents the policy at its first checkout).
+          persist-credentials: false
 
       # The Go autobuild compiles the module, so give it the toolchain go.mod
       # asks for instead of gambling on whatever the runner image ships plus a

--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -93,6 +93,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # No job in this workflow pushes; drop the checkout token from disk
+          # (build.yml documents the policy at its first checkout).
+          persist-credentials: false
 
       # The raw release binary, verified against a hardcoded sha256, rather
       # than the alternatives:
@@ -143,6 +147,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # A plain `docker build`, unlike build-and-push's buildx-by-digest: this
       # image is scanned and thrown away, never pushed, and gha cache plumbing
@@ -168,7 +174,7 @@ jobs:
       # released fix: bump the base image, a Go dep, or cut a fresh release.
       # exit-code 1 makes those findings a red X rather than a report.
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ steps.target.outputs.ref }}
           format: sarif
@@ -191,7 +197,7 @@ jobs:
           always() &&
           (github.event_name != 'pull_request' ||
            github.event.pull_request.head.repo.full_name == github.repository)
-        uses: github/codeql-action/upload-sarif@9e3211c9a3b9311dfe05da2ed48eea3386f042dd # v4.37.6
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: trivy-results.sarif
           category: trivy-image
@@ -218,6 +224,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Dependency review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0


### PR DESCRIPTION
Follow-up to #464. The four workflows added in #466/#467/#468/#472 were audited by zizmor *before* `workflow-audit.yml` existed to enforce it on them. Once everything merged, the gate ran over the whole tree on `staging` and filed **8 code-scanning alerts against the very files that introduced it** — 6 `artipacked` (note) + 2 `ref-version-mismatch` (warning).

## The two real defects

`git ls-remote` prints **two** lines for an annotated tag: the tag object, then the peeled commit under `^{}`. The tag-object SHA was taken as the pin for both:

| action | shipped (tag object) | correct (peeled commit) |
|---|---|---|
| `aquasecurity/trivy-action` v0.36.0 | `a9c7b0f0…` | `ed142fd0…` |
| `github/codeql-action/upload-sarif` v4.37.6 | `9e3211c9…` | `5595ccaf…` |

A tag object is not a commit, so `uses:` could not have resolved either pin. Both live in `image-scan`, whose steps had not yet run on a push event — which is why the jobs looked green. Verified:

```
$ git ls-remote https://github.com/aquasecurity/trivy-action refs/tags/v0.36.0 refs/tags/v0.36.0^{}
a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8	refs/tags/v0.36.0
ed142fd0673e97e23eac54620cfb913e5ce36c25	refs/tags/v0.36.0^{}
```

## The six token findings

`persist-credentials: false` on all six checkouts across `codeql.yml`, `chart-lint.yml` and `scans.yml`. `build.yml` already applies this everywhere except its three genuinely pushing jobs (create-tag, publish-helm, create-release); **no** job in these three workflows pushes, so the policy applies uniformly. The first checkout in each file carries a short comment pointing at build.yml, which documents the policy in full.

## Verification

```
$ zizmor .github/workflows/    → No findings to report. Good job! (9 ignored, 57 suppressed)
$ actionlint                   → clean (all 6 workflows)
```

Before: 8 open alerts. The corrected trivy/codeql pins get their first real exercise on this PR's own `image-scan` run.

Part of #464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)