### PR TITLE
feat(ai): add Google Gemini provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,9 +36,9 @@ DATABASE_URL=postgresql://schautrack:schautrack@db:5432/schautrack
 # =============================================================================
 # AI FEATURES
 # =============================================================================
-# Photo-based calorie estimation with support for OpenAI, Claude, and Ollama.
+# Photo-based calorie estimation with support for OpenAI, Claude, Gemini, and Ollama.
 
-# AI provider to use: openai, claude, or ollama. Required to enable AI features.
+# AI provider to use: openai, claude, gemini, or ollama. Required to enable AI features.
 # AI_PROVIDER=
 
 # Global API key (fallback when users don't have their own)
@@ -50,7 +50,7 @@ DATABASE_URL=postgresql://schautrack:schautrack@db:5432/schautrack
 # Custom endpoint override (e.g., http://your-ollama-host:11434/v1). Leave blank to use provider defaults.
 # AI_ENDPOINT=
 
-# Specify AI model to use (e.g., gpt-4o, claude-sonnet-4-5-20250929, gemma3:12b). Required for OpenAI and Claude.
+# Specify AI model to use (e.g., gpt-4o, claude-sonnet-4-5-20250929, gemini-3.6-flash, gemma3:12b). Required for OpenAI, Claude, and Gemini.
 # AI_MODEL=
 
 # Daily limit for AI requests per user when using the global key (0 = unlimited).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This document contains important context and decisions for Claude Code when work
 - Email verification and transactional email — registration verification, email-change verification, password reset, and 2FA-reset emails (`handler/auth_email.go`, `service/email.go`; requires SMTP)
 - Captcha — SVG challenge on login / registration / verification-resend for brute-force protection (`service/captcha.go`, `GET /auth/captcha`)
 - Calorie entry tracking with daily goals
-- AI-powered calorie estimation from food photos (OpenAI, Claude, or Ollama)
+- AI-powered calorie estimation from food photos (OpenAI, Claude, Gemini, or Ollama)
 - Macro (macronutrient) tracking — protein, carbs, fat, fiber, sugar (`service/macros.go`, `POST /settings/macros`)
 - Saved foods — reusable quick-add favorites that can be tracked into entries (`handler/saved_foods.go`, `/api/saved-foods`)
 - Recurring per-day todos (`handler/todos.go`, `service/todos.go`, `/api/todos`)
@@ -329,7 +329,7 @@ Passkeys / WebAuthn (enabled when `PASSKEYS_RP_ID` is set):
 - `PASSKEYS_RP_ORIGINS`: Comma-separated allowed origins for multi-domain setups
 
 AI Configuration (Global Fallbacks):
