### PR TITLE
fix: set explicit width/height on captcha images

### DIFF
--- a/client/src/pages/ForgotPassword/ForgotPassword.tsx
+++ b/client/src/pages/ForgotPassword/ForgotPassword.tsx
@@ -54,7 +54,7 @@ export default function ForgotPassword() {
           {captchaSvg && (
             <div className="flex flex-col gap-2">
               <div className="flex justify-center rounded-md bg-muted/50 p-2 invert [&_img]:max-w-full">
-                <img src={`data:image/svg+xml;base64,${btoa(captchaSvg)}`} alt={t('forgotPassword.captchaAltText')} />
+                <img src={`data:image/svg+xml;base64,${btoa(captchaSvg)}`} alt={t('forgotPassword.captchaAltText')} width={150} height={50} />
               </div>
               {captchaQuestion && (
                 <p className="text-sm text-muted-foreground">

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -207,7 +207,7 @@ export default function Login() {
               {captchaSvg && (
                 <div className="flex flex-col gap-2">
                   <div className="flex justify-center rounded-md bg-muted/50 p-2 invert [&_img]:max-w-full">
-                    <img src={`data:image/svg+xml;base64,${btoa(captchaSvg)}`} alt={t('login.captchaAltText')} />
+                    <img src={`data:image/svg+xml;base64,${btoa(captchaSvg)}`} alt={t('login.captchaAltText')} width={150} height={50} />
                   </div>
                   {captchaQuestion && (
                     <p className="text-sm text-muted-foreground">

--- a/client/src/pages/Register/Register.tsx
+++ b/client/src/pages/Register/Register.tsx
@@ -175,7 +175,7 @@ export default function Register() {
           ) : (
             <div className="flex flex-col gap-2">
               <div className="flex justify-center rounded-md bg-muted/50 p-2 invert [&_img]:max-w-full">
-                <img src={`data:image/svg+xml;base64,${btoa(captchaSvg)}`} alt={t('register.captchaAltText')} />
+                <img src={`data:image/svg+xml;base64,${btoa(captchaSvg)}`} alt={t('register.captchaAltText')} width={150} height={50} />
               </div>
               {captchaQuestion && (
                 <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

Closes #487

Lighthouse flagged image elements without explicit intrinsic dimensions. This audits every `<img>` in `client/src` and fixes the ones where the rendered size is actually knowable ahead of fetch, per the issue's scope.

## Images changed

| File | Dimensions | Source of the numbers |
|---|---|---|
| `client/src/pages/Login/Login.tsx` (captcha) | `width={150} height={50}` | `internal/service/captcha.go` `renderCaptchaSVG`: `width := 150; height := 50` are hardcoded constants, always emitted regardless of the challenge text |
| `client/src/pages/Register/Register.tsx` (captcha) | `width={150} height={50}` | same as above |
| `client/src/pages/ForgotPassword/ForgotPassword.tsx` (captcha) | `width={150} height={50}` | same as above |

## Images audited and deliberately left unchanged

- **`Landing.tsx` Google Play badge** — already has `width={646} height={250}` from a prior commit (`8c08f9c4`). Verified against the actual PNG IHDR-equivalent header of `public/google-play-badge.png`: 646×250. No change needed.
- **`Legal/Imprint.tsx`** address/email `<img>`s (`/imprint/address.svg`, `/imprint/email.svg`) — these are Go-rendered SVGs (`internal/handler/legal.go` → `textToSvg`) whose `width`/`height` are computed from the admin-configured `IMPRINT_ADDRESS`/`IMPRINT_EMAIL` text length (`width = max(maxLineLen*10, 100)`, `height = numLines*24`). This varies per deployment/admin config and is genuinely unknown until the SVG is fetched — exactly the case the issue says to leave alone. No Go changes made.
- **OIDC provider-logo `<img>`s** (`Login.tsx`, `Register.tsx`, `OIDCSettings.tsx`, `StepUpModal.tsx`) — externally-sourced brand logos of unknown native size, but already rendered in a fixed `w-5 h-5` (20×20) CSS box, which already satisfies Lighthouse's check independent of the source asset's dimensions.
- **2FA QR `<img>`** (`TwoFactorSettings.tsx`) — already rendered in a fixed `w-[200px] h-[200px]` CSS box; already satisfies the check.
- **Sidebar/Header logo `<img>`s** — already carry `width={40}/{44} height={40}/{44}`, matching the aspect ratio of the actual source `public/logo-128.webp` (verified 128×128 from the WebP VP8 bitstream header).
- **AI photo preview `<img>`** (`AIPhotoModal.tsx`) — shows a photo captured/uploaded by the user; size is genuinely unknown until that happens, matching the issue's explicit exclusion.

## Test plan

- [x] `npm run build` — succeeds
- [x] `npm run lint` — no findings
- [x] `npm test` — 161 tests pass across 19 files
- [x] No Go files changed (imprint SVG generator intentionally untouched), so `go build ./...` was run as a sanity check and succeeds; full `go test ./...` not required since no Go source changed
- [x] Manually confirmed intrinsic byte-level dimensions of `public/google-play-badge.png` (646×250) and `public/logo-128.webp` (128×128) rather than guessing
- [x] Diff kept to the 3 captcha `<img>` lines only — `Landing.tsx` was intentionally left untouched since another concurrent PR (#486) is editing heading levels in that same file