### PR TITLE
fix: make the quick-add "+ more" overflow actually add food

### DIFF
--- a/client/src/i18n/locales/de/dashboard.json
+++ b/client/src/i18n/locales/de/dashboard.json
@@ -242,6 +242,7 @@
     "sectionTitle": "Schnellzugriff",
     "manageButton": "Verwalten",
     "moreButton": "+ mehr",
+    "lessButton": "− weniger",
     "modalTitle": "Gespeicherte Lebensmittel",
     "searchPlaceholder": "Suchen…",
     "newButton": "+ Neu",

--- a/client/src/i18n/locales/en/dashboard.json
+++ b/client/src/i18n/locales/en/dashboard.json
@@ -249,6 +249,7 @@
     "deleteSavedFoodAriaLabel": "Delete saved food",
     "draftNamePlaceholder": "Name (e.g. Porridge)",
     "emptyState": "No saved foods yet. Use the \"Save\" button on the entry form, or hit \"+ New\".",
+    "lessButton": "− less",
     "logQuantityButton": "Log {{count}}×",
     "logQuantityButton_one": "Log {{count}}×",
     "logQuantityButton_other": "Log {{count}}×",

--- a/client/src/i18n/locales/es/dashboard.json
+++ b/client/src/i18n/locales/es/dashboard.json
@@ -242,6 +242,7 @@
     "sectionTitle": "Acceso rápido",
     "manageButton": "Gestionar",
     "moreButton": "+ más",
+    "lessButton": "− menos",
     "modalTitle": "Alimentos guardados",
     "searchPlaceholder": "Buscar…",
     "newButton": "+ Nuevo",

--- a/client/src/i18n/locales/fr/dashboard.json
+++ b/client/src/i18n/locales/fr/dashboard.json
@@ -242,6 +242,7 @@
     "sectionTitle": "Ajout rapide",
     "manageButton": "Gérer",
     "moreButton": "+ plus",
+    "lessButton": "− moins",
     "modalTitle": "Aliments enregistrés",
     "searchPlaceholder": "Rechercher…",
     "newButton": "+ Nouveau",

--- a/client/src/i18n/locales/it/dashboard.json
+++ b/client/src/i18n/locales/it/dashboard.json
@@ -242,6 +242,7 @@
     "sectionTitle": "Aggiunta rapida",
     "manageButton": "Gestisci",
     "moreButton": "+ altri",
+    "lessButton": "− meno",
     "modalTitle": "Cibi salvati",
     "searchPlaceholder": "Cerca…",
     "newButton": "+ Nuovo",

--- a/client/src/i18n/locales/nl/dashboard.json
+++ b/client/src/i18n/locales/nl/dashboard.json
@@ -242,6 +242,7 @@
     "sectionTitle": "Snel toevoegen",
     "manageButton": "Beheren",
     "moreButton": "+ meer",
+    "lessButton": "− minder",
     "modalTitle": "Opgeslagen eten",
     "searchPlaceholder": "Zoeken…",
     "newButton": "+ Nieuw",

--- a/client/src/i18n/locales/pl/dashboard.json
+++ b/client/src/i18n/locales/pl/dashboard.json
@@ -250,6 +250,7 @@
     "sectionTitle": "Szybkie dodawanie",
     "manageButton": "Zarządzaj",
     "moreButton": "+ więcej",
+    "lessButton": "− mniej",
     "modalTitle": "Zapisane produkty",
     "searchPlaceholder": "Szukaj…",
     "newButton": "+ Nowy",

--- a/client/src/i18n/locales/pt/dashboard.json
+++ b/client/src/i18n/locales/pt/dashboard.json
@@ -242,6 +242,7 @@
     "sectionTitle": "Adição rápida",
     "manageButton": "Gerir",
     "moreButton": "+ mais",
+    "lessButton": "− menos",
     "modalTitle": "Alimentos guardados",
     "searchPlaceholder": "Pesquisar…",
     "newButton": "+ Novo",