-- `AI_PROVIDER`: Default AI provider (`openai`, `claude`, or `ollama`)
+- `AI_PROVIDER`: Default AI provider (`openai`, `claude`, `gemini`, or `ollama`)
 - `AI_KEY`: Global API key (fallback when users don't have their own)
 - `AI_KEY_ENCRYPTION_SECRET`: Random 32-byte hex string used to encrypt user API keys in the database
 - `AI_ENDPOINT`: Optional custom endpoint override (leave blank to use provider defaults)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Schautrack is built to stay out of your way. Log calories and macros, set goals,
 - Log calories and macros (protein, carbs, fat, fiber, sugar)
 - Saved foods for one-tap quick-add of frequent meals
 - Daily goals with color-coded progress tracking
-- AI-powered nutrition estimation from food photos (OpenAI, Claude, or Ollama)
+- AI-powered nutrition estimation from food photos (OpenAI, Claude, Gemini, or Ollama)
 - Barcode scanning via OpenFoodFacts
 - Weight tracking with unit preference (kg/lbs)
 - Optional body-fat percentage per weigh-in — lean/fat mass, category bands, and a Katch-McArdle calorie budget that beats the height/age estimate
@@ -131,17 +131,17 @@ Settings follow a strict priority hierarchy: **environment variables** > **admin
 
 ### AI Features
 
-Photo-based nutrition estimation with support for OpenAI, Claude, and Ollama.
+Photo-based nutrition estimation with support for OpenAI, Claude, Gemini, and Ollama.
 
 > **Configuration priority:** Environment variables > admin panel settings > user settings. When any global AI config is set (provider or key), user personal AI settings are ignored. Users can only bring their own API key when no global config exists.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AI_PROVIDER` | *(empty)* | AI provider to use: `openai`, `claude`, or `ollama`. Required to enable AI features. |
+| `AI_PROVIDER` | *(empty)* | AI provider to use: `openai`, `claude`, `gemini`, or `ollama`. Required to enable AI features. |
 | `AI_KEY` | *(empty)* | Global API key (used by all users; overrides personal keys) |
 | `AI_KEY_ENCRYPTION_SECRET` | *(empty)* | Random 32-byte hex string for encrypting user API keys |
 | `AI_ENDPOINT` | *(empty)* | Custom endpoint override (e.g., `http://your-ollama-host:11434/v1`). Leave blank to use provider defaults. |
-| `AI_MODEL` | *(empty)* | Specify AI model to use (e.g., `gpt-4o`, `claude-sonnet-4-5-20250929`, `gemma3:12b`). Required for OpenAI and Claude. |
+| `AI_MODEL` | *(empty)* | Specify AI model to use (e.g., `gpt-4o`, `claude-sonnet-4-5-20250929`, `gemini-3.6-flash`, `gemma3:12b`). Required for OpenAI, Claude, and Gemini. |
 | `AI_DAILY_LIMIT` | *(unset → unlimited)* | Daily limit for AI requests per user when using global key (`0` or unset = unlimited). The app applies **no** limit unless this is set via env or the admin panel. Note: the Helm chart sets this to `10` by default. |
 
 **Note:** Ollama models must be downloaded before use. The docker-compose setup automatically pulls the model specified in `AI_MODEL`. Models specified only in API requests will fail if not pre-downloaded.

--- a/client/src/i18n/locales/de/landing.json
+++ b/client/src/i18n/locales/de/landing.json
@@ -74,7 +74,7 @@
       "heading": "Unterauftragsverarbeiter",
       "intro": "Wir nutzen einige wenige externe Dienste zum Betrieb von Schautrack:",
       "items": {
-        "aiEstimation": "<strong>KI-Nährwertschätzung:</strong> Wenn du ein Foto deines Essens zur Schätzung einreichst, wird das Foto an den vom Betreiber dieser Schautrack-Instanz konfigurierten KI-Anbieter gesendet — derzeit entweder OpenAI oder Anthropic Claude (beide mit Sitz in den USA) oder eine selbst gehostete Ollama-Instanz. Du kannst in den Einstellungen auch einen eigenen API-Schlüssel für jeden dieser Anbieter konfigurieren. Wenn du diese Funktion nicht nutzt, werden keine Fotodaten mit einem KI-Anbieter geteilt. Deine Körpermaße, Gewichtseinträge und Gewichtsziele werden niemals an KI-Anbieter gesendet.",
+        "aiEstimation": "<strong>KI-Nährwertschätzung:</strong> Wenn du ein Foto deines Essens zur Schätzung einreichst, wird das Foto an den vom Betreiber dieser Schautrack-Instanz konfigurierten KI-Anbieter gesendet — derzeit OpenAI, Anthropic Claude oder Google Gemini (alle mit Sitz in den USA) oder eine selbst gehostete Ollama-Instanz. Du kannst in den Einstellungen auch einen eigenen API-Schlüssel für jeden dieser Anbieter konfigurieren. Wenn du diese Funktion nicht nutzt, werden keine Fotodaten mit einem KI-Anbieter geteilt. Deine Körpermaße, Gewichtseinträge und Gewichtsziele werden niemals an KI-Anbieter gesendet.",
         "barcodeLookups": "<strong>Barcode-Abfragen:</strong> Gescannte Barcode-Nummern werden an <linkOff>Open Food Facts</linkOff> gesendet, um Nährwertdaten zum Produkt abzurufen, gemäß der <linkOdbl>Open Database License (ODbL)</linkOdbl>.",
         "hosting": "<strong>Hosting:</strong> ein EU-Hosting-Anbieter mit Sitz in Deutschland.",
         "emailDelivery": "<strong>E-Mail-Versand:</strong> ein Anbieter für transaktionale E-Mails für Bestätigungen, Passwort-Resets und Benachrichtigungen bei Kontoänderungen.",
@@ -83,7 +83,7 @@
     },
     "internationalTransfers": {
       "heading": "Internationale Datenübermittlungen",
-      "body": "Wenn als KI-Anbieter OpenAI oder Anthropic Claude konfiguriert ist, wird das eingereichte Foto zur Schätzung an einen Empfänger in den USA übermittelt. Solche Übermittlungen stützen sich auf die Standardvertragsklauseln des jeweiligen Anbieters. Du kannst diese Übermittlungen vermeiden, indem du die KI-Schätzung nicht nutzt oder in den Einstellungen einen selbst gehosteten Ollama-Endpunkt konfigurierst."
+      "body": "Wenn als KI-Anbieter OpenAI, Anthropic Claude oder Google Gemini konfiguriert ist, wird das eingereichte Foto zur Schätzung an einen Empfänger in den USA übermittelt. Solche Übermittlungen stützen sich auf die Standardvertragsklauseln des jeweiligen Anbieters. Du kannst diese Übermittlungen vermeiden, indem du die KI-Schätzung nicht nutzt oder in den Einstellungen einen selbst gehosteten Ollama-Endpunkt konfigurierst."
     },
     "retention": {
       "heading": "Aufbewahrung",

--- a/client/src/i18n/locales/en/landing.json
+++ b/client/src/i18n/locales/en/landing.json
@@ -81,7 +81,7 @@
       "heading": "Health Data"
     },
     "internationalTransfers": {
-      "body": "If the configured AI provider is OpenAI or Anthropic Claude, submitting a photo for estimation transfers that image to a recipient in the United States. Such transfers rely on the provider's Standard Contractual Clauses. You can avoid these transfers by not using the AI estimation feature, or by configuring a self-hosted Ollama endpoint in Settings.",
+      "body": "If the configured AI provider is OpenAI, Anthropic Claude, or Google Gemini, submitting a photo for estimation transfers that image to a recipient in the United States. Such transfers rely on the provider's Standard Contractual Clauses. You can avoid these transfers by not using the AI estimation feature, or by configuring a self-hosted Ollama endpoint in Settings.",
       "heading": "International Transfers"
     },
     "intro": "Schautrack collects only the data necessary to provide the calorie, nutrition, and weight tracking service.",
@@ -117,7 +117,7 @@
       "heading": "Sub-processors",
       "intro": "We use a small number of external services to operate Schautrack:",
       "items": {
-        "aiEstimation": "<strong>AI nutrition estimation:</strong> When you submit a food photo for estimation, the photo is sent to the AI provider configured by the operator of this Schautrack instance — currently either OpenAI or Anthropic Claude (both based in the United States), or a self-hosted Ollama instance. You can also configure your own API key for any of these providers in Settings. If you do not use this feature, no photo data is shared with any AI provider. Your body metrics, weight entries, and weight goals are never sent to AI providers.",
+        "aiEstimation": "<strong>AI nutrition estimation:</strong> When you submit a food photo for estimation, the photo is sent to the AI provider configured by the operator of this Schautrack instance — currently OpenAI, Anthropic Claude, or Google Gemini (all based in the United States), or a self-hosted Ollama instance. You can also configure your own API key for any of these providers in Settings. If you do not use this feature, no photo data is shared with any AI provider. Your body metrics, weight entries, and weight goals are never sent to AI providers.",
         "backups": "<strong>Backups:</strong> encrypted offsite backups stored in the EU.",
         "barcodeLookups": "<strong>Barcode lookups:</strong> Scanned barcode numbers are sent to <linkOff>Open Food Facts</linkOff> to retrieve product nutrition data, under the <linkOdbl>Open Database License (ODbL)</linkOdbl>.",
         "emailDelivery": "<strong>Email delivery:</strong> a transactional email provider for verification, password reset, and account-change notifications.",

--- a/client/src/i18n/locales/es/landing.json
+++ b/client/src/i18n/locales/es/landing.json
@@ -92,7 +92,7 @@
       "heading": "Subencargados del tratamiento",
       "intro": "Utilizamos un pequeño número de servicios externos para operar Schautrack:",
       "items": {
-        "aiEstimation": "<strong>Estimación nutricional con IA:</strong> Cuando envías una foto de comida para su estimación, la foto se envía al proveedor de IA configurado por el operador de esta instancia de Schautrack — actualmente OpenAI o Anthropic Claude (ambos con sede en Estados Unidos), o una instancia autoalojada de Ollama. También puedes configurar tu propia clave de API para cualquiera de estos proveedores en Ajustes. Si no utilizas esta función, no se comparten datos de fotos con ningún proveedor de IA. Tus medidas corporales, entradas de peso y objetivos de peso nunca se envían a los proveedores de IA.",
+        "aiEstimation": "<strong>Estimación nutricional con IA:</strong> Cuando envías una foto de comida para su estimación, la foto se envía al proveedor de IA configurado por el operador de esta instancia de Schautrack — actualmente OpenAI, Anthropic Claude o Google Gemini (todos con sede en Estados Unidos), o una instancia autoalojada de Ollama. También puedes configurar tu propia clave de API para cualquiera de estos proveedores en Ajustes. Si no utilizas esta función, no se comparten datos de fotos con ningún proveedor de IA. Tus medidas corporales, entradas de peso y objetivos de peso nunca se envían a los proveedores de IA.",
         "barcodeLookups": "<strong>Búsquedas de códigos de barras:</strong> Los números de código de barras escaneados se envían a <linkOff>Open Food Facts</linkOff> para obtener los datos nutricionales del producto, bajo la <linkOdbl>Open Database License (ODbL)</linkOdbl>.",
         "hosting": "<strong>Alojamiento:</strong> un proveedor de alojamiento con sede en la UE, en Alemania.",
         "emailDelivery": "<strong>Envío de correo electrónico:</strong> un proveedor de correo transaccional para las notificaciones de verificación, restablecimiento de contraseña y cambios en la cuenta.",
@@ -101,7 +101,7 @@
     },
     "internationalTransfers": {
       "heading": "Transferencias internacionales",
-      "body": "Si el proveedor de IA configurado es OpenAI o Anthropic Claude, al enviar una foto para su estimación esa imagen se transfiere a un destinatario en Estados Unidos. Estas transferencias se basan en las Cláusulas Contractuales Tipo del proveedor. Puedes evitar estas transferencias no utilizando la función de estimación con IA, o configurando un endpoint autoalojado de Ollama en Ajustes."
+      "body": "Si el proveedor de IA configurado es OpenAI, Anthropic Claude o Google Gemini, al enviar una foto para su estimación esa imagen se transfiere a un destinatario en Estados Unidos. Estas transferencias se basan en las Cláusulas Contractuales Tipo del proveedor. Puedes evitar estas transferencias no utilizando la función de estimación con IA, o configurando un endpoint autoalojado de Ollama en Ajustes."
     },
     "retention": {
       "heading": "Conservación de datos",

--- a/client/src/i18n/locales/fr/landing.json
+++ b/client/src/i18n/locales/fr/landing.json
@@ -92,7 +92,7 @@
       "heading": "Sous-traitants",
       "intro": "Nous utilisons un petit nombre de services externes pour exploiter Schautrack :",
       "items": {
-        "aiEstimation": "<strong>Estimation nutritionnelle par IA :</strong> Lorsque vous soumettez une photo d'aliment pour estimation, celle-ci est envoyée au fournisseur d'IA configuré par l'exploitant de cette instance Schautrack — actuellement OpenAI ou Anthropic Claude (tous deux basés aux États-Unis), ou une instance Ollama auto-hébergée. Vous pouvez également configurer votre propre clé API pour l'un de ces fournisseurs dans les Paramètres. Si vous n'utilisez pas cette fonctionnalité, aucune donnée photo n'est partagée avec un fournisseur d'IA. Vos mensurations corporelles, vos entrées de poids et vos objectifs de poids ne sont jamais envoyés aux fournisseurs d'IA.",
+        "aiEstimation": "<strong>Estimation nutritionnelle par IA :</strong> Lorsque vous soumettez une photo d'aliment pour estimation, celle-ci est envoyée au fournisseur d'IA configuré par l'exploitant de cette instance Schautrack — actuellement OpenAI, Anthropic Claude ou Google Gemini (tous basés aux États-Unis), ou une instance Ollama auto-hébergée. Vous pouvez également configurer votre propre clé API pour l'un de ces fournisseurs dans les Paramètres. Si vous n'utilisez pas cette fonctionnalité, aucune donnée photo n'est partagée avec un fournisseur d'IA. Vos mensurations corporelles, vos entrées de poids et vos objectifs de poids ne sont jamais envoyés aux fournisseurs d'IA.",
         "barcodeLookups": "<strong>Recherches de codes-barres :</strong> Les numéros de code-barres scannés sont envoyés à <linkOff>Open Food Facts</linkOff> pour récupérer les données nutritionnelles du produit, sous la <linkOdbl>licence Open Database License (ODbL)</linkOdbl>.",
         "hosting": "<strong>Hébergement :</strong> un hébergeur basé dans l'UE, en Allemagne.",
         "emailDelivery": "<strong>Envoi d'e-mails :</strong> un fournisseur d'e-mails transactionnels pour la vérification, la réinitialisation de mot de passe et les notifications de changement de compte.",
@@ -101,7 +101,7 @@
     },
     "internationalTransfers": {
       "heading": "Transferts internationaux",
-      "body": "Si le fournisseur d'IA configuré est OpenAI ou Anthropic Claude, la soumission d'une photo pour estimation transfère cette image à un destinataire situé aux États-Unis. Ces transferts s'appuient sur les clauses contractuelles types du fournisseur. Vous pouvez éviter ces transferts en n'utilisant pas la fonctionnalité d'estimation par IA, ou en configurant un point de terminaison Ollama auto-hébergé dans les Paramètres."
+      "body": "Si le fournisseur d'IA configuré est OpenAI, Anthropic Claude ou Google Gemini, la soumission d'une photo pour estimation transfère cette image à un destinataire situé aux États-Unis. Ces transferts s'appuient sur les clauses contractuelles types du fournisseur. Vous pouvez éviter ces transferts en n'utilisant pas la fonctionnalité d'estimation par IA, ou en configurant un point de terminaison Ollama auto-hébergé dans les Paramètres."
     },
     "retention": {
       "heading": "Conservation",

--- a/client/src/i18n/locales/it/landing.json
+++ b/client/src/i18n/locales/it/landing.json
@@ -92,7 +92,7 @@
       "heading": "Sub-responsabili del trattamento",
       "intro": "Utilizziamo un piccolo numero di servizi esterni per gestire Schautrack:",
       "items": {
-        "aiEstimation": "<strong>Stima nutrizionale con AI:</strong> Quando invii una foto di un cibo per la stima, la foto viene inviata al provider AI configurato dal gestore di questa istanza di Schautrack — attualmente OpenAI o Anthropic Claude (entrambi con sede negli Stati Uniti), oppure un'istanza Ollama self-hosted. Puoi anche configurare una tua chiave API per uno di questi provider nelle Impostazioni. Se non utilizzi questa funzione, nessun dato fotografico viene condiviso con alcun provider AI. I tuoi dati corporei, le voci di peso e gli obiettivi di peso non vengono mai inviati ai provider AI.",
+        "aiEstimation": "<strong>Stima nutrizionale con AI:</strong> Quando invii una foto di un cibo per la stima, la foto viene inviata al provider AI configurato dal gestore di questa istanza di Schautrack — attualmente OpenAI, Anthropic Claude o Google Gemini (tutti con sede negli Stati Uniti), oppure un'istanza Ollama self-hosted. Puoi anche configurare una tua chiave API per uno di questi provider nelle Impostazioni. Se non utilizzi questa funzione, nessun dato fotografico viene condiviso con alcun provider AI. I tuoi dati corporei, le voci di peso e gli obiettivi di peso non vengono mai inviati ai provider AI.",
         "barcodeLookups": "<strong>Ricerche codice a barre:</strong> I numeri dei codici a barre scansionati vengono inviati a <linkOff>Open Food Facts</linkOff> per recuperare i dati nutrizionali del prodotto, secondo la <linkOdbl>Open Database License (ODbL)</linkOdbl>.",
         "hosting": "<strong>Hosting:</strong> un provider di hosting con sede nell'UE, in Germania.",
         "emailDelivery": "<strong>Invio email:</strong> un provider di email transazionali per verifica, reset password e notifiche di modifica account.",
@@ -101,7 +101,7 @@
     },
     "internationalTransfers": {
       "heading": "Trasferimenti internazionali",
-      "body": "Se il provider AI configurato è OpenAI o Anthropic Claude, l'invio di una foto per la stima trasferisce l'immagine a un destinatario negli Stati Uniti. Tali trasferimenti si basano sulle Clausole Contrattuali Standard del provider. Puoi evitare questi trasferimenti non utilizzando la funzione di stima AI, oppure configurando un endpoint Ollama self-hosted nelle Impostazioni."
+      "body": "Se il provider AI configurato è OpenAI, Anthropic Claude o Google Gemini, l'invio di una foto per la stima trasferisce l'immagine a un destinatario negli Stati Uniti. Tali trasferimenti si basano sulle Clausole Contrattuali Standard del provider. Puoi evitare questi trasferimenti non utilizzando la funzione di stima AI, oppure configurando un endpoint Ollama self-hosted nelle Impostazioni."
     },
     "retention": {
       "heading": "Conservazione",

--- a/client/src/i18n/locales/nl/landing.json
+++ b/client/src/i18n/locales/nl/landing.json
@@ -92,7 +92,7 @@
       "heading": "Subverwerkers",
       "intro": "We gebruiken een klein aantal externe diensten om Schautrack te laten draaien:",
       "items": {
-        "aiEstimation": "<strong>AI-voedingsschatting:</strong> Wanneer je een foto van eten indient voor een schatting, wordt de foto verstuurd naar de AI-provider die is geconfigureerd door de beheerder van deze Schautrack-instantie — momenteel OpenAI of Anthropic Claude (beide gevestigd in de Verenigde Staten), of een zelf gehoste Ollama-instantie. Je kunt in Instellingen ook je eigen API-sleutel voor elk van deze providers configureren. Als je deze functie niet gebruikt, wordt er geen fotodata gedeeld met een AI-provider. Je lichaamsmaten, gewichtsitems en gewichtsdoelen worden nooit naar AI-providers gestuurd.",
+        "aiEstimation": "<strong>AI-voedingsschatting:</strong> Wanneer je een foto van eten indient voor een schatting, wordt de foto verstuurd naar de AI-provider die is geconfigureerd door de beheerder van deze Schautrack-instantie — momenteel OpenAI, Anthropic Claude of Google Gemini (alle gevestigd in de Verenigde Staten), of een zelf gehoste Ollama-instantie. Je kunt in Instellingen ook je eigen API-sleutel voor elk van deze providers configureren. Als je deze functie niet gebruikt, wordt er geen fotodata gedeeld met een AI-provider. Je lichaamsmaten, gewichtsitems en gewichtsdoelen worden nooit naar AI-providers gestuurd.",
         "barcodeLookups": "<strong>Barcode-opzoekingen:</strong> Gescande barcodenummers worden verstuurd naar <linkOff>Open Food Facts</linkOff> om productvoedingsgegevens op te halen, onder de <linkOdbl>Open Database License (ODbL)</linkOdbl>.",
         "hosting": "<strong>Hosting:</strong> een in de EU gevestigde hostingprovider in Duitsland.",
         "emailDelivery": "<strong>E-mailbezorging:</strong> een transactionele e-mailprovider voor verificatie, wachtwoordreset en meldingen over accountwijzigingen.",
@@ -101,7 +101,7 @@
     },
     "internationalTransfers": {
       "heading": "Internationale overdrachten",
-      "body": "Als de geconfigureerde AI-provider OpenAI of Anthropic Claude is, wordt de foto bij het indienen voor een schatting overgedragen aan een ontvanger in de Verenigde Staten. Dergelijke overdrachten zijn gebaseerd op de Standard Contractual Clauses van de provider. Je kunt deze overdrachten vermijden door de AI-schattingsfunctie niet te gebruiken, of door in Instellingen een zelf gehost Ollama-endpoint te configureren."
+      "body": "Als de geconfigureerde AI-provider OpenAI, Anthropic Claude of Google Gemini is, wordt de foto bij het indienen voor een schatting overgedragen aan een ontvanger in de Verenigde Staten. Dergelijke overdrachten zijn gebaseerd op de Standard Contractual Clauses van de provider. Je kunt deze overdrachten vermijden door de AI-schattingsfunctie niet te gebruiken, of door in Instellingen een zelf gehost Ollama-endpoint te configureren."
     },
     "retention": {
       "heading": "Bewaartermijn",

--- a/client/src/i18n/locales/pl/landing.json
+++ b/client/src/i18n/locales/pl/landing.json
@@ -92,7 +92,7 @@
       "heading": "Podwykonawcy",
       "intro": "Korzystamy z niewielkiej liczby usług zewnętrznych do prowadzenia Schautrack:",
       "items": {
-        "aiEstimation": "<strong>Szacowanie odżywcze AI:</strong> Gdy przesyłasz zdjęcie jedzenia do oszacowania, zdjęcie jest wysyłane do dostawcy AI skonfigurowanego przez operatora tej instancji Schautrack — obecnie OpenAI, Anthropic Claude (oba z siedzibą w Stanach Zjednoczonych) lub samodzielnie hostowana instancja Ollama. Możesz też skonfigurować własny klucz API dla dowolnego z tych dostawców w Ustawieniach. Jeśli nie korzystasz z tej funkcji, żadne dane zdjęć nie są udostępniane żadnemu dostawcy AI. Twoje dane biometryczne, wpisy wagi i cele wagowe nigdy nie są wysyłane do dostawców AI.",
+        "aiEstimation": "<strong>Szacowanie odżywcze AI:</strong> Gdy przesyłasz zdjęcie jedzenia do oszacowania, zdjęcie jest wysyłane do dostawcy AI skonfigurowanego przez operatora tej instancji Schautrack — obecnie OpenAI, Anthropic Claude lub Google Gemini (wszyscy z siedzibą w Stanach Zjednoczonych) albo samodzielnie hostowana instancja Ollama. Możesz też skonfigurować własny klucz API dla dowolnego z tych dostawców w Ustawieniach. Jeśli nie korzystasz z tej funkcji, żadne dane zdjęć nie są udostępniane żadnemu dostawcy AI. Twoje dane biometryczne, wpisy wagi i cele wagowe nigdy nie są wysyłane do dostawców AI.",
         "barcodeLookups": "<strong>Wyszukiwanie kodów kreskowych:</strong> Zeskanowane numery kodów kreskowych są wysyłane do <linkOff>Open Food Facts</linkOff> w celu pobrania danych odżywczych produktu, na podstawie <linkOdbl>Open Database License (ODbL)</linkOdbl>.",
         "hosting": "<strong>Hosting:</strong> dostawca hostingu z siedzibą w UE, w Niemczech.",
         "emailDelivery": "<strong>Dostarczanie e-maili:</strong> dostawca transakcyjnej poczty e-mail do weryfikacji, resetowania hasła i powiadomień o zmianach na koncie.",
@@ -101,7 +101,7 @@
     },
     "internationalTransfers": {
       "heading": "Międzynarodowe przekazywanie danych",
-      "body": "Jeśli skonfigurowanym dostawcą AI jest OpenAI lub Anthropic Claude, przesłanie zdjęcia do oszacowania powoduje przekazanie tego obrazu do odbiorcy w Stanach Zjednoczonych. Takie przekazania opierają się na Standardowych Klauzulach Umownych dostawcy. Możesz uniknąć takich przekazań, nie korzystając z funkcji szacowania AI lub konfigurując samodzielnie hostowany endpoint Ollama w Ustawieniach."
+      "body": "Jeśli skonfigurowanym dostawcą AI jest OpenAI, Anthropic Claude lub Google Gemini, przesłanie zdjęcia do oszacowania powoduje przekazanie tego obrazu do odbiorcy w Stanach Zjednoczonych. Takie przekazania opierają się na Standardowych Klauzulach Umownych dostawcy. Możesz uniknąć takich przekazań, nie korzystając z funkcji szacowania AI lub konfigurując samodzielnie hostowany endpoint Ollama w Ustawieniach."
     },
     "retention": {
       "heading": "Okres przechowywania",

--- a/client/src/i18n/locales/pt/landing.json
+++ b/client/src/i18n/locales/pt/landing.json
@@ -92,7 +92,7 @@
       "heading": "Subcontratantes",
       "intro": "Utilizamos um pequeno número de serviços externos para operar o Schautrack:",
       "items": {
-        "aiEstimation": "<strong>Estimativa nutricional por IA:</strong> Quando submete uma fotografia de comida para estimativa, a fotografia é enviada para o fornecedor de IA configurado pelo operador desta instância do Schautrack — atualmente OpenAI ou Anthropic Claude (ambos sediados nos Estados Unidos), ou uma instância Ollama autoalojada. Também pode configurar a sua própria chave da API para qualquer um destes fornecedores nas Definições. Se não utilizar esta funcionalidade, nenhum dado de fotografia é partilhado com qualquer fornecedor de IA. As suas métricas corporais, registos de peso e objetivos de peso nunca são enviados a fornecedores de IA.",
+        "aiEstimation": "<strong>Estimativa nutricional por IA:</strong> Quando submete uma fotografia de comida para estimativa, a fotografia é enviada para o fornecedor de IA configurado pelo operador desta instância do Schautrack — atualmente OpenAI, Anthropic Claude ou Google Gemini (todos sediados nos Estados Unidos), ou uma instância Ollama autoalojada. Também pode configurar a sua própria chave da API para qualquer um destes fornecedores nas Definições. Se não utilizar esta funcionalidade, nenhum dado de fotografia é partilhado com qualquer fornecedor de IA. As suas métricas corporais, registos de peso e objetivos de peso nunca são enviados a fornecedores de IA.",
         "barcodeLookups": "<strong>Consultas de código de barras:</strong> Os números de código de barras lidos são enviados para <linkOff>Open Food Facts</linkOff> para obter dados nutricionais do produto, ao abrigo da <linkOdbl>Open Database License (ODbL)</linkOdbl>.",
         "hosting": "<strong>Alojamento:</strong> um fornecedor de alojamento sediado na UE, na Alemanha.",
         "emailDelivery": "<strong>Envio de email:</strong> um fornecedor de email transacional para verificação, reposição de palavra-passe e notificações de alteração de conta.",
@@ -101,7 +101,7 @@
     },
     "internationalTransfers": {
       "heading": "Transferências Internacionais",
-      "body": "Se o fornecedor de IA configurado for a OpenAI ou a Anthropic Claude, submeter uma fotografia para estimativa transfere essa imagem para um destinatário nos Estados Unidos. Estas transferências baseiam-se nas Cláusulas Contratuais-Tipo do fornecedor. Pode evitar estas transferências não utilizando a funcionalidade de estimativa por IA, ou configurando um endpoint Ollama autoalojado nas Definições."
+      "body": "Se o fornecedor de IA configurado for a OpenAI, a Anthropic Claude ou o Google Gemini, submeter uma fotografia para estimativa transfere essa imagem para um destinatário nos Estados Unidos. Estas transferências baseiam-se nas Cláusulas Contratuais-Tipo do fornecedor. Pode evitar estas transferências não utilizando a funcionalidade de estimativa por IA, ou configurando um endpoint Ollama autoalojado nas Definições."
     },
     "retention": {
       "heading": "Retenção",

--- a/client/src/pages/Settings/AISettings.tsx
+++ b/client/src/pages/Settings/AISettings.tsx
@@ -81,6 +81,7 @@ export default function AISettings({ user, onSave }: Props) {
               <SelectItem value={NONE}>{t('ai.providerDefault')}</SelectItem>
               <SelectItem value="openai">OpenAI</SelectItem>
               <SelectItem value="claude">Claude</SelectItem>
+              <SelectItem value="gemini">Google Gemini</SelectItem>
               <SelectItem value="ollama">Ollama</SelectItem>
             </SelectContent>
           </Select>

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -134,7 +134,7 @@ Items marked [A] are covered by automated E2E tests (`npm run test:e2e`).
 - [x] [A] Cancel pending email change
 - [x] [A] Change password
 - [x] [A] Set/clear personal AI key and endpoint
-- [ ] Change AI provider (OpenAI / Claude / Ollama), verify AI still works (requires real keys)
+- [ ] Change AI provider (OpenAI / Claude / Gemini / Ollama), verify AI still works (requires real keys)
 - [ ] Custom AI model override
 - [x] [A] Export data (JSON) — includes entries, weights (with body fat), settings
 - [x] [A] Import data (JSON) — verify entries and weights (with body fat) restored

--- a/e2e/settings-extra.spec.ts
+++ b/e2e/settings-extra.spec.ts
@@ -39,13 +39,13 @@ test.describe.serial('Settings Extra', () => {
     await expect(aiHeading).toBeVisible({ timeout: 10000 });
     await aiHeading.scrollIntoViewIfNeeded();
 
-    // Find Provider select and change it to 'claude'
+    // Find Provider select and change it to Gemini.
     const aiCard = page.getByTestId('ai-settings-card');
     const providerSelect = aiCard.getByTestId('ai-provider');
     const providerSelectVisible = await providerSelect.isVisible({ timeout: 3000 }).catch(() => false);
 
     if (providerSelectVisible) {
-      await chooseOption(page, providerSelect, 'claude');
+      await chooseOption(page, providerSelect, 'gemini');
     }
 
     // Fill Model input

--- a/helm/schautrack/README.md
+++ b/helm/schautrack/README.md
@@ -161,7 +161,7 @@ Schautrack supports AI-powered nutrition estimation from food photos:
 
 ```yaml
 ai:
-  provider: openai  # or: claude, ollama
+  provider: openai  # or: claude, gemini, ollama
   key: "sk-..."
   model: "gpt-4o"
   keyEncryptionSecret: ""  # Generate with: openssl rand -hex 32
@@ -334,11 +334,11 @@ application's default in force. See
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `ai.provider` | AI provider: `openai`, `claude`, or `ollama` | `""` |
+| `ai.provider` | AI provider: `openai`, `claude`, `gemini`, or `ollama` | `""` |
 | `ai.key` | API key for AI provider | `""` |
 | `ai.keyEncryptionSecret` | Secret for encrypting user API keys | `""` |
 | `ai.endpoint` | Custom API endpoint | `""` |
-| `ai.model` | Model override (e.g., `gpt-4o`, `claude-sonnet-4-5-20250929`, `gemma3:12b`) | `""` |
+| `ai.model` | Model override (e.g., `gpt-4o`, `claude-sonnet-4-5-20250929`, `gemini-3.6-flash`, `gemma3:12b`) | `""` |
 | `ai.dailyLimit` | Daily requests per user (0 = unlimited). The app defaults to unlimited; this chart sets `10`. | `10` |
 
 ### SMTP

--- a/helm/schautrack/values.yaml
+++ b/helm/schautrack/values.yaml
@@ -240,7 +240,7 @@ smtp:
 # ⚠️  SECURITY WARNING: AI keys are sensitive and can incur costs!
 # Use existingSecret in production - never commit API keys to Git
 ai:
-  # AI provider: openai, claude, or ollama
+  # AI provider: openai, claude, gemini, or ollama
   provider: ""
   # API key for AI provider - DO NOT commit real keys to Git
   key: ""
@@ -249,7 +249,7 @@ ai:
   keyEncryptionSecret: ""
   # Custom API endpoint (leave empty for defaults)
   endpoint: ""
-  # Model override (e.g., gpt-4o, claude-sonnet-4-5-20250929, gemma3:12b)
+  # Model override (e.g., gpt-4o, claude-sonnet-4-5-20250929, gemini-3.6-flash, gemma3:12b)
   model: ""
   # Daily request limit per user when using global key (0 = unlimited)
   dailyLimit: 10

--- a/internal/handler/admin_settings.go
+++ b/internal/handler/admin_settings.go
@@ -49,15 +49,15 @@ var adminSettings = []AdminSetting{
 	// AI Features
 	// =========================================================================
 	{Key: "ai_provider", Env: "AI_PROVIDER", Section: "ai", Tier: "hot",
-		Help:     `One of: openai, claude, ollama.`,
-		Validate: oneOf("openai", "claude", "ollama", "")},
+		Help:     `One of: openai, claude, gemini, ollama.`,
+		Validate: oneOf("openai", "claude", "gemini", "ollama", "")},
 	{Key: "ai_key", Env: "AI_KEY", Section: "ai", Tier: "hot", Secret: true,
 		Help: "Global API key (fallback when users don't have their own)."},
 	{Key: "ai_endpoint", Env: "AI_ENDPOINT", Section: "ai", Tier: "hot",
 		Help:     "Custom endpoint override. Leave empty for provider defaults.",
 		Validate: validURL},
 	{Key: "ai_model", Env: "AI_MODEL", Section: "ai", Tier: "hot",
-		Help: `Model name (e.g. gpt-4o, claude-sonnet-4-5-20250929, gemma3:12b).`},
+		Help: `Model name (e.g. gpt-4o, claude-sonnet-4-5-20250929, gemini-3.6-flash, gemma3:12b).`},
 	{Key: "ai_daily_limit", Env: "AI_DAILY_LIMIT", Section: "ai", Tier: "hot",
 		Help:     "Daily AI request limit per user when using the global key. 0 = unlimited.",
 		Validate: validNonNegInt},

--- a/internal/handler/admin_settings_test.go
+++ b/internal/handler/admin_settings_test.go
@@ -227,27 +227,28 @@ func TestValidRPID(t *testing.T) {
 
 func TestOneOf(t *testing.T) {
 	// ai_provider's allow-list, used as the representative instance.
-	fn := oneOf("openai", "claude", "ollama", "")
+	fn := oneOf("openai", "claude", "gemini", "ollama", "")
 	runValidatorCases(t, "oneOf", fn, []validatorCase{
 		{in: "", ok: true, note: "empty is in the allow-list explicitly"},
 		{in: "openai", ok: true},
 		{in: "claude", ok: true},
+		{in: "gemini", ok: true},
 		{in: "ollama", ok: true},
 
 		{in: "OpenAI", ok: false, note: "exact comparison, no case folding"},
 		{in: "OPENAI", ok: false, note: "exact comparison, no case folding"},
 		{in: " openai", ok: false, note: "exact comparison, no trimming"},
 		{in: "openai ", ok: false, note: "exact comparison, no trimming"},
-		{in: "gemini", ok: false},
+		{in: "Gemini", ok: false},
 	})
 
 	// The error message must list the allowed values — it is surfaced verbatim
 	// to the admin as the 400 body (see AdminHandler.UpdateSettings).
-	err := fn("gemini")
+	err := fn("unsupported")
 	if err == nil {
-		t.Fatal("oneOf(...)(\"gemini\") = nil, want error")
+		t.Fatal("oneOf(...)(\"unsupported\") = nil, want error")
 	}
-	for _, want := range []string{"openai", "claude", "ollama"} {
+	for _, want := range []string{"openai", "claude", "gemini", "ollama"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("oneOf error %q does not mention allowed value %q", err.Error(), want)
 		}

--- a/internal/handler/ai.go
+++ b/internal/handler/ai.go
@@ -149,7 +149,7 @@ func (h *AIHandler) Estimate(w http.ResponseWriter, r *http.Request) {
 		ErrorJSON(w, http.StatusBadRequest, "No AI provider configured.")
 		return
 	}
-	if provider != "openai" && provider != "claude" && provider != "ollama" {
+	if provider != "openai" && provider != "claude" && provider != "gemini" && provider != "ollama" {
 		ErrorJSON(w, http.StatusBadRequest, "Invalid provider")
 		return
 	}
@@ -170,7 +170,7 @@ func (h *AIHandler) Estimate(w http.ResponseWriter, r *http.Request) {
 	})
 	apiKey, endpoint, customModel, usingGlobalKey := cfg.APIKey, cfg.Endpoint, cfg.Model, cfg.UsingGlobalKey
 
-	if (provider == "openai" || provider == "claude") && apiKey == "" {
+	if (provider == "openai" || provider == "claude" || provider == "gemini") && apiKey == "" {
 		ErrorJSON(w, http.StatusBadRequest, fmt.Sprintf("%s requires an API key.", provider))
 		return
 	}
@@ -184,7 +184,7 @@ func (h *AIHandler) Estimate(w http.ResponseWriter, r *http.Request) {
 			usingGlobalKey = true
 		}
 	}
-	if (provider == "openai" || provider == "claude") && customModel == "" {
+	if (provider == "openai" || provider == "claude" || provider == "gemini") && customModel == "" {
 		ErrorJSON(w, http.StatusBadRequest, fmt.Sprintf("%s requires AI_MODEL to be configured.", provider))
 		return
 	}

--- a/internal/handler/entries.go
+++ b/internal/handler/entries.go
@@ -42,7 +42,7 @@ func (h *EntriesHandler) getAIProviderName(r *http.Request, user *model.User) *s
 	if provider == "" {
 		return nil
 	}
-	names := map[string]string{"openai": "OpenAI", "claude": "Anthropic", "ollama": "Ollama"}
+	names := map[string]string{"openai": "OpenAI", "claude": "Anthropic", "gemini": "Google Gemini", "ollama": "Ollama"}
 	name := names[provider]
 	if name == "" {
 		name = provider

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -228,7 +228,7 @@ func (h *SettingsHandler) AISettings(w http.ResponseWriter, r *http.Request) {
 	idx := 1
 
 	// Provider
-	validProviders := map[string]bool{"openai": true, "claude": true, "ollama": true}
+	validProviders := map[string]bool{"openai": true, "claude": true, "gemini": true, "ollama": true}
 	var newProvider *string
 	if validProviders[body.AIProvider] {
 		newProvider = &body.AIProvider

--- a/internal/handler/settings_test.go
+++ b/internal/handler/settings_test.go
@@ -84,6 +84,7 @@ func intP(n int) *int { return &n }
 func TestShouldClearStoredAIKey(t *testing.T) {
 	openai := "openai"
 	claude := "claude"
+	gemini := "gemini"
 	tests := []struct {
 		name    string
 		next    *string
@@ -93,6 +94,7 @@ func TestShouldClearStoredAIKey(t *testing.T) {
 		{"no provider in payload — never clear", nil, &openai, false},
 		{"same provider, current set — autosave must not wipe", &openai, &openai, false},
 		{"different provider — clear (key is provider-specific)", &claude, &openai, true},
+		{"switching to gemini clears provider-specific key", &gemini, &openai, true},
 		{"current nil, new provider — clear (no-op in DB but consistent)", &openai, nil, true},
 		{"both nil", nil, nil, false},
 	}

--- a/internal/service/ai.go
+++ b/internal/service/ai.go
@@ -165,6 +165,27 @@ func CallAIProvider(ctx context.Context, provider, apiKey, endpoint, base64Data,
 		}
 		reqBody, _ = json.Marshal(body)
 
+	case "gemini":
+		if endpoint == "" {
+			endpoint = "https://generativelanguage.googleapis.com/v1beta"
+		}
+		url = strings.TrimRight(endpoint, "/") + "/models/" + model + ":generateContent"
+		headers = map[string]string{"x-goog-api-key": apiKey}
+		body := map[string]any{
+			"contents": []map[string]any{{
+				"role": "user",
+				"parts": []map[string]any{
+					{"inlineData": map[string]any{"mimeType": mediaType, "data": base64Data}},
+					{"text": prompt},
+				},
+			}},
+			"generationConfig": map[string]any{
+				"maxOutputTokens":  1000,
+				"responseMimeType": "application/json",
+			},
+		}
+		reqBody, _ = json.Marshal(body)
+
 	case "ollama":
 		url = strings.TrimRight(endpoint, "/") + "/chat/completions"
 		headers = map[string]string{}
@@ -228,6 +249,28 @@ func parseAIResponse(provider string, body []byte) (*AIResult, error) {
 		}
 		if len(resp.Content) > 0 {
 			content = resp.Content[0].Text
+		}
+	} else if provider == "gemini" {
+		var resp struct {
+			Candidates []struct {
+				Content struct {
+					Parts []struct {
+						Text string `json:"text"`
+					} `json:"parts"`
+				} `json:"content"`
+			} `json:"candidates"`
+		}
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("failed to parse Gemini response")
+		}
+		if len(resp.Candidates) > 0 {
+			var parts []string
+			for _, part := range resp.Candidates[0].Content.Parts {
+				if part.Text != "" {
+					parts = append(parts, part.Text)
+				}
+			}
+			content = strings.Join(parts, "")
 		}
 	} else {
 		var resp struct {

--- a/internal/service/ai_test.go
+++ b/internal/service/ai_test.go
@@ -133,6 +133,56 @@ func TestCallAIProvider_TokenLimitParam(t *testing.T) {
 	}
 }
 
+func TestCallAIProvider_GeminiRequest(t *testing.T) {
+	var captured map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models/gemini-test:generateContent" {
+			t.Errorf("path = %q, want %q", r.URL.Path, "/models/gemini-test:generateContent")
+		}
+		if got := r.Header.Get("x-goog-api-key"); got != "gemini-key" {
+			t.Errorf("x-goog-api-key = %q, want %q", got, "gemini-key")
+		}
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &captured); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"{\"calories\":100,\"food\":\"apple\",\"macros\":{}}"}]}}]}`))
+	}))
+	defer srv.Close()
+
+	_, err := CallAIProvider(context.Background(), "gemini", "gemini-key", srv.URL, "Zg==", "image/jpeg", "describe", "gemini-test")
+	if err != nil {
+		t.Fatalf("CallAIProvider: %v", err)
+	}
+
+	contents, ok := captured["contents"].([]any)
+	if !ok || len(contents) != 1 {
+		t.Fatalf("contents = %#v, want one content item", captured["contents"])
+	}
+	content, _ := contents[0].(map[string]any)
+	if content["role"] != "user" {
+		t.Errorf("role = %#v, want user", content["role"])
+	}
+	parts, ok := content["parts"].([]any)
+	if !ok || len(parts) != 2 {
+		t.Fatalf("parts = %#v, want image and text", content["parts"])
+	}
+	imagePart, _ := parts[0].(map[string]any)
+	inlineData, _ := imagePart["inlineData"].(map[string]any)
+	if inlineData["mimeType"] != "image/jpeg" || inlineData["data"] != "Zg==" {
+		t.Errorf("inlineData = %#v, want JPEG test image", inlineData)
+	}
+	textPart, _ := parts[1].(map[string]any)
+	if textPart["text"] != "describe" {
+		t.Errorf("text part = %#v, want describe", textPart["text"])
+	}
+	config, _ := captured["generationConfig"].(map[string]any)
+	if config["responseMimeType"] != "application/json" || config["maxOutputTokens"] != float64(1000) {
+		t.Errorf("generationConfig = %#v, want JSON and 1000 tokens", config)
+	}
+}
+
 // TestCallAIProvider_ContextCancellation guards the fix for the request
 // context being ignored: when the caller cancels (e.g. the user aborts the
 // HTTP request), the upstream AI call must return promptly instead of
@@ -244,6 +294,19 @@ func claudeEnvelope(text string) string {
 	return string(b)
 }
 
+func geminiEnvelope(parts ...string) string {
+	geminiParts := make([]map[string]any, 0, len(parts))
+	for _, text := range parts {
+		geminiParts = append(geminiParts, map[string]any{"text": text})
+	}
+	b, _ := json.Marshal(map[string]any{
+		"candidates": []map[string]any{{
+			"content": map[string]any{"parts": geminiParts},
+		}},
+	})
+	return string(b)
+}
+
 // TestParseAIResponse exercises parseAIResponse directly across the edge cases
 // that were previously only reached indirectly through CallAIProvider: markdown-
 // fenced and prose-wrapped JSON, the NO_FOOD_DETECTED sentinel, empty/absent
@@ -279,10 +342,16 @@ func TestParseAIResponse(t *testing.T) {
 			want:     &AIResult{Calories: 90, Food: "celery"},
 		},
 		{
-			name:     "unknown provider falls back to the choices envelope",
+			name:     "gemini joins text parts from the candidates envelope",
 			provider: "gemini",
-			body:     openaiEnvelope(`{"calories":42,"food":"olive"}`),
+			body:     geminiEnvelope(`{"calories":42,`, `"food":"olive"}`),
 			want:     &AIResult{Calories: 42, Food: "olive"},
+		},
+		{
+			name:     "unknown provider falls back to the choices envelope",
+			provider: "other",
+			body:     openaiEnvelope(`{"calories":43,"food":"pear"}`),
+			want:     &AIResult{Calories: 43, Food: "pear"},
 		},
 		{
 			name:     "markdown-fenced json is unwrapped by brace slicing",
@@ -361,6 +430,12 @@ func TestParseAIResponse(t *testing.T) {
 			wantErr:  "empty AI response",
 		},
 		{
+			name:     "empty gemini candidates array",
+			provider: "gemini",
+			body:     `{"candidates":[]}`,
+			wantErr:  "empty AI response",
+		},
+		{
 			name:     "whitespace-only content is not valid JSON",
 			provider: "openai",
 			body:     openaiEnvelope("   \n\t "),
@@ -379,6 +454,12 @@ func TestParseAIResponse(t *testing.T) {
 			provider: "claude",
 			body:     `<html>gateway error</html>`,
 			wantErr:  "failed to parse Claude response",
+		},
+		{
+			name:     "malformed gemini envelope",
+			provider: "gemini",
+			body:     `<html>gateway error</html>`,
+			wantErr:  "failed to parse Gemini response",
 		},
 
 		// --- malformed inner JSON ---


### PR DESCRIPTION
## Summary

- add Google Gemini as a supported AI nutrition-estimation provider
- send multimodal `generateContent` requests with inline image data and JSON output configuration
- parse Gemini candidate/part responses into the existing `AIResult`
- expose Gemini in user and admin provider settings
- update deployment documentation, Helm examples, the manual test checklist, and privacy disclosures in every supported language

## Implementation

- uses the Gemini REST endpoint `models/{model}:generateContent`
- authenticates with the `x-goog-api-key` header
- requires an API key and explicit model, consistent with the hosted OpenAI and Claude providers
- preserves custom endpoint support
- reuses the existing provider/model/key database fields, so no migration is required

## Tests

- `go test ./...`
- `go vet ./...`
- `npm --prefix client run typecheck`
- `npm --prefix client run lint`
- `LANG=en_US.UTF-8 npm --prefix client test` (161 tests)
- `npm --prefix client run i18n:check`
- `npm --prefix client run i18n:drift`
- `npm --prefix client run build`
- manual end-to-end test from an Android phone against a locally built Docker Compose stack using `gemini-3.6-flash`: food-photo estimation returned HTTP 200 and the estimated entry was saved successfully

Implemented and tested with assistance from OpenAI Codex.
