### PR TITLE
feat: link the architecture guide from llms.txt

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -12,6 +12,7 @@
 
 - [Self-hosting guide](https://github.com/schaurian/schautrack#readme): Docker, Kubernetes, and configuration instructions.
 - [API guide](https://github.com/schaurian/schautrack/blob/main/docs/api-v1.md): usage, authentication, scopes, and endpoint reference.
+- [Architecture guide](https://github.com/schaurian/schautrack/blob/main/docs/architecture.md): system design, request pipeline, and the real-time (SSE) update flow.
 
 ## Source and support
 


### PR DESCRIPTION
## Summary
- `/llms.txt` (issue #488) is **already implemented and live in production** — shipped in commit `8c08f9c4` ("fix: address agent and lighthouse audit findings", 2026-08-09), which added `public/llms.txt`, wired it through the existing `spaFallback` public static-file path in `cmd/server/main.go`, added `TestLLMSTxtServedFromPublicStaticPath` in `cmd/server/main_test.go`, and documented it in `docs/api-internal.md`.
- Verified live: `GET https://schautrack.com/llms.txt` returns 200. All acceptance criteria in #488 are met: 200 `text/plain`, single H1, short blockquote summary, organized H2 sections with canonical links, served from the existing public static-file path, and covered by a route/integration test.
- Every link in the file was checked and returns 200: the hosted app, `/api/v1/docs`, `/api/v1/openapi.json`, `/privacy`, `/terms`, `/imprint` (all on schautrack.com), and the GitHub README/api-v1.md/releases/android-repo links.
- The one gap against the requested canonical-docs list was `docs/architecture.md`, which wasn't linked. This PR adds it under the "Documentation" section, next to the README and API guide links.

## Test plan
- [x] `go test ./...` passes, including `TestLLMSTxtServedFromPublicStaticPath` (asserts 200, `Content-Type: text/plain`, and the `# Schautrack` H1).
- [x] Manually verified every URL referenced in `public/llms.txt` (production site + GitHub) resolves with 200.

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhPLVD9yn32Hrag8pPfZbt