--- a/client/src/pages/Dashboard/SavedFoodsRow.test.tsx
+++ b/client/src/pages/Dashboard/SavedFoodsRow.test.tsx
@@ -1,0 +1,101 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SavedFood } from '@/types';
+import SavedFoodsRow from './SavedFoodsRow';
+
+// The quick-add row shows the first 8 foods on desktop / 6 on mobile and folds
+// the rest behind "+ more". Everything past that cut is only reachable through
+// that control, so what it opens has to be able to track — issue #489, where
+// "+ more" opened the Manage list instead and clicking a food there started a
+// rename rather than logging an entry.
+
+vi.mock('@/api/savedFoods', () => ({
+  listSavedFoods: vi.fn(),
+  trackSavedFood: vi.fn(),
+  createSavedFood: vi.fn(),
+  updateSavedFood: vi.fn(),
+  deleteSavedFood: vi.fn(),
+}));
+
+vi.mock('@/api/entries', () => ({
+  deleteEntry: vi.fn(),
+}));
+
+import { listSavedFoods, trackSavedFood } from '@/api/savedFoods';
+
+const food = (id: number): SavedFood => ({
+  id,
+  name: `Food ${id}`,
+  emoji: null,
+  amount: 100 * id,
+  macros: { protein: null, carbs: null, fat: null, fiber: null, sugar: null },
+  use_count: 0,
+  last_used_at: null,
+});
+
+/** More than DESKTOP_CHIPS (8), so 9 and 10 sit in the overflow at every width. */
+const TEN_FOODS = Array.from({ length: 10 }, (_, i) => food(i + 1));
+
+function renderRow() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <SavedFoodsRow selectedDate="2026-08-30" />
+    </QueryClientProvider>,
+  );
+}
+
+const chip = (name: string) => screen.getByRole('button', { name });
+
+describe('SavedFoodsRow overflow', () => {
+  beforeEach(() => {
+    vi.mocked(listSavedFoods).mockResolvedValue({ ok: true, savedFoods: TEN_FOODS });
+    vi.mocked(trackSavedFood).mockResolvedValue({
+      ok: true,
+      entry: { id: 4242 } as never,
+    });
+  });
+
+  it('tracks a food that is only reachable through "+ more"', async () => {
+    const user = userEvent.setup();
+    renderRow();
+
+    // Food 10 is past the cut at both widths, so it is not on screen yet.
+    // Food 1 matches twice: the row renders a desktop and a mobile list and
+    // hides one of them with CSS, which jsdom does not apply.
+    await screen.findAllByRole('button', { name: 'Food 1' });
+    expect(screen.queryByRole('button', { name: 'Food 10' })).toBeNull();
+
+    await user.click(chip('+ more'));
+
+    // Whatever "+ more" reveals, clicking a food in it must log that food —
+    // it is the only path to these entries.
+    await user.click(await screen.findByRole('button', { name: 'Food 10' }));
+
+    await waitFor(() => {
+      expect(trackSavedFood).toHaveBeenCalledWith(10, '2026-08-30', 1);
+    });
+  });
+
+  it('folds the overflow away again', async () => {
+    const user = userEvent.setup();
+    renderRow();
+
+    await user.click(await screen.findByRole('button', { name: '+ more' }));
+    expect(screen.getByRole('button', { name: 'Food 10' })).toBeInTheDocument();
+
+    await user.click(chip('− less'));
+    expect(screen.queryByRole('button', { name: 'Food 10' })).toBeNull();
+    expect(chip('+ more')).toBeInTheDocument();
+  });
+
+  it('offers no overflow control when every food already fits', async () => {
+    vi.mocked(listSavedFoods).mockResolvedValue({ ok: true, savedFoods: [food(1), food(2)] });
+    renderRow();
+
+    await screen.findAllByRole('button', { name: 'Food 1' });
+    expect(screen.queryByRole('button', { name: '+ more' })).toBeNull();
+  });
+});

