### PR TITLE
fix: harden sitemap and timezone cookie

### DIFF
--- a/internal/handler/legal.go
+++ b/internal/handler/legal.go
@@ -69,7 +69,7 @@ func SitemapXml(cfg *config.Config) http.HandlerFunc {
 		sb.WriteString(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` + "\n")
 		for _, p := range pages {
 			fmt.Fprintf(&sb, "  <url>\n    <loc>%s%s</loc>\n    <changefreq>%s</changefreq>\n    <priority>%s</priority>\n  </url>\n",
-				baseURL, p.Loc, p.Changefreq, p.Priority)
+				escapeXml(baseURL), escapeXml(p.Loc), escapeXml(p.Changefreq), escapeXml(p.Priority))
 		}
 		sb.WriteString("</urlset>")
 
@@ -183,6 +183,8 @@ func textToSvg(text string) string {
 }
 
 func escapeXml(s string) string {
-	r := strings.NewReplacer("<", "&lt;", ">", "&gt;", "&", "&amp;", "'", "&apos;", `"`, "&quot;")
+	// Escape ampersands first so the entities added for the other characters
+	// are not escaped a second time.
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", "'", "&apos;", `"`, "&quot;")
 	return r.Replace(s)
 }

--- a/internal/handler/legal_test.go
+++ b/internal/handler/legal_test.go
@@ -2,12 +2,46 @@ package handler
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"schautrack/internal/config"
 )
+
+func TestSitemapXmlEscapesRequestDerivedBaseURL(t *testing.T) {
+	h := SitemapXml(&config.Config{})
+	req := httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
+	req.Host = "example.test<injected>&more"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+
+	h(rec, req)
+
+	if got := rec.Header().Get("Content-Type"); got != "application/xml" {
+		t.Errorf("Content-Type = %q, want application/xml", got)
+	}
+	if body := rec.Body.String(); strings.Contains(body, "<injected>") || !strings.Contains(body, "example.test&lt;injected&gt;&amp;more") {
+		t.Errorf("request-derived URL was not XML-escaped:\n%s", body)
+	}
+
+	var sitemap struct {
+		URLs []struct {
+			Loc string `xml:"loc"`
+		} `xml:"url"`
+	}
+	if err := xml.Unmarshal(rec.Body.Bytes(), &sitemap); err != nil {
+		t.Fatalf("sitemap is not well-formed XML: %v\n%s", err, rec.Body.String())
+	}
+	if len(sitemap.URLs) != 6 {
+		t.Fatalf("URL count = %d, want 6", len(sitemap.URLs))
+	}
+	if got, want := sitemap.URLs[0].Loc, "https://example.test<injected>&more/"; got != want {
+		t.Errorf("first loc = %q, want %q", got, want)
+	}
+}
 
 func TestAssetLinks_UnconfiguredReturns404(t *testing.T) {
 	// No fingerprint configured -> endpoint is disabled and must 404 rather

--- a/internal/middleware/timezone.go
+++ b/internal/middleware/timezone.go
@@ -35,11 +35,18 @@ func RememberClientTimezone(next http.Handler) http.Handler {
 				Path:     "/",
 				MaxAge:   365 * 24 * 60 * 60,
 				HttpOnly: true,
+				Secure:   requestSecure(r),
 				SameSite: http.SameSiteLaxMode,
 			})
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// requestSecure reports whether the request arrived over TLS, either directly
+// or through a reverse proxy that terminated TLS.
+func requestSecure(r *http.Request) bool {
+	return r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 }
 
 // GetClientTimezone returns the timezone from the X-Timezone header or cookie.

--- a/internal/middleware/timezone_test.go
+++ b/internal/middleware/timezone_test.go
@@ -1,6 +1,11 @@
 package middleware
 
-import "testing"
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestNormalizeTimezone(t *testing.T) {
 	cases := []struct {
@@ -19,5 +24,40 @@ func TestNormalizeTimezone(t *testing.T) {
 		if got != c.want {
 			t.Errorf("normalizeTimezone(%q) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+func TestRememberClientTimezoneSetsSecureCookieForSecureRequests(t *testing.T) {
+	cases := []struct {
+		name       string
+		forwarded  string
+		tls        bool
+		wantSecure bool
+	}{
+		{"plain HTTP", "", false, false},
+		{"TLS", "", true, true},
+		{"TLS at proxy", "https", false, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("X-Timezone", "Europe/Berlin")
+			req.Header.Set("X-Forwarded-Proto", tc.forwarded)
+			if tc.tls {
+				req.TLS = &tls.ConnectionState{}
+			}
+			rec := httptest.NewRecorder()
+
+			RememberClientTimezone(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})).ServeHTTP(rec, req)
+
+			cookies := rec.Result().Cookies()
+			if len(cookies) != 1 {
+				t.Fatalf("cookie count = %d, want 1", len(cookies))
+			}
+			if got := cookies[0].Secure; got != tc.wantSecure {
+				t.Errorf("Secure = %t, want %t", got, tc.wantSecure)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes the two verified code defects from #475 and #478.

- XML-escape request/config-derived sitemap values and cover a hostile Host header.
- Mark the timezone-preference cookie Secure on direct TLS and HTTPS-terminated proxy requests, consistent with session cookies.

Verification: `go test ./...`.