### PR TITLE
fix: keep deferred locale catalogs out of the entry chunk

### DIFF
--- a/client/src/i18n/index.ts
+++ b/client/src/i18n/index.ts
@@ -27,15 +27,47 @@ export function isSupportedLanguage(code: string): boolean {
 type Catalog = Record<string, unknown>;
 type CatalogModule = { default: Catalog };
 
-// English remains in the startup bundle as the fallback. Every other catalog
-// is a Vite-managed dynamic import, so it is requested only for the detected
-// language or after the user changes their language preference.
-const catalogLoaders = import.meta.glob<CatalogModule>('./locales/*/*.json');
+/** The namespaces every locale ships. Exported so tests assert against one list. */
+export const NAMESPACES = ['common', 'auth', 'dashboard', 'settings', 'landing'] as const;
+
+/**
+ * English stays in the startup bundle, statically imported, and is never fetched.
+ * It is the fallback language: any key a deferred catalog is missing resolves
+ * against it, so a lazily-loaded English would render raw key paths on a miss.
+ */
+const ENGLISH_CATALOGS: Record<string, Catalog> = {
+  auth: enAuth,
+  common: enCommon,
+  dashboard: enDashboard,
+  landing: enLanding,
+  settings: enSettings,
+};
+
+/**
+ * Every other catalog is a Vite-managed dynamic import, so it is requested only
+ * for the detected language or after the user changes their language preference.
+ *
+ * English is excluded from the glob deliberately. Globbing it too made Rollup
+ * see the same module both statically (the imports above) and dynamically, which
+ * it reports as INEFFECTIVE_DYNAMIC_IMPORT and resolves by keeping the module in
+ * the entry chunk — the dynamic half was dead weight. `read()` serves English
+ * from the bundled map instead, so the backend still answers for every language.
+ */
+const catalogLoaders = import.meta.glob<CatalogModule>([
+  './locales/*/*.json',
+  '!./locales/en/*.json',
+]);
 
 const catalogBackend: BackendModule = {
   type: 'backend',
   init() {},
   read(language: string, namespace: string, callback: ReadCallback) {
+    const bundled = language === 'en' ? ENGLISH_CATALOGS[namespace] : undefined;
+    if (bundled) {
+      callback(null, bundled);
+      return;
+    }
+
     const loader = catalogLoaders[`./locales/${language}/${namespace}.json`];
     if (!loader) {
       callback(new Error(`No translation catalog for ${language}/${namespace}`), false);
@@ -57,20 +89,12 @@ export const i18nReady = i18n
     // Tell i18next that English is only the bundled subset; without this it
     // assumes every language is already present and never calls the backend.
     partialBundledLanguages: true,
-    resources: {
-      en: {
-        auth: enAuth,
-        common: enCommon,
-        dashboard: enDashboard,
-        landing: enLanding,
-        settings: enSettings,
-      },
-    },
+    resources: { en: ENGLISH_CATALOGS },
     fallbackLng: 'en',
     supportedLngs: SUPPORTED_CODES,
     nonExplicitSupportedLngs: true, // 'de-DE' -> 'de'
     load: 'languageOnly',
-    ns: ['common', 'auth', 'dashboard', 'settings', 'landing'],
+    ns: [...NAMESPACES],
     defaultNS: 'common',
     interpolation: { escapeValue: false }, // React already escapes
     detection: {

--- a/client/src/i18n/runtime.test.tsx
+++ b/client/src/i18n/runtime.test.tsx
@@ -1,27 +1,138 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const NAMESPACES = ['common', 'auth', 'dashboard', 'settings', 'landing'];
+/**
+ * Runtime coverage for deferred translation catalogs (issue #485).
+ *
+ * `tests/i18nBundleSplit.test.ts` proves the build half — that only English
+ * rides in the entry chunk. This file proves the runtime half: that a deferred
+ * catalog still arrives complete, and still *renders*, for a returning user's
+ * stored language and for every language the selector offers.
+ *
+ * Catalogs are read here with an eager `import.meta.glob` on purpose: this is a
+ * test module, outside the application's entry graph, so it never reaches the
+ * shipped bundle. Comparing the loaded resource bundle against the file on disk
+ * is what makes "the complete catalog" an assertion rather than a hope.
+ */
+
+type Catalog = Record<string, unknown>;
+
+const NAMESPACES = ['common', 'auth', 'dashboard', 'settings', 'landing'] as const;
 const DEFERRED_LANGUAGES = ['de', 'es', 'fr', 'it', 'nl', 'pl', 'pt'];
 
-async function freshI18n(storedLanguage?: string) {
+/**
+ * One key per namespace, each translated differently from English in all eight
+ * locales. Rendering only `common` would let a half-fetched language pass.
+ */
+const PROBE_KEYS: Record<(typeof NAMESPACES)[number], string> = {
+  common: 'app.loading',
+  auth: 'deleteAccount.couldNotDelete',
+  dashboard: 'aiPhoto.analyzingText',
+  landing: 'features.aiEstimation.title',
+  settings: 'account.logout',
+};
+
+const catalogModules = import.meta.glob<{ default: Catalog }>('./locales/*/*.json', {
+  eager: true,
+});
+const catalogs: Record<string, Record<string, Catalog>> = {};
+for (const path in catalogModules) {
+  const match = /\.\/locales\/([^/]+)\/([^/]+)\.json$/.exec(path);
+  if (!match) continue;
+  (catalogs[match[1]] ??= {})[match[2]] = catalogModules[path].default;
+}
+
+let releaseDom: (() => void) | undefined;
+
+/**
+ * Boot the real i18n module from a clean slate, as a page load would.
+ *
+ * Everything React touches is imported *after* `vi.resetModules()` and in one
+ * batch. The reset gives the re-imported i18n module a fresh copy of
+ * react-i18next, and a hook from one copy of React cannot run inside a tree
+ * rendered by another — the dispatcher is per-copy. Importing react and Testing
+ * Library alongside keeps the whole render in a single module registry.
+ */
+async function freshRuntime(storedLanguage?: string) {
   localStorage.clear();
   if (storedLanguage) localStorage.setItem('i18nextLng', storedLanguage);
   vi.resetModules();
 
-  const module = await import('./index');
-  await module.i18nReady;
-  return module.default;
+  const [i18nModule, reactI18next, react, testing] = await Promise.all([
+    import('./index'),
+    import('react-i18next'),
+    import('react'),
+    import('@testing-library/react'),
+  ]);
+
+  await i18nModule.i18nReady;
+  releaseDom = testing.cleanup;
+  const namespaces: readonly string[] = i18nModule.NAMESPACES;
+
+  const i18n = i18nModule.default;
+
+  /** Every paint of the probe, oldest first, as ns -> rendered text. */
+  const painted: Record<string, string>[] = [];
+
+  function Probe() {
+    const { t } = reactI18next.useTranslation([...NAMESPACES]);
+    const snapshot: Record<string, string> = {};
+    for (const ns of NAMESPACES) snapshot[ns] = t(`${ns}:${PROBE_KEYS[ns]}`);
+    painted.push(snapshot);
+
+    return react.createElement(
+      'div',
+      null,
+      NAMESPACES.map((ns) =>
+        react.createElement('span', { key: ns, 'data-testid': ns }, snapshot[ns])
+      )
+    );
+  }
+
+  const rendered = testing.render(react.createElement(Probe));
+  const read = (ns: string) => rendered.getByTestId(ns).textContent ?? '';
+  const changeLanguage = async (lng: string) => {
+    await testing.act(async () => {
+      await i18n.changeLanguage(lng);
+    });
+  };
+
+  return { i18n, namespaces, painted, read, changeLanguage };
 }
 
 afterEach(() => {
+  releaseDom?.();
+  releaseDom = undefined;
   localStorage.clear();
   vi.resetModules();
 });
 
-describe('deferred catalog loading', () => {
-  it('loads a stored language and all its namespaces before the first render', async () => {
-    const i18n = await freshI18n('de-DE');
+/** Asserts the DOM shows `lng`'s own catalog text, not English and not a key. */
+function expectRenderedLanguage(
+  i18n: { getResource: (l: string, n: string, k: string) => unknown },
+  read: (ns: string) => string,
+  lng: string
+) {
+  for (const ns of NAMESPACES) {
+    const key = PROBE_KEYS[ns];
+    const expected = i18n.getResource(lng, ns, key) as string;
+    expect(expected, `fixture: ${lng}/${ns}:${key} must exist`).toBeTruthy();
 
+    const shown = read(ns);
+    expect(shown, `${lng} ${ns} renders its own catalog`).toBe(expected);
+    expect(shown, `${lng} ${ns} is not the English fallback`).not.toBe(
+      i18n.getResource('en', ns, key) as string
+    );
+    expect(shown, `${lng} ${ns} is not a raw key path`).not.toContain(key);
+  }
+}
+
+describe('a returning user with a stored language', () => {
+  it('loads every namespace of that language before the first render', async () => {
+    const { i18n, namespaces } = await freshRuntime('de-DE');
+
+    // The probes below only cover a namespace this list names, so a sixth one
+    // added to src/i18n/index.ts must show up here too.
+    expect([...namespaces]).toEqual([...NAMESPACES]);
     expect(i18n.resolvedLanguage).toBe('de');
     expect(document.documentElement.lang).toBe('de');
     for (const namespace of NAMESPACES) {
@@ -30,19 +141,69 @@ describe('deferred catalog loading', () => {
     expect(i18n.t('app.loading')).toBe('Lädt...');
   });
 
-  it('fetches every supported language catalog when it is selected', async () => {
-    const i18n = await freshI18n('en');
+  it('paints that language on the very first frame, never English first', async () => {
+    const { i18n, painted, read } = await freshRuntime('de-DE');
+
+    // The regression this guards is a flash of English: the app mounting
+    // before the stored language's catalogs have arrived. Assert on the first
+    // recorded paint, not just the settled DOM, so a later correction cannot
+    // hide it.
+    expect(painted.length).toBeGreaterThan(0);
+    expect(painted[0].common).toBe('Lädt...');
+    for (const snapshot of painted) {
+      expect(snapshot.common).not.toBe(i18n.getResource('en', 'common', 'app.loading'));
+    }
+    expectRenderedLanguage(i18n, read, 'de');
+  });
+});
+
+describe('switching language', () => {
+  it('fetches, renders and completes the catalog for every supported language', async () => {
+    const { i18n, read, changeLanguage } = await freshRuntime('en');
 
     for (const language of DEFERRED_LANGUAGES) {
-      expect(i18n.hasResourceBundle(language, 'common')).toBe(false);
+      expect(
+        i18n.hasResourceBundle(language, 'common'),
+        `${language} must not be bundled up front`
+      ).toBe(false);
 
-      await i18n.changeLanguage(language);
+      await changeLanguage(language);
 
       expect(i18n.resolvedLanguage).toBe(language);
+      expect(document.documentElement.lang).toBe(language);
+
       for (const namespace of NAMESPACES) {
         expect(i18n.hasResourceBundle(language, namespace)).toBe(true);
+        // Not a subset, not a truncated fetch: the whole file, key for key.
+        expect(i18n.getResourceBundle(language, namespace)).toEqual(
+          catalogs[language][namespace]
+        );
       }
-      expect(i18n.t('app.loading')).not.toBe('app.loading');
+
+      expectRenderedLanguage(i18n, read, language);
+    }
+  });
+
+  it('falls back to English text when a catalog fails to load', async () => {
+    const { i18n, read, changeLanguage } = await freshRuntime('en');
+
+    // Simulate the deferred chunk 404ing — a stale index.html after a deploy,
+    // or an offline client. English is bundled, so the UI must stay readable
+    // rather than render key paths.
+    const failing = 'fr';
+    i18n.services.backendConnector.backend.read = (
+      _lng: string,
+      _ns: string,
+      callback: (err: unknown, data: false | Catalog) => void
+    ) => {
+      callback(new Error('chunk unavailable'), false);
+    };
+
+    await changeLanguage(failing);
+
+    for (const ns of NAMESPACES) {
+      const key = PROBE_KEYS[ns];
+      expect(read(ns)).toBe(i18n.getResource('en', ns, key) as string);
     }
   });
 });

--- a/client/tests/i18nBundleSplit.test.ts
+++ b/client/tests/i18nBundleSplit.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build, type Rollup } from 'vite';
+
+/**
+ * Bundle-split regression tests for deferred translation catalogs (issue #485).
+ *
+ * `src/i18n/index.ts` used to load every namespace of all eight locales with an
+ * eager `import.meta.glob`, so a first-time visitor downloaded ~330 kB of
+ * catalogs (~113 kB gzip) they would never read. `src/i18n/runtime.test.tsx`
+ * proves the *runtime* half of the fix — that a deferred catalog still arrives
+ * and still renders. It cannot prove the half that motivated the issue: that
+ * the bytes actually left the entry chunk. A single `{ eager: true }` put back
+ * on that glob would keep every runtime test green while silently undoing the
+ * saving.
+ *
+ * So this file runs the real production build (in memory — `write: false`, no
+ * `dist/` is touched) and asserts on the emitted chunk graph:
+ *
+ *   - the entry chunk carries the English catalogs, because English is the
+ *     fallback language and a fetched fallback would render raw key paths on
+ *     a miss;
+ *   - the entry chunk carries no other locale;
+ *   - every other locale/namespace pair is still reachable, as its own chunk.
+ *
+ * The build is the slow part here, so it runs once for the whole file.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const clientRoot = resolve(here, '..');
+
+const LOCALES = ['de', 'en', 'es', 'fr', 'it', 'nl', 'pl', 'pt'];
+const NAMESPACES = ['common', 'auth', 'dashboard', 'settings', 'landing'];
+
+let chunks: Rollup.OutputChunk[] = [];
+let entry: Rollup.OutputChunk;
+
+beforeAll(async () => {
+  const result = await build({
+    root: clientRoot,
+    logLevel: 'silent',
+    build: {
+      // Keep the assertions about *this* repo's chunking, not about a stale
+      // dist/ some earlier command left behind, and write nothing to disk.
+      write: false,
+      sourcemap: false,
+    },
+  });
+
+  const outputs = (Array.isArray(result) ? result : [result]) as Rollup.RollupOutput[];
+  chunks = outputs
+    .flatMap((o) => o.output)
+    .filter((o): o is Rollup.OutputChunk => o.type === 'chunk');
+
+  const entries = chunks.filter((c) => c.isEntry);
+  expect(entries).toHaveLength(1);
+  entry = entries[0];
+}, 180_000);
+
+/** Module ids of every catalog a chunk inlined, as `lng/ns` pairs. */
+function catalogsIn(chunk: Rollup.OutputChunk): string[] {
+  return Object.keys(chunk.modules)
+    .map((id) => /src\/i18n\/locales\/([^/]+)\/([^/]+)\.json$/.exec(id))
+    .filter((m): m is RegExpExecArray => m !== null)
+    .map((m) => `${m[1]}/${m[2]}`)
+    .sort();
+}
+
+describe('translation catalogs in the production bundle', () => {
+  it('keeps the English fallback in the entry chunk', () => {
+    const inEntry = catalogsIn(entry);
+    for (const ns of NAMESPACES) {
+      expect(inEntry).toContain(`en/${ns}`);
+    }
+  });
+
+  it('keeps every other locale out of the entry chunk', () => {
+    const foreign = catalogsIn(entry).filter((id) => !id.startsWith('en/'));
+    expect(foreign).toEqual([]);
+  });
+
+  it('emits each deferred catalog as its own chunk', () => {
+    const deferred = new Set(
+      chunks.filter((c) => !c.isEntry).flatMap((c) => catalogsIn(c))
+    );
+
+    for (const lng of LOCALES.filter((l) => l !== 'en')) {
+      for (const ns of NAMESPACES) {
+        expect(deferred, `${lng}/${ns} must be split out`).toContain(`${lng}/${ns}`);
+      }
+    }
+  });
+
+  it('ships no non-English translated string in the entry chunk', () => {
+    // Belt and braces: the module-id assertions above would miss a catalog
+    // inlined by some future plugin that rewrites ids. These four strings are
+    // "Loading..." in four of the deferred locales.
+    for (const sample of ['Lädt...', 'Cargando...', 'Chargement...', 'Ładowanie...']) {
+      expect(entry.code).not.toContain(sample);
+    }
+  });
+
+  it('has a loader entry for every deferred catalog and none for English', () => {
+    // The glob in src/i18n/index.ts excludes English on purpose: globbing a
+    // module that is also statically imported makes Rollup report
+    // INEFFECTIVE_DYNAMIC_IMPORT and keep it in the entry chunk anyway.
+    const source = readFileSync(resolve(clientRoot, 'src/i18n/index.ts'), 'utf8');
+    expect(source).toContain("'!./locales/en/*.json'");
+    expect(source).not.toMatch(/import\.meta\.glob[^)]*eager/);
+  });
+});
+
+describe('the boot sequence waits for the detected language', () => {
+  it('mounts React inside i18nReady', () => {
+    // A returning user with a stored non-English language must not see a frame
+    // of English first. main.tsx guarantees that by creating the React root
+    // only after i18nReady resolves — by which point the detected language's
+    // namespaces have been fetched. Hoisting createRoot out of that callback
+    // reintroduces the flash, and no runtime test would notice.
+    const source = readFileSync(resolve(clientRoot, 'src/main.tsx'), 'utf8');
+    const gate = source.indexOf('i18nReady.then(');
+    expect(gate).toBeGreaterThan(-1);
+    expect(source.indexOf('createRoot(')).toBeGreaterThan(gate);
+  });
+});


### PR DESCRIPTION
Closes #485.

## What was already there

The deferred-catalog backend landed on `staging` in 8c08f9c4 (`fix: address agent and lighthouse audit findings`): `src/i18n/index.ts` already used a non-eager `import.meta.glob` behind an i18next `BackendModule`, English stayed statically imported as the fallback, and `main.tsx` already gated `createRoot` on `i18nReady`. I verified that on `origin/staging` before touching anything — the entry chunk there contains no non-English catalog.

So this PR does the two things that were left: remove the last of the English dead weight, and make the split something CI can actually defend.

## Changes

**1. Exclude English from the dynamic glob** (`client/src/i18n/index.ts`)

Globbing `./locales/*/*.json` included `en`, which is also statically imported. Rollup saw one module both ways, reported it five times as `INEFFECTIVE_DYNAMIC_IMPORT`, and resolved it by keeping the module in the entry chunk — so the dynamic half was pure noise. The glob now excludes `!./locales/en/*.json` and `read()` serves English from the bundled map, so the backend still answers for every supported language and English is still never fetched. That matters: English is the fallback, and a lazily-loaded fallback renders raw key paths on a miss.

**2. `client/tests/i18nBundleSplit.test.ts` (new)**

Runs the real production build in memory (`write: false`, `dist/` untouched, ~0.5 s) and asserts on the emitted chunk graph:

- English catalogs are in the entry chunk (the fallback must be bundled);
- no other locale is in the entry chunk, by module id *and* by string sample;
- every deferred locale/namespace pair is emitted as its own chunk;
- `src/i18n/index.ts` carries no `eager` glob;
- `main.tsx` still creates the React root inside `i18nReady.then(...)` — hoisting `createRoot` out of that callback is exactly what reintroduces a flash of English for a returning user, and no runtime test would notice.

Negative control: with `{ eager: true }` put back on the glob, 4 of these 6 fail.

**3. Real renders in `client/src/i18n/runtime.test.tsx`**

The existing tests asserted i18next state only. They now render through `react-i18next` (every React-touching module imported after `vi.resetModules()` so the whole tree lives in one module registry) and cover:

- a returning user with `i18nextLng=de-DE` paints German on the **first** recorded frame — asserted on the paint log, not just the settled DOM, so a later correction cannot hide a flash;
- each of the seven deferred languages, after `changeLanguage`, renders its own catalog across **all five** namespaces (one probe key per namespace, each translated differently from English in all eight locales — rendering only `common` would let a half-fetched language pass);
- the loaded resource bundle deep-equals the catalog file on disk, so "complete catalog" is an assertion rather than a hope;
- a catalog that fails to load falls back to English text, not key paths.

Negative control: dropping the `await i18nReady` fails the first-frame test.

## Before / after

Entry chunk, from `npm run build` (before = the same tree with `{ eager: true }` restored on the glob):

| | raw | gzip |
|---|---|---|
| eager glob (before #485) | 694.61 kB | 225.75 kB |
| `staging` today (8c08f9c4) | 360.60 kB | 112.60 kB |
| this branch | **358.80 kB** | **111.93 kB** |

335.81 kB raw / 113.82 kB gzip off the initial load. Each language is now 5 chunks totalling ~45–49 kB raw (~17–19 kB gzip), fetched only when it is the detected language or the user selects it. Asset count goes 26 → 86 files (40 catalog chunks).

## Verification

Run in `client/` (deps installed with `npm ci`):

- `npm run build` — clean, and the five `INEFFECTIVE_DYNAMIC_IMPORT` warnings are gone
- `npm test` — 169 passed (20 files)
- `npm run lint` — clean
- `npm run i18n:check` — parity passed for all 7 locales
- `npm run i18n:drift` — no files updated
- `go test ./...` — passes

**Local e2e: not run.** The Playwright harness (`compose.test.yml`) uses a hardcoded, shared compose project name and other agents were running against it concurrently, so I did not run `npm run test:e2e` on this machine.

**CI e2e: green on this commit.** The workflow's `e2e` job ran the full suite on GitHub-hosted runners — 266 passed, 0 failed, 0 skipped (run 33320967591, job 99283058307, 6m14s). That includes `e2e/language-switch.spec.ts`, which covers the three paths this change touches: a live switch to German updating the UI and `<html lang>`, the preference persisting across a reload (the returning-user first render), and an anonymous visitor with a `de-DE` browser locale being autodetected. Worth knowing when reading that green tick: the `e2e` job is still `continue-on-error: true` (report-only, see #312), so it would not have blocked the PR — but the "Run Playwright suite" step itself reported success, it was not merely tolerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhPLVD9yn32Hrag8pPfZbt

