### PR TITLE
ci: promote e2e from continue-on-error to a real release gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,7 +265,8 @@ jobs:
         run: npm run i18n:check
         working-directory: client
 
-  # A real gate from the first commit, not `continue-on-error` like `e2e`: the
+  # A real gate from the first commit, not `continue-on-error` the way `e2e`
+  # started out (#457 promoted it only after a week of green staging runs): the
   # tree is lint-clean as of this change, so there is no red-by-default period
   # to wait out. It is in `compute-version`'s `needs:` for the same reason
   # gofmt and go vet already are — those hard-gate the release chain today from
@@ -391,17 +392,19 @@ jobs:
     needs: test
     # A hung browser must not sit on a runner for the default 6 hours.
     timeout-minutes: 45
-    # REPORT-ONLY FOR NOW. This suite has never executed in CI, so its first
-    # runs are expected to surface environment differences rather than real
-    # regressions, and a gate that is red by default is a gate somebody deletes.
+    # A REAL GATE (#457), not report-only. Promoted after the suite ran
+    # 266/266 green with zero flaky and zero retries used on every `staging`
+    # run of this workflow from 2026-08-09 through 2026-08-30, and on the
+    # `main` release run on 2026-08-30. The four root causes behind the
+    # chronic flakes it used to have — worker-shared accounts, a strict-mode
+    # violation, the SSE subscription race, and a `waitForURL(/\/login|\//)`
+    # that matched any URL with a slash — are fixed rather than retried away
+    # (#453, #455).
     #
-    # TO TURN IT INTO A REAL GATE (target: once it has been green on `staging`
-    # for a week — tracked in #312) TWO changes are needed, not one:
-    #   1. delete the `continue-on-error` line below, and
-    #   2. add `e2e` to `compute-version`'s `needs:` — otherwise the release
-    #      chain still runs in parallel with this job and a red suite publishes
-    #      an image anyway.
-    continue-on-error: true
+    # Promotion needed both changes together, not just dropping
+    # `continue-on-error` here: `compute-version` now also `needs:` this job
+    # (see below), otherwise the release chain ran in parallel with e2e and a
+    # red suite could still publish an image.
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -488,7 +491,11 @@ jobs:
 
   compute-version:
     runs-on: ubuntu-latest
-    needs: [test, lint]
+    # `e2e` is in this list (#457) so the release chain waits on it rather than
+    # running alongside it — without that, a red E2E suite would still let
+    # compute-version -> build-and-push -> create-manifest publish an image
+    # before the failure was even reported.
+    needs: [test, lint, e2e]
     # Deliberately not serialised: this job only *reads* git state. A group here
     # would be theatre — it is released the moment the job ends, several jobs
     # before create-tag writes anything. Job-level concurrency cannot span a


### PR DESCRIPTION
## Summary

Closes #457.

`build.yml`'s `e2e` job has carried `continue-on-error: true` since it was first wired into CI, with a comment saying promotion needs two changes together and is tracked in #312 (closed — that issue was about getting e2e into CI at all, not about this promotion).

**Green-run evidence (the stated precondition):** the `e2e` job has concluded `success` on every `staging` run of `build.yml` from 2026-08-09 through 2026-08-30 (266/266 tests, zero flaky, zero retries used), and on today's `main` release run. The four root causes behind the suite's historical flakiness — worker-shared accounts, a strict-mode violation, the SSE subscription race, and a `waitForURL(/\/login|\//)` that matched any URL with a slash — are fixed rather than retried away (#453, #455).

## Changes

Both changes together, as the tracking comment required (doing only #1 is useless — the release chain would still run in parallel with e2e and a red suite would still publish an image):

1. Delete `continue-on-error: true` from the `e2e` job.
2. Add `e2e` to `compute-version`'s `needs:` (now `[test, lint, e2e]`), so the release chain waits on the suite instead of racing it.

Also:
- Replaced the stale "TO TURN IT INTO A REAL GATE ... tracked in #312" comment on the `e2e` job with one reflecting that it's now a real gate, plus the evidence above.
- Fixed the `lint` job's comment, which compared itself to `` `continue-on-error` like `e2e` `` — no longer accurate now that e2e is also a real gate.

## Explicitly NOT touched

Per the existing (and preserved) comments in `build.yml`: the `vuln` job and everything in `scans.yml` stay out of the release `needs:` chain on purpose — they can go red on upstream advisories published on someone else's schedule, and gating releases on those would let an unrelated CVE block a hotfix. `e2e` is different because it tests this repo's own code, which is exactly why it belongs in the chain and those don't. This PR does not add `vuln` or any scanner job to `needs:` anywhere.

## DAG check

Confirmed nothing else `needs:` the `e2e` job, and `compute-version` is already upstream of the entire release chain (`create-tag`, `build-and-push`, `create-manifest`, `create-release`, `publish-helm`, `notify-argocd` all transitively depend on it), so adding `e2e` there is sufficient to gate every downstream release step.

## Test plan

- [x] `actionlint v1.7.12` (same pinned version as `.github/workflows/workflow-audit.yml`) run locally against `.github/workflows/*.yml` — clean, no findings.
- [x] `zizmor v1.29.0` (same pinned version as `workflow-audit.yml`) run locally against `.github/workflows/build.yml` — "No findings to report."
- [x] Confirmed only `.github/workflows/build.yml` changed; no Go/client code touched, so `go test ./...` is not applicable here.
- Not run (per instructions): `npm run test:e2e` / any `compose.test.yml` command — the compose project name is shared across concurrent worktrees, so it's deliberately excluded from this change's own verification even though it's the job being edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhPLVD9yn32Hrag8pPfZbt