--- a/client/src/pages/Dashboard/SavedFoodsRow.tsx
+++ b/client/src/pages/Dashboard/SavedFoodsRow.tsx
@@ -31,6 +31,11 @@ export default function SavedFoodsRow({ selectedDate, onTracked }: Props) {
   const [modalOpen, setModalOpen] = useState(false);
   const [tracking, setTracking] = useState<number | null>(null);
   const [quantityPickerId, setQuantityPickerId] = useState<number | null>(null);
+  // "+ more" unfolds the rest of the chips in place. It used to open the Manage
+  // dialog, which stopped being able to track anything once the per-row Track
+  // button was dropped — so every food past the cut became unloggable (#489).
+  // Manage is still one tap away in the header; it is for editing the list.
+  const [expanded, setExpanded] = useState(false);
 
   const { data } = useQuery({
     queryKey: ['savedFoods'],
@@ -70,6 +75,18 @@ export default function SavedFoodsRow({ selectedDate, onTracked }: Props) {
     setTracking(null);
   };
 
+  const renderChip = (food: SavedFood) => (
+    <Chip
+      key={food.id}
+      food={food}
+      loading={tracking === food.id}
+      quantityPickerOpen={quantityPickerId === food.id}
+      onTrack={(qty) => handleTrack(food, qty)}
+      onOpenQuantity={() => setQuantityPickerId(food.id)}
+      onCloseQuantity={() => setQuantityPickerId(null)}
+    />
+  );
+
   return (
     <>
       <div data-testid="saved-foods-row" className="rounded-2xl border border-white/[0.06] bg-white/[0.015] overflow-hidden">
@@ -80,39 +97,34 @@ export default function SavedFoodsRow({ selectedDate, onTracked }: Props) {
           </Button>
         </div>
         <div className="flex flex-wrap gap-1.5 p-3">
-          <div className="contents max-sm:hidden">
-            {all.slice(0, DESKTOP_CHIPS).map((food) => (
-              <Chip
-                key={food.id}
-                food={food}
-                loading={tracking === food.id}
-                quantityPickerOpen={quantityPickerId === food.id}
-                onTrack={(qty) => handleTrack(food, qty)}
-                onOpenQuantity={() => setQuantityPickerId(food.id)}
-                onCloseQuantity={() => setQuantityPickerId(null)}
-              />
-            ))}
-          </div>
-          <div className="contents sm:hidden">
-            {all.slice(0, MOBILE_CHIPS).map((food) => (
-              <Chip
-                key={food.id}
-                food={food}
-                loading={tracking === food.id}
-                quantityPickerOpen={quantityPickerId === food.id}
-                onTrack={(qty) => handleTrack(food, qty)}
-                onOpenQuantity={() => setQuantityPickerId(food.id)}
-                onCloseQuantity={() => setQuantityPickerId(null)}
-              />
-            ))}
-          </div>
-          {(all.length > DESKTOP_CHIPS || (all.length > MOBILE_CHIPS)) && (
+          {expanded ? (
+            // One list once everything is shown: the two breakpoint lists below
+            // only exist to cut at a different count per width, and rendering
+            // both here would duplicate every chip in the DOM.
+            all.map(renderChip)
+          ) : (
+            <>
+              <div className="contents max-sm:hidden">
+                {all.slice(0, DESKTOP_CHIPS).map(renderChip)}
+              </div>
+              <div className="contents sm:hidden">
+                {all.slice(0, MOBILE_CHIPS).map(renderChip)}
+              </div>
+            </>
+          )}
+          {all.length > MOBILE_CHIPS && (
             <button
               type="button"
-              className="rounded-full border border-dashed border-border bg-transparent text-muted-foreground px-3 py-1 text-sm hover:text-foreground hover:border-ring cursor-pointer transition-colors"
-              onClick={() => setModalOpen(true)}
+              className={cn(
+                'rounded-full border border-dashed border-border bg-transparent text-muted-foreground px-3 py-1 text-sm hover:text-foreground hover:border-ring cursor-pointer transition-colors',
+                // Nothing is folded away on desktop until the desktop cut is
+                // passed, so don't offer to unfold there.
+                !expanded && all.length <= DESKTOP_CHIPS && 'sm:hidden',
+              )}
+              aria-expanded={expanded}
+              onClick={() => setExpanded((v) => !v)}
             >
-              {t('savedFoods.moreButton')}
+              {expanded ? t('savedFoods.lessButton') : t('savedFoods.moreButton')}
             </button>
           )}
         </div>


### PR DESCRIPTION
Closes #489

## What the reporter sees

The quick-add row in the add-food sheet shows the first 8 saved foods on desktop and the first 6 on mobile, with a `+ more` button for the rest. Tapping a food in what `+ more` opens does nothing — no entry is logged, on mobile and desktop alike.

## Root cause

`+ more` did not open an overflow list of chips. It opened the **Manage** dialog — the same screen the "Manage" button in the section header opens.

That used to work by accident: every row in Manage had a **Track** button, so a food reached through `+ more` could still be logged. `ed2689c1` ("refactor(dashboard): drop the Track button from Manage quick foods") removed that button on the sound reasoning that *"Manage is for editing the list; tracking belongs to the chips"* — but nothing re-pointed `+ more` at anything that tracks. From v2.4.1 onward it was a dead end:

- clicking a food's name in Manage calls `beginEdit('name', …)`, which swaps the name for a rename input. To a user that looks like a click that did nothing;
- and because `+ more` was the only route to the foods past the cut, **every saved food beyond the 8th (desktop) / 6th (mobile) became impossible to quick-add at all**. The more saved foods you have, the more of your list is unreachable.

So it was not a swallowed event, a z-index overlay, or a missing handler on one render path — the control was wired to the wrong screen, and the screen it was wired to had quietly lost the ability to do the job.

## Fix

`+ more` now unfolds the remaining chips **in place** and becomes `− less`. The overflow foods are the same `<Chip>` component as the visible ones, so they behave identically: one tap logs one unit, press-and-hold (or right-click, or Shift+Enter) opens the quantity picker. Manage stays in the header, still purely for editing — the design intent of `ed2689c1` is preserved rather than reverted.

Two smaller things fall out of it:

- **No duplicated chips in the DOM.** The row renders a desktop list and a mobile list and hides one with CSS. Expanded, there is nothing left to cut, so it renders a single list.
- **`+ more` no longer appears on desktop when it would reveal nothing.** The old condition was `length > 8 || length > 6`, i.e. just `> 6`, so with 7 or 8 saved foods desktop showed a `+ more` whose overflow was empty.

## Tests

New `client/src/pages/Dashboard/SavedFoodsRow.test.tsx` (vitest + Testing Library). The first case is the regression guard: with 10 saved foods, `Food 10` is off-screen, click `+ more`, click `Food 10`, expect `trackSavedFood(10, date, 1)`. On the old code it fails with *"Number of calls: 0"* — the click lands on Manage's rename button instead. Two more cases cover folding back up and not offering the control when everything already fits.

```
client: npm test            20 files, 164 tests passed
client: npm run lint        clean
client: npm run build       clean
client: npm run i18n:check  parity ok (new savedFoods.lessButton in all 8 locales)
client: npm run i18n:drift  no drift
go test ./...               all passed
```

Not run: the Playwright e2e suite, deliberately — the harness's compose project name is shared and other work was running against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhPLVD9yn32Hrag8pPfZbt
