### PR TITLE
fix: restore unicode-range on the self-hosted font subsets

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,23 +5,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import App from './App';
 import { i18nReady } from '@/i18n';
-// Self-hosted Noto Sans (weights 400/500/600/700) — replaces the third-party
-// Google Fonts request for GDPR compliance and air-gapped/self-hosted support.
-// All supported locales use the Latin script; Polish additionally requires
-// Latin Extended. Importing explicit subsets avoids bundling unused scripts.
-import '@fontsource/noto-sans/latin-400.css';
-import '@fontsource/noto-sans/latin-ext-400.css';
-import '@fontsource/noto-sans/latin-500.css';
-import '@fontsource/noto-sans/latin-ext-500.css';
-import '@fontsource/noto-sans/latin-600.css';
-import '@fontsource/noto-sans/latin-ext-600.css';
-import '@fontsource/noto-sans/latin-700.css';
-import '@fontsource/noto-sans/latin-ext-700.css';
-// Display face for titles, section labels and the ring numerals.
-import '@fontsource/space-grotesk/latin-500.css';
-import '@fontsource/space-grotesk/latin-ext-500.css';
-import '@fontsource/space-grotesk/latin-700.css';
-import '@fontsource/space-grotesk/latin-ext-700.css';
+// Self-hosted Noto Sans (weights 400/500/600/700) and Space Grotesk (500/700) —
+// replaces the third-party Google Fonts request for GDPR compliance and
+// air-gapped/self-hosted support. Latin and Latin Extended only; see the header
+// of fonts.css for why the @font-face rules are declared there rather than
+// imported from @fontsource directly.
+import '@/styles/fonts.css';
 import '@/styles/global.css';
 
 export const queryClient = new QueryClient({

--- a/client/src/styles/fonts.css
+++ b/client/src/styles/fonts.css
@@ -1,0 +1,170 @@
+/*
+ * Self-hosted web fonts — Latin and Latin Extended only (issue #484).
+ *
+ * Why these rules are hand-written instead of importing @fontsource's own
+ * stylesheets:
+ *
+ * @fontsource ships two shapes of stylesheet. `<weight>.css` declares every
+ * subset the family has (Cyrillic, Greek, Devanagari, Vietnamese, …) and each
+ * @font-face carries a `unicode-range`, so the browser downloads only the
+ * subsets a page actually renders. `<subset>-<weight>.css` declares a single
+ * subset and deliberately omits `unicode-range` — it is meant to be used
+ * *alone*, as "this family is only ever this subset".
+ *
+ * Composing two of the latter (`latin-400.css` + `latin-ext-400.css`) does not
+ * produce a two-subset family. Both rules then describe the same
+ * family/style/weight with the same (absent) unicode-range, so the later rule
+ * simply replaces the earlier one: the browser resolves 'Noto Sans' 400 to the
+ * latin-ext file only. That file holds no ASCII glyphs — 1138 codepoints, none
+ * of A-Z, a-z or 0-9 — so the entire UI silently falls back to system-ui while
+ * still paying to download a 55 KB font nobody can see a glyph from.
+ *
+ * So: the subset files' woff2 assets, with the `unicode-range` descriptors from
+ * the composed stylesheets put back. Latin is fetched for every locale;
+ * latin-ext is fetched only when a page renders one of ąćęłńśźż (Polish is the
+ * one supported locale that needs it — ó lives in the latin range).
+ *
+ * Unsupported scripts (Cyrillic, Greek, Devanagari, Vietnamese) are omitted on
+ * purpose: their assets are then never emitted into the bundle at all. Text a
+ * user types in those scripts falls back to a system font, which is the
+ * trade the issue asks for.
+ *
+ * woff2 only, no woff fallback. Every browser that can run this app (ES2020,
+ * React 19) has supported woff2 since 2016; shipping the woff twins doubled the
+ * emitted font assets for bytes no client ever requested.
+ *
+ * The ranges below are copied verbatim from
+ * node_modules/@fontsource/<family>/<weight>.css. If @fontsource updates them,
+ * `fonts.test.ts` fails — it diffs these rules against the package.
+ */
+
+/* U+0100-02BA … — Latin Extended */
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/noto-sans/files/noto-sans-latin-ext-400-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308,
+    U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113,
+    U+2C60-2C7F, U+A720-A7FF;
+}
+
+/* U+0000-00FF … — Latin */
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/noto-sans/files/noto-sans-latin-400-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
+    U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url('@fontsource/noto-sans/files/noto-sans-latin-ext-500-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308,
+    U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113,
+    U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url('@fontsource/noto-sans/files/noto-sans-latin-500-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
+    U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 600;
+  src: url('@fontsource/noto-sans/files/noto-sans-latin-ext-600-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308,
+    U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113,
+    U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 600;
+  src: url('@fontsource/noto-sans/files/noto-sans-latin-600-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
+    U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/noto-sans/files/noto-sans-latin-ext-700-normal.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308,
+    U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113,
+    U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: 'Noto Sans';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/noto-sans/files/noto-sans-latin-700-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
+    U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* Display face for titles, section labels and the ring numerals. */
+@font-face {
+  font-family: 'Space Grotesk';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url('@fontsource/space-grotesk/files/space-grotesk-latin-ext-500-normal.woff2')
+    format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308,
+    U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113,
+    U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: 'Space Grotesk';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url('@fontsource/space-grotesk/files/space-grotesk-latin-500-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
+    U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: 'Space Grotesk';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/space-grotesk/files/space-grotesk-latin-ext-700-normal.woff2')
+    format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308,
+    U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113,
+    U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: 'Space Grotesk';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/space-grotesk/files/space-grotesk-latin-700-normal.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
+    U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}

--- a/client/tests/fonts.test.ts
+++ b/client/tests/fonts.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { inflateSync } from 'node:zlib';
+
+/**
+ * Regression tests for the self-hosted web fonts (issue #484).
+ *
+ * The bug these exist to prevent: @fontsource's per-subset stylesheets
+ * (`latin-400.css`, `latin-ext-400.css`, …) deliberately omit `unicode-range`,
+ * because each is meant to be the *only* stylesheet for its family. Importing
+ * two of them stacks two @font-face rules with an identical
+ * family/style/weight/unicode-range tuple, so the later rule replaces the
+ * earlier one instead of composing with it. The result is that the browser
+ * resolves the family to the latin-ext file — which contains no ASCII glyphs at
+ * all — and every page downloads the big Latin-Extended cut whether or not a
+ * single Polish character is on screen.
+ *
+ * So the checks below assert the three properties that make
+ * `src/styles/fonts.css` correct, all of which the shipped version violated:
+ *
+ *  1. every @font-face carries a `unicode-range`,
+ *  2. no two rules collide on (family, style, weight, unicode-range), and
+ *  3. the ranges match the ones @fontsource itself publishes.
+ *
+ * Plus the thing the issue actually asks for: that the subsets we keep really
+ * do cover every character the eight supported locales use. That one is checked
+ * against the fonts' real `cmap` tables, not against the declared ranges — a
+ * codepoint can sit inside `unicode-range` and still be absent from the file.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const clientRoot = resolve(here, '..');
+const fontsCssPath = resolve(clientRoot, 'src/styles/fonts.css');
+const fontsCss = readFileSync(fontsCssPath, 'utf8');
+const nodeModules = resolve(clientRoot, 'node_modules');
+
+/** Weights each family is expected to ship, per the design. */
+const EXPECTED_WEIGHTS: Record<string, number[]> = {
+  'Noto Sans': [400, 500, 600, 700],
+  'Space Grotesk': [500, 700],
+};
+
+/** The two subsets the supported locales need. */
+const EXPECTED_SUBSETS = ['latin', 'latin-ext'];
+
+interface FontFace {
+  family: string;
+  style: string;
+  weight: string;
+  src: string;
+  unicodeRange: string | undefined;
+  /** The @fontsource package path inside the single `url()`. */
+  file: string;
+}
+
+function parseFontFaces(css: string): FontFace[] {
+  const faces: FontFace[] = [];
+  for (const [, body] of css.matchAll(/@font-face\s*\{([^}]*)\}/g)) {
+    const decl = (name: string): string | undefined => {
+      const m = body.match(new RegExp(`(?:^|;)\\s*${name}\\s*:\\s*([^;]+)`, 'i'));
+      return m ? m[1].replace(/\s+/g, ' ').trim() : undefined;
+    };
+    const src = decl('src') ?? '';
+    const urls = [...src.matchAll(/url\(\s*['"]?([^'")]+)['"]?\s*\)/g)].map((m) => m[1]);
+    expect(urls, `each @font-face declares exactly one url() in ${src}`).toHaveLength(1);
+    faces.push({
+      family: (decl('font-family') ?? '').replace(/['"]/g, ''),
+      style: decl('font-style') ?? '',
+      weight: decl('font-weight') ?? '',
+      src,
+      unicodeRange: decl('unicode-range')?.replace(/\s+/g, ''),
+      file: urls[0],
+    });
+  }
+  return faces;
+}
+
+const faces = parseFontFaces(fontsCss);
+
+/** Reads the tables out of a WOFF 1.0 container. */
+function woffTables(path: string): Map<string, Buffer> {
+  const d = readFileSync(path);
+  expect(d.subarray(0, 4).toString('latin1'), `${path} is a WOFF container`).toBe('wOFF');
+  const numTables = d.readUInt16BE(12);
+  const out = new Map<string, Buffer>();
+  for (let i = 0; i < numTables; i++) {
+    const e = 44 + i * 20;
+    const tag = d.subarray(e, e + 4).toString('latin1');
+    const offset = d.readUInt32BE(e + 4);
+    const compLength = d.readUInt32BE(e + 8);
+    const origLength = d.readUInt32BE(e + 12);
+    const raw = d.subarray(offset, offset + compLength);
+    out.set(tag, compLength === origLength ? raw : inflateSync(raw));
+  }
+  return out;
+}
+
+/** Every codepoint the font has a glyph for, from its `cmap`. */
+function codepoints(cmap: Buffer): Set<number> {
+  let chosen: { offset: number; format: number } | undefined;
+  const n = cmap.readUInt16BE(2);
+  for (let i = 0; i < n; i++) {
+    const platform = cmap.readUInt16BE(4 + i * 8);
+    const encoding = cmap.readUInt16BE(6 + i * 8);
+    const offset = cmap.readUInt32BE(8 + i * 8);
+    const unicode =
+      (platform === 3 && (encoding === 1 || encoding === 10)) ||
+      (platform === 0 && encoding >= 3 && encoding <= 6);
+    if (!unicode) continue;
+    const format = cmap.readUInt16BE(offset);
+    // Prefer format 12 (full Unicode) over format 4 (BMP only).
+    if (!chosen || format === 12) chosen = { offset, format };
+  }
+  if (!chosen) throw new Error('no Unicode cmap subtable');
+
+  const cps = new Set<number>();
+  const { offset, format } = chosen;
+  if (format === 4) {
+    const segCount = cmap.readUInt16BE(offset + 6) / 2;
+    const endBase = offset + 14;
+    const startBase = endBase + segCount * 2 + 2;
+    const deltaBase = startBase + segCount * 2;
+    const rangeBase = deltaBase + segCount * 2;
+    for (let i = 0; i < segCount; i++) {
+      const end = cmap.readUInt16BE(endBase + i * 2);
+      const start = cmap.readUInt16BE(startBase + i * 2);
+      if (start === 0xffff) continue;
+      const delta = cmap.readInt16BE(deltaBase + i * 2);
+      const rangeOffset = cmap.readUInt16BE(rangeBase + i * 2);
+      for (let c = start; c <= end; c++) {
+        let glyph: number;
+        if (rangeOffset === 0) {
+          glyph = (c + delta) & 0xffff;
+        } else {
+          const at = rangeBase + i * 2 + rangeOffset + (c - start) * 2;
+          if (at + 2 > cmap.length) continue;
+          glyph = cmap.readUInt16BE(at);
+          if (glyph !== 0) glyph = (glyph + delta) & 0xffff;
+        }
+        if (glyph !== 0) cps.add(c);
+      }
+    }
+  } else if (format === 12) {
+    const groups = cmap.readUInt32BE(offset + 12);
+    for (let i = 0; i < groups; i++) {
+      const g = offset + 16 + i * 12;
+      const start = cmap.readUInt32BE(g);
+      const end = cmap.readUInt32BE(g + 4);
+      for (let c = start; c <= end; c++) cps.add(c);
+    }
+  } else {
+    throw new Error(`unsupported cmap format ${format}`);
+  }
+  return cps;
+}
+
+/** Resolves a `@fontsource/...woff2` url to the sibling `.woff` in node_modules. */
+function woffSibling(file: string): string {
+  return resolve(nodeModules, file.replace(/\.woff2$/, '.woff'));
+}
+
+describe('self-hosted font stylesheet', () => {
+  it('declares exactly the intended families, weights and subsets', () => {
+    const seen = faces.map((f) => `${f.family}/${f.weight}/${subsetOf(f.file)}`).sort();
+    const want = Object.entries(EXPECTED_WEIGHTS)
+      .flatMap(([family, weights]) =>
+        weights.flatMap((w) => EXPECTED_SUBSETS.map((s) => `${family}/${w}/${s}`))
+      )
+      .sort();
+    expect(seen).toEqual(want);
+  });
+
+  it('gives every @font-face a unicode-range', () => {
+    // Without this, two rules for the same family/weight collide and the last
+    // one silently wins — the exact bug that shipped the ASCII-less latin-ext
+    // cut to every visitor.
+    const missing = faces.filter((f) => !f.unicodeRange).map((f) => f.file);
+    expect(missing).toEqual([]);
+  });
+
+  it('never lets two faces collide on the same descriptor tuple', () => {
+    const keys = faces.map((f) => `${f.family}|${f.style}|${f.weight}|${f.unicodeRange}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('uses the unicode-ranges @fontsource publishes for these subsets', () => {
+    // If @fontsource re-cuts a subset, the ranges here go stale and text in the
+    // moved codepoints would fall back to a system font. Diff them.
+    for (const face of faces) {
+      const pkg = face.file.split('/files/')[0];
+      const upstream = readFileSync(resolve(nodeModules, pkg, `${face.weight}.css`), 'utf8');
+      const basename = face.file.split('/').pop();
+      const block = upstream
+        .split('@font-face')
+        .find((b) => b.includes(basename!.replace(/\.woff2$/, '.woff2')));
+      expect(block, `${basename} still exists upstream`).toBeDefined();
+      const range = block!.match(/unicode-range:\s*([^;]+)/)?.[1].replace(/\s+/g, '');
+      expect(face.unicodeRange, `unicode-range for ${basename}`).toBe(range);
+    }
+  });
+
+  it('ships woff2 only, with every referenced file present', () => {
+    for (const face of faces) {
+      expect(face.file, 'font url is a woff2 in @fontsource').toMatch(
+        /^@fontsource\/[^/]+\/files\/.+\.woff2$/
+      );
+      expect(face.src, 'no legacy woff fallback — woff2 is universally supported').not.toMatch(
+        /format\(['"]woff['"]\)/
+      );
+      expect(existsSync(resolve(nodeModules, face.file)), `${face.file} exists`).toBe(true);
+    }
+  });
+
+  it('is the only place the app pulls fonts in', () => {
+    const main = readFileSync(resolve(clientRoot, 'src/main.tsx'), 'utf8');
+    expect(main).toContain("import '@/styles/fonts.css';");
+    // A bare @fontsource stylesheet import would re-introduce either the
+    // unused scripts or the unicode-range-less subset files.
+    expect(main).not.toMatch(/@fontsource\/[^'"]+\.css/);
+  });
+});
+
+function subsetOf(file: string): string {
+  const m = file.match(/-(latin-ext|latin)-\d+-normal\.woff2$/);
+  if (!m) throw new Error(`cannot read subset from ${file}`);
+  return m[1];
+}
+
+describe('locale coverage', () => {
+  /** Every character used by every supported locale's translations. */
+  const localeChars = (() => {
+    const dir = resolve(clientRoot, 'src/i18n/locales');
+    const chars = new Map<string, Set<string>>();
+    for (const locale of readdirSync(dir)) {
+      const set = new Set<string>();
+      for (const file of readdirSync(resolve(dir, locale))) {
+        const walk = (node: unknown): void => {
+          if (typeof node === 'string') for (const c of node) set.add(c);
+          else if (Array.isArray(node)) node.forEach(walk);
+          else if (node && typeof node === 'object')
+            for (const [k, v] of Object.entries(node)) {
+              for (const c of k) set.add(c);
+              walk(v);
+            }
+        };
+        walk(JSON.parse(readFileSync(resolve(dir, locale, file), 'utf8')));
+      }
+      chars.set(locale, set);
+    }
+    return chars;
+  })();
+
+  /**
+   * Characters no Latin cut can supply, which fall back to the platform's
+   * symbol/emoji font by design. Listed explicitly so that a *new* uncovered
+   * character — a locale gaining Greek or Cyrillic, say — fails instead of
+   * quietly rendering in a fallback face.
+   */
+  const FALLBACK_BY_DESIGN = new Set(['\n', '⚠', '🔄']);
+
+  it('covers all eight supported locales', () => {
+    expect([...localeChars.keys()].sort()).toEqual(['de', 'en', 'es', 'fr', 'it', 'nl', 'pl', 'pt']);
+  });
+
+  it('has a real glyph for every locale character in both families', () => {
+    for (const [family, weights] of Object.entries(EXPECTED_WEIGHTS)) {
+      const covered = new Set<number>();
+      for (const face of faces.filter((f) => f.family === family && f.weight === String(weights[0])))
+        for (const cp of codepoints(woffTables(woffSibling(face.file)).get('cmap')!)) covered.add(cp);
+
+      for (const [locale, chars] of localeChars) {
+        const missing = [...chars].filter(
+          (c) => !covered.has(c.codePointAt(0)!) && !FALLBACK_BY_DESIGN.has(c)
+        );
+        expect(missing, `${family} covers ${locale}`).toEqual([]);
+      }
+    }
+  });
+
+  it('needs latin-ext for Polish and only for Polish', () => {
+    // The justification for keeping latin-ext at all. If this ever flips, the
+    // subset can be dropped from the critical path entirely.
+    const latinOnly = new Set<number>();
+    const latinFace = faces.find((f) => f.family === 'Noto Sans' && subsetOf(f.file) === 'latin')!;
+    for (const cp of codepoints(woffTables(woffSibling(latinFace.file)).get('cmap')!))
+      latinOnly.add(cp);
+
+    const needsExt = new Map<string, string>();
+    for (const [locale, chars] of localeChars) {
+      const beyond = [...chars]
+        .filter((c) => !latinOnly.has(c.codePointAt(0)!) && !FALLBACK_BY_DESIGN.has(c))
+        .sort();
+      if (beyond.length > 0) needsExt.set(locale, beyond.join(''));
+    }
+    expect([...needsExt.keys()]).toEqual(['pl']);
+    // Polish diacritics only — ó/Ó are in the latin cut and never show up here.
+    const POLISH = new Set('ąćęłńśźżĄĆĘŁŃŚŹŻ');
+    expect([...needsExt.get('pl')!].filter((c) => !POLISH.has(c))).toEqual([]);
+    expect(needsExt.get('pl')!.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #484

## What I found

`main.tsx` no longer imported the all-subset stylesheets — commit 8c08f9c4 ("fix: address agent and lighthouse audit findings") had already swapped them for `@fontsource/<family>/latin-<weight>.css` + `latin-ext-<weight>.css`. That swap is broken, and it is currently on `main`.

@fontsource ships two shapes of stylesheet:

- `<weight>.css` — every subset the family has, each `@font-face` carrying a `unicode-range`, so the browser fetches only the subsets a page renders.
- `<subset>-<weight>.css` — a single subset with **no `unicode-range`**, meant to be the *only* stylesheet for that family.

Importing two of the second kind does not compose a two-subset family. Both rules describe the same family/style/weight with the same (absent) `unicode-range`, so the later one replaces the earlier one. `'Noto Sans'` 400 therefore resolved to `noto-sans-latin-ext-400-normal.woff2` — 1138 codepoints, **not one of A-Z, a-z or 0-9** (verified by parsing the font's `cmap`).

Chrome recovers by walking back to the previously declared face, so it downloads *both* files for every weight. Browsers that don't walk back render the entire UI in `system-ui`.

## The fix

Declare the twelve `@font-face` rules directly in `client/src/styles/fonts.css`, pointing at the same self-hosted @fontsource woff2 assets (no CDN, nothing added to `package.json`) with the `unicode-range` descriptors from the composed stylesheets put back. Weights are unchanged: Noto Sans 400/500/600/700, Space Grotesk 500/700.

Also drops the legacy `.woff` twins that the @fontsource CSS lists alongside each woff2. Every browser that can run this app has supported woff2 since 2016; shipping both doubled the emitted font assets for bytes no client ever requested.

## Locale verification

Checked, not assumed. All 40 locale JSON files across the eight locales were parsed and every character tested against the fonts' real `cmap` tables:

| locale | needs latin-ext? |
|---|---|
| de, en, es, fr, it, nl, pt | no — latin only |
| **pl** | **yes — `ąćęłńśźż` (upper and lower)** |

`ó`/`Ó` are in the latin range, so they are *not* what makes Polish need latin-ext. `œ` (fr) is also in latin. The only characters no Latin cut can supply are `⚠` and `🔄` in `settings.json`, which fall back to the platform symbol font exactly as they did before.

## Measurements

Built with `npm run build` at each of the three states.

**Emitted `dist/assets`:**

| | CSS raw | CSS gzip | font files | font bytes | subsets emitted |
|---|---|---|---|---|---|
| all-subset (state the issue was filed on) | 99,530 | 15,432 | 76 | 1,684,920 | cyrillic, cyrillic-ext, devanagari, greek, greek-ext, latin, latin-ext, vietnamese |
| current `staging` (this PR's base) | 89,244 | 14,301 | 24 | 800,204 | latin, latin-ext |
| **this PR** | **90,362** | **14,342** | **12** | **338,824** | latin, latin-ext |

vs. the issue's baseline: CSS −9,168 bytes raw (−9.2%), −1,090 gzip (−7.1%); font assets −64 files (−84%), −1,346,096 bytes (−80%). No script-specific cut is emitted any more.

vs. `staging`: font assets −12 files (−50%), −461,380 bytes (−58%). CSS is +1,118 raw / +41 gzip — the `unicode-range` descriptors, which is what buys the transfer win below.

**Fonts a browser actually downloads** (headless Chromium, static server access log, page rendering all six faces):

| | non-Polish page | Polish page |
|---|---|---|
| all-subset baseline | 6 files, 79,728 B | 12 files, 338,824 B |
| current `staging` | **12 files, 338,824 B** | 12 files, 338,824 B |
| **this PR** | **6 files, 79,728 B** | 12 files, 338,824 B |

So `staging` today ships **4.25× the font bytes** of the version the issue was filed against, on every non-Polish page load. This PR restores 79,728 B while keeping the emitted-asset reduction the issue asked for. Polish is unchanged and correct — latin-ext arrives on demand.

`font-display: swap` is preserved on every rule and the family/weight set is identical, so there is no new layout shift.

## Test

New `client/tests/fonts.test.ts` (9 tests, runs in the existing `logic` vitest project) pins:

1. exactly the intended families × weights × subsets,
2. every `@font-face` has a `unicode-range`,
3. no two rules collide on (family, style, weight, unicode-range),
4. the ranges still match what @fontsource publishes (catches an upstream re-cut),
5. woff2 only, every referenced file present in `node_modules`,
6. `main.tsx` pulls fonts from nowhere else,
7. every character in all eight locales has a real glyph — read from the `cmap` of the packaged fonts, because a codepoint can sit inside a `unicode-range` and still be missing from the file,
8. latin-ext is needed by Polish and only by Polish.

Mutation-checked: stripping `unicode-range` from `fonts.css` fails tests 2/3/4; adding a Greek string to `en/common.json` fails tests 7/8.

## Checks

- `npm run build` — passes
- `npm run lint` — passes (189 files, clean)
- `npm test` — 170 passed (20 files), up from 161
- `go test ./...` — passes
- No dependency or lockfile change; `npm ci` only.
- E2E not run, per instruction (shared compose project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhPLVD9yn32Hrag8pPfZbt
