### PR TITLE
ci: add OpenSSF Scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OpenSSF Scorecard
+
+# Tracks repository-level supply-chain posture over time. This complements the
+# code, dependency, image, and workflow scanners from #464: Scorecard checks
+# the GitHub repository configuration and publishes its SARIF result to the
+# Security tab.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '17 5 * * 1'
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Resolves the remaining Tier 2 CI posture gap in #464.

Adds a weekly and default-branch OpenSSF Scorecard workflow that uploads SARIF to the Security tab. The repository already has private vulnerability reporting enabled; all other ranked scanners from #464 are already live on `staging`.