### PR TITLE
feat: add CloudNativePG as a second in-chart database engine

### DIFF
--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -90,12 +90,35 @@ jobs:
       # key that helm itself happily templates into a manifest the API server
       # would reject.
       #
-      # No -schema-location beyond kubeconform's default: the chart templates
-      # only core kinds (Deployment, Service, Ingress, PVC, ConfigMap, Secret,
-      # ServiceAccount), all covered by the stock schemas. Add a CRD schema
-      # location only when a CRD template actually lands.
-      - name: Validate rendered manifests
-        run: helm template helm/schautrack | kubeconform -strict -summary
+      # A CRD template has now landed, so the second -schema-location is here:
+      # the chart renders a CloudNativePG Cluster (and ScheduledBackup), whose
+      # schemas are not in kubeconform's stock set. `default` must be listed
+      # explicitly — naming any location replaces the built-in list rather than
+      # adding to it, so omitting it would stop validating every core kind.
+      #
+      # NOT -ignore-missing-schemas, which is the tempting one-word fix: it
+      # would silence this by skipping validation of the only resource the
+      # chart newly introduces, i.e. exactly the manifest most likely to be
+      # wrong, while still reporting "Valid" for everything else.
+      #
+      # Both engines are rendered, because they are mutually exclusive and the
+      # default (bundled) would otherwise be the only one CI ever checks.
+      - name: Validate rendered manifests (bundled engine)
+        run: |
+          helm template helm/schautrack --set postgresql.auth.password=ci \
+            | kubeconform -strict -summary \
+                -schema-location default \
+                -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+
+      - name: Validate rendered manifests (CloudNativePG engine)
+        run: |
+          helm template helm/schautrack --set postgresql.mode=cnpg \
+              --set postgresql.backup.enabled=true \
+              --set postgresql.backup.destinationPath=s3://ci/schautrack \
+              --set postgresql.backup.s3Credentials.secretName=ci-s3 \
+            | kubeconform -strict -summary \
+                -schema-location default \
+                -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
 
   dockerfile:
     runs-on: ubuntu-latest

--- a/docs/cloudnativepg.md
+++ b/docs/cloudnativepg.md
@@ -1,0 +1,260 @@
+# PostgreSQL on CloudNativePG
+
+The chart runs PostgreSQL one of two ways, chosen with `postgresql.mode`:
+
+- **`bundled`** (the default) — a single PostgreSQL Pod with a PVC. Nothing to
+  install, nothing else to run.
+- **`cnpg`** — a [CloudNativePG](https://cloudnative-pg.io/) `Cluster`.
+
+Both are supported. This page is about `cnpg`: when it is worth the operator,
+how to configure it, and how to move an existing `bundled` install onto it
+without losing data.
+
+**Upgrading the chart changes nothing on its own.** `bundled` stays the default
+precisely so an upgrade cannot move a running release off its data.
+
+## Which one do you want
+
+`bundled` is a `Deployment` with `replicas: 1`, `strategy: Recreate` and a PVC.
+That is genuinely enough for a single-node homelab, or anywhere the volume is
+already covered by cluster-level backups. It has no failover and no
+point-in-time recovery, and restoring it means restoring a volume.
+
+`cnpg` gives you continuous backup to object storage, PITR to any moment in the
+retention window, replicas with automatic failover, and managed minor-version
+upgrades — in exchange for running an operator.
+
+Rule of thumb: if losing the last day of entries would merely annoy you, and
+something already snapshots the PVC, `bundled` is fine. If you would be upset,
+or you want the database to survive a node dying without you noticing, use
+`cnpg`.
+
+```yaml
+postgresql:
+  enabled: true
+  mode: cnpg
+```
+
+`mode` defaults to `bundled` because Helm cannot tell a fresh install from an
+upgrade. A default of `cnpg` would move every existing release onto an empty
+Cluster while its data sat in a PVC nothing mounts — the database would look
+erased on an upgrade nobody asked for.
+
+## Prerequisites
+
+The CNPG operator (>= 1.24) must already be installed. The chart deliberately
+does not install it: the operator is cluster-scoped and shared between every
+application that uses it, so owning it from an application chart would mean two
+releases fighting over one set of CRDs.
+
+```bash
+kubectl apply --server-side -f \
+  https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.28/releases/cnpg-1.28.0.yaml
+kubectl -n cnpg-system wait --for=condition=Available deploy/cnpg-controller-manager --timeout=180s
+```
+
+## The one invariant you must not break
+
+**Everything that talks to the database uses the `-rw` Service.**
+
+CNPG publishes three Services: `-rw` (the current primary), `-ro` (hot
+standbys) and `-r` (any instance). Pointing schautrack at `-ro` or `-r` looks
+like it works — reads succeed, the health check passes — and then breaks
+Server-Sent Events silently.
+
+`NOTIFY` does not replicate. `internal/sse` publishes cross-instance events with
+`pg_notify` and consumes them with a dedicated `LISTEN` connection, so a
+listener attached to a standby waits on a channel that never fires. There is no
+error: linked-user views simply stop updating, and nothing in the logs says why.
+
+The chart wires this correctly on its own — `DATABASE_URL` comes from the
+operator-generated `<cluster>-app` Secret, whose `uri` key resolves to `-rw` —
+and `scripts/migrate-to-cnpg.sh` refuses to finish if the DSN it finds does not.
+If you override the DSN by hand, keep it on `-rw`.
+
+## Fresh installs
+
+Set `mode: cnpg`. The app reads its credentials from the Secret the operator
+generates; there is no password to choose or store.
+
+```yaml
+postgresql:
+  enabled: true
+  mode: cnpg
+  instances: 1        # 3 for real high availability
+  storage:
+    size: 10Gi
+```
+
+`instances: 1` is a single instance with no standby: still a real improvement on
+the old Deployment (managed backups, PITR, supervised restarts), but a node loss
+is downtime until the volume reattaches. Use 3 for HA. Two gives you a standby
+without quorum, so prefer 3 if you can afford the storage.
+
+### Sizing `maxConnections`
+
+The default of 100 is derived, not guessed. `internal/database` pins the pgxpool
+to `MaxConns = 20` per replica, and `sse.Listen` holds **one more** connection
+outside the pool for the lifetime of the process, because a `LISTEN` occupies
+its connection permanently. So the floor is `replicas × 21`, plus CNPG's own
+superuser and streaming-replication slots. Two replicas need 42 before overhead;
+100 leaves room to scale to four without touching it.
+
+## Migrating an existing install
+
+Two paths. Pick by how your release is deployed, not by preference — the
+Helm-managed one **will be reverted** under ArgoCD.
+
+### Helm-managed releases
+
+```bash
+scripts/migrate-to-cnpg.sh -n <namespace> -r <release> [-f your-values.yaml]
+```
+
+Your values file must set `postgresql.mode: cnpg`; the script refuses to run
+otherwise, since upgrading with the mode still on `bundled` would recreate the
+old Deployment on top of the database it just dumped.
+
+Run it with `--dry-run` first; that stops after preflight without changing
+anything.
+
+What it does, and why in this order:
+
+1. **Scales the app to 0.** Downtime starts. Dumping a live database would be
+   internally consistent — `pg_dump` is snapshot-based — but rows written after
+   the snapshot would be lost at cutover with nobody noticing.
+2. **Fingerprints the source** (`scripts/db-fingerprint.sql`): an md5 per table
+   over ordered, fully-rendered rows, plus every sequence position.
+3. **Dumps** in custom format, then **proves the dump is restorable** by running
+   `pg_restore --list` over it *inside the pod* and asserting the expected
+   tables carry data. A truncated transfer is caught here, before anything is
+   deleted.
+4. **Annotates the old PVC** `helm.sh/resource-policy=keep` so Helm leaves it
+   behind. This is your rollback; nothing in the script deletes it.
+5. **Upgrades the release** with the app pinned at 0 replicas.
+6. **Restores** with `pg_restore --role=<app user>`, then asserts every table in
+   `public` is owned by that user.
+7. **Fingerprints the result and diffs it** against step 2. Row counts are
+   excluded from the comparison because `pg_stat_user_tables` is an estimate
+   until `ANALYZE` runs; the digests and sequences are exact.
+8. **Verifies the app's real DSN** over TCP, and that `LISTEN`/`NOTIFY` actually
+   delivers on it.
+9. **Scales the app back up.** Downtime ends.
+
+If anything fails before step 5, the app is scaled back up automatically —
+nothing was changed. After step 5 it deliberately stays down, because coming up
+against a half-restored database is worse than staying dark.
+
+### ArgoCD-managed releases
+
+`scripts/migrate-to-cnpg.sh` is wrong here and running it is actively dangerous.
+It drives `helm upgrade`, which an Application with `selfHeal: true` reverts,
+and its PVC guard is `helm.sh/resource-policy=keep` — a **Helm** annotation that
+ArgoCD does not honour.
+
+With `prune: true`, the moment the new chart syncs, ArgoCD deletes the old
+Deployment, Service **and PVC**, because they are no longer in the rendered
+manifest set. The `kubernetes.io/pvc-protection` finalizer does not save you: it
+only blocks deletion while a Pod is mounting the volume, and that Pod is being
+deleted in the same sync.
+
+Do this instead:
+
+```bash
+NS=schautrack-staging
+APP=schautrack-staging
+REL=schautrack-staging
+
+# 1. Protect the volume from the prune, in ArgoCD's own vocabulary.
+kubectl -n "$NS" annotate pvc "$REL-postgresql" \
+  argocd.argoproj.io/sync-options=Prune=false,Delete=false --overwrite
+
+# 2. Stop ArgoCD from syncing or self-healing mid-migration.
+kubectl -n argocd patch application "$APP" --type merge \
+  -p '{"spec":{"syncPolicy":{"automated":null}}}'
+
+# 3. Stop writers.
+kubectl -n "$NS" scale deploy "$REL" --replicas=0
+
+# 4. Fingerprint and dump, exactly as the script does.
+kubectl -n "$NS" exec -i "deploy/$REL-postgresql" -- \
+  psql -U schautrack -d schautrack -tA < scripts/db-fingerprint.sql > /tmp/before.txt
+kubectl -n "$NS" exec "deploy/$REL-postgresql" -- \
+  pg_dump -U schautrack -d schautrack -Fc --no-owner --no-acl > /tmp/schautrack.dump
+kubectl -n "$NS" exec -i "deploy/$REL-postgresql" -- pg_restore --list < /tmp/schautrack.dump | head
+
+# 5. Point the Application at the 3.x chart and sync ONCE, manually.
+#    (Update targetRevision, then:)
+argocd app sync "$APP"
+
+# 6. Restore into the new Cluster, then verify — same steps 6-8 as above.
+PRIMARY=$(kubectl -n "$NS" get pods -l "cnpg.io/cluster=$REL-postgresql,cnpg.io/instanceRole=primary" -o name | head -1)
+kubectl -n "$NS" exec -i "$PRIMARY" -- pg_restore -U postgres -d schautrack \
+  --role=schautrack --no-owner --no-acl --clean --if-exists --exit-on-error < /tmp/schautrack.dump
+
+# 7. Re-enable automation once you are satisfied.
+kubectl -n argocd patch application "$APP" --type merge \
+  -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
+```
+
+Leave the old PVC in place until you have watched the new cluster for a while.
+It is the only rollback that does not depend on the dump file surviving.
+
+## Other things pointed at the database
+
+The chart only knows about its own Deployment. Anything else in the namespace
+holding a DSN has to move too, and will fail quietly rather than loudly:
+
+- **sql-exporter** — repoint at `<release>-postgresql-rw`. Metrics stop being
+  collected otherwise, which looks like "no data" on a dashboard rather than an
+  error.
+
+## Backups
+
+Off by default, because it cannot work without credentials and a backup that is
+silently not running is worse than one you know you have not configured. This is
+the main reason to be on CNPG at all, so configure it:
+
+```yaml
+postgresql:
+  backup:
+    enabled: true
+    destinationPath: s3://my-bucket/schautrack
+    endpointURL: https://minio.example.com   # omit for AWS
+    s3Credentials:
+      secretName: schautrack-backup-s3
+    retentionPolicy: "30d"
+    schedule: "0 0 3 * * *"    # SIX fields, seconds first — CNPG's cron, not Kubernetes'
+```
+
+Verify a backup completed before believing in it:
+
+```bash
+kubectl -n "$NS" get backup
+```
+
+## Importing from a PostgreSQL you keep running
+
+`postgresql.bootstrap.importFrom` makes CNPG run `pg_dump | pg_restore` against
+an external server as it bootstraps. This is the right tool when the source is a
+database you control and can keep running — it is **not** the path off the old
+bundled Deployment, because the same Helm upgrade that creates the Cluster
+deletes the source before the bootstrap can reach it.
+
+It is read **only** at bootstrap. On an already-initialised Cluster it does
+nothing, so leaving it enabled will not re-import or overwrite live data. Set it
+back to `false` afterwards anyway, so a future Cluster rebuild does not point at
+a server that no longer exists.
+
+## Rollback
+
+Before cutover: scale the app back up. Nothing has changed.
+
+After cutover, before you delete the old PVC: set `postgresql.mode: bundled`
+again with `postgresql.persistence.existingClaim` pointing at the retained PVC.
+The bundled engine is still in the chart, so this is a values change rather than
+a chart downgrade. The data is exactly as it was when the app was scaled down,
+because nothing ever wrote to it again.
+
+After you delete the old PVC: your only copy is the dump, and a CNPG backup if
+you configured one. Do not delete the PVC on migration day.

--- a/helm/schautrack/Chart.yaml
+++ b/helm/schautrack/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: schautrack
-description: A simple nutrition tracking web application
+description: A simple nutrition tracking web application, with PostgreSQL provisioned by CloudNativePG
 type: application
-version: 0.5.0
+version: 2.7.0
 appVersion: "0.1.9"
 keywords:
   - nutrition

--- a/helm/schautrack/README.md
+++ b/helm/schautrack/README.md
@@ -10,7 +10,7 @@ This chart deploys [Schautrack](https://github.com/schaurian/schautrack) on a Ku
 
 - Kubernetes 1.22+
 - Helm 3.x
-- PV provisioner support (if using bundled PostgreSQL)
+- PV provisioner support (for `mode: bundled`), or the CloudNativePG operator >= 1.24 (for `mode: cnpg`)
 
 ## Installing
 
@@ -43,8 +43,15 @@ config:
   adminEmail: "admin@example.com"
 
 postgresql:
+  # mode: bundled (the default) — a single Postgres Pod with a PVC
   auth:
     password: ""  # Use sealed-secrets or external-secrets
+
+  # ...or CloudNativePG, for backups, PITR and failover:
+  # mode: cnpg
+  # instances: 3
+  # storage:
+  #   size: 10Gi
 
 ingress:
   enabled: true
@@ -88,7 +95,7 @@ existingSecret: "my-schautrack-secrets"
 
 # These values are ignored when existingSecret is set:
 # smtp.user, smtp.pass, ai.key, ai.keyEncryptionSecret,
-# oidc.clientSecret, postgresql.auth.password, externalDatabase.url
+# oidc.clientSecret, externalDatabase.url
 ```
 
 The referenced Secret must contain these keys:
@@ -96,7 +103,7 @@ The referenced Secret must contain these keys:
 | Key | Required | Description |
 |-----|----------|-------------|
 | `DATABASE_URL` | Yes | PostgreSQL connection string |
-| `POSTGRES_PASSWORD` | If postgresql.enabled | Password for bundled PostgreSQL |
+| `POSTGRES_PASSWORD` | If `mode: bundled` | Password for the bundled PostgreSQL (under `cnpg` the operator owns it) |
 | `SMTP_USER` | No | SMTP username |
 | `SMTP_PASS` | No | SMTP password |
 | `AI_KEY` | No | API key for AI provider |
@@ -126,7 +133,7 @@ spec:
 
 ### Using an external database
 
-Disable the bundled PostgreSQL and provide a connection string:
+Disable the in-chart CloudNativePG cluster and provide a connection string:
 
 ```yaml
 postgresql:
@@ -373,46 +380,83 @@ application's default in force. See
 | `passkeys.rpName` | Display name shown in browser/OS passkey prompts | `""` (`Schautrack`) |
 | `passkeys.rpOrigins` | Allowed origins, comma-separated full URLs with scheme | `""` (`https://<rpId>`) |
 
-### PostgreSQL (bundled)
+### PostgreSQL
+
+Two engines, both supported. `postgresql.mode` picks one:
+
+- **`bundled`** (default) — a single PostgreSQL Pod with a PVC. No operator, no
+  extra moving parts. No failover or point-in-time recovery.
+- **`cnpg`** — a [CloudNativePG](https://cloudnative-pg.io/) `Cluster`:
+  continuous backup to object storage, PITR, replicas with automatic failover,
+  managed minor-version upgrades. Requires the CloudNativePG operator (>= 1.24)
+  already installed cluster-wide; the chart does not install it, because the
+  operator is shared and owning it from an application chart would mean two
+  releases fighting over one set of CRDs.
+
+Upgrading the chart does not change your engine — `bundled` stays the default so
+an upgrade cannot move a running release off its data. Switching an existing
+install is a data migration, not a values change: see
+[docs/cloudnativepg.md](../../docs/cloudnativepg.md).
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `postgresql.enabled` | Deploy bundled PostgreSQL | `true` |
+| `postgresql.enabled` | Provision an in-chart database (`false` = use `externalDatabase.url`) | `true` |
+| `postgresql.mode` | `bundled` or `cnpg` | `bundled` |
+
+#### mode: bundled
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
 | `postgresql.image.repository` | PostgreSQL image | `postgres` |
 | `postgresql.image.tag` | PostgreSQL version | `18-alpine` |
-| `postgresql.auth.database` | Database name | `schautrack` |
-| `postgresql.auth.username` | Database user | `schautrack` |
 | `postgresql.auth.password` | Database password (**required**) | `""` |
-| `postgresql.livenessProbe` | Liveness probe for the postgres container. See note below. | `exec: pg_isready -U schautrack -d schautrack`, `initialDelaySeconds: 30`, `periodSeconds: 10` |
-| `postgresql.readinessProbe` | Readiness probe for the postgres container. See note below. | `exec: pg_isready -U schautrack -d schautrack`, `initialDelaySeconds: 5`, `periodSeconds: 5` |
 | `postgresql.persistence.enabled` | Enable persistence | `true` |
-| `postgresql.persistence.existingClaim` | Use existing PVC (ignores other persistence options if set) | `""` |
+| `postgresql.persistence.existingClaim` | Use an existing PVC (ignores the other persistence options) | `""` |
 | `postgresql.persistence.size` | PVC size | `5Gi` |
-| `postgresql.persistence.storageClass` | Storage class | `""` |
+| `postgresql.persistence.storageClass` | Storage class | `"-"` |
 | `postgresql.persistence.accessMode` | PVC access mode | `ReadWriteOnce` |
-| `postgresql.persistence.annotations` | PVC annotations (e.g., for Velero backups) | `{}` |
-| `postgresql.persistence.labels` | PVC labels | `{}` |
-| `postgresql.resources` | Resource requests/limits | `{}` |
+| `postgresql.livenessProbe` / `.readinessProbe` | Probes for the postgres container. The defaults are literal strings naming the *default* database/user, so override them if you change `auth.database` or `auth.username` | `pg_isready -U schautrack -d schautrack` |
 
-> **Note:** the default probe commands above are literal strings baked in at
-> chart-author time — they check the *default* `schautrack`/`schautrack`
-> database/user, not whatever you set `postgresql.auth.database` /
-> `postgresql.auth.username` to. If you change either of those, override
-> `postgresql.livenessProbe`/`postgresql.readinessProbe` to match, the same
-> way you would set `httpGet`/`tcpSocket`/`exec` on the app probes above.
->
-> The default handler here is `exec`, not `httpGet` — so switching this
-> probe follows the same [null-out rule](#probes) but with a different key.
-> For example, to use a TCP check instead:
-> ```yaml
-> postgresql:
->   livenessProbe:
->     exec: null   # required — clears the default handler
->     tcpSocket:
->       port: postgresql
->     initialDelaySeconds: 30
->     periodSeconds: 10
-> ```
+#### mode: cnpg
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `postgresql.instances` | Instances. 1 = no standby; use 3 for real HA | `1` |
+| `postgresql.imageName` | Override the operator's default PostgreSQL image | `""` |
+| `postgresql.auth.database` | Database name (both modes) | `schautrack` |
+| `postgresql.auth.username` | Database user / owner (both modes) | `schautrack` |
+| `postgresql.auth.existingSecret` | `kubernetes.io/basic-auth` Secret to use instead of the operator-generated one. Must also carry a `uri` key | `""` |
+| `postgresql.storage.size` | Data volume size | `10Gi` |
+| `postgresql.storage.storageClass` | Storage class (empty = cluster default) | `""` |
+| `postgresql.walStorage.enabled` | Put the WAL on its own volume | `false` |
+| `postgresql.walStorage.size` | WAL volume size | `2Gi` |
+| `postgresql.maxConnections` | `max_connections`. See note below | `100` |
+| `postgresql.parameters` | Extra `postgresql.conf` parameters | `{}` |
+| `postgresql.resources` | Resource requests/limits | `{}` |
+| `postgresql.affinity` | Pod affinity rules | `{}` |
+| `postgresql.backup.enabled` | Continuous backup + PITR to S3 | `false` |
+| `postgresql.backup.destinationPath` | e.g. `s3://bucket/schautrack` | `""` |
+| `postgresql.backup.endpointURL` | Set for non-AWS S3 (MinIO, R2) | `""` |
+| `postgresql.backup.s3Credentials.secretName` | Secret with the S3 keys | `""` |
+| `postgresql.backup.retentionPolicy` | Retention window | `30d` |
+| `postgresql.backup.schedule` | **Six**-field cron, seconds first. Empty disables it | `0 0 3 * * *` |
+| `postgresql.bootstrap.importFrom.enabled` | One-shot `pg_dump`/`pg_restore` import at bootstrap from a PostgreSQL you keep running. Not the path off the old bundled DB | `false` |
+
+Under `cnpg`, `postgresql.auth.password` is ignored: CloudNativePG generates and
+owns the credential, and the app reads `DATABASE_URL` straight from the Secret
+the operator manages. That is also why a password rotation does not need a chart
+upgrade to take effect.
+
+> **Note on `maxConnections`:** the default is derived, not chosen. The app pins
+> its pgxpool to `MaxConns = 20` per replica and holds one *more* connection
+> outside the pool for the SSE `LISTEN`, which occupies its connection for the
+> lifetime of the process. The floor is therefore `replicas × 21` plus
+> CloudNativePG's own superuser and replication slots.
+
+> **Note on Services:** CloudNativePG publishes `-rw`, `-ro` and `-r`. Everything
+> here uses `-rw`. `NOTIFY` does not replicate, so a DSN on a read Service leaves
+> the SSE broker listening to a channel that never fires — reads work, health
+> checks pass, and cross-instance updates die silently.
 
 ### External Database
 

--- a/helm/schautrack/templates/_helpers.tpl
+++ b/helm/schautrack/templates/_helpers.tpl
@@ -77,13 +77,110 @@ app.kubernetes.io/component: database
 {{- end }}
 
 {{/*
-Database URL
+The CNPG read-write Service — the cluster's current primary.
+
+Everything this chart points at the database uses this and only this. CNPG also
+publishes -ro (hot standbys) and -r (any instance), and both are wrong here:
+NOTIFY does not replicate, so a LISTEN on a standby never fires and the SSE
+broker sits on a silent channel forever.
+*/}}
+{{- define "schautrack.postgresql.rwService" -}}
+{{- printf "%s-rw" (include "schautrack.postgresql.fullname" .) }}
+{{- end }}
+
+{{/*
+Name of the Secret CNPG generates for the application user, and the key in it
+holding a ready-made connection URI.
+
+CNPG owns this credential: it is generated at bootstrap and can be rotated by
+the operator, so the chart never templates the password and never stores it in
+values.yaml. Deployments read DATABASE_URL straight out of this Secret.
+*/}}
+{{- define "schautrack.postgresql.appSecretName" -}}
+{{- if .Values.postgresql.auth.existingSecret }}
+{{- .Values.postgresql.auth.existingSecret }}
+{{- else }}
+{{- printf "%s-app" (include "schautrack.postgresql.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Database URL for everything except CNPG mode.
+
+In CNPG mode there is deliberately no value to render: the URI lives in the
+operator-managed Secret and is injected by secretKeyRef, so a password rotation
+takes effect without a chart upgrade. The bundled path keeps templating its own
+URL exactly as it always has, because changing that would change the Secret
+under a running release for no benefit.
 */}}
 {{- define "schautrack.databaseUrl" -}}
-{{- if .Values.postgresql.enabled }}
+{{- if include "schautrack.postgresql.isBundled" . }}
 {{- printf "postgres://%s:%s@%s:5432/%s" (.Values.postgresql.auth.username | urlquery) (.Values.postgresql.auth.password | urlquery) (include "schautrack.postgresql.fullname" .) .Values.postgresql.auth.database }}
 {{- else }}
 {{- .Values.externalDatabase.url }}
+{{- end }}
+{{- end }}
+
+{{/*
+The Service the app connects to, whichever engine is running.
+
+CNPG publishes no Service at the Cluster's own name, so the two differ and the
+difference is easy to miss — the bundled Service *is* the plain fullname.
+*/}}
+{{- define "schautrack.postgresql.serviceName" -}}
+{{- if include "schautrack.postgresql.isCNPG" . }}
+{{- include "schautrack.postgresql.rwService" . }}
+{{- else }}
+{{- include "schautrack.postgresql.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Which in-chart database engine this release runs: "cnpg" or "bundled".
+
+Helm cannot tell a fresh install from an upgrade. A default that resolved to
+`cnpg` would therefore move every existing release off the Deployment it has
+been running, leaving its data in a PVC nothing mounts any more — the database
+would look erased, on an upgrade nobody was warned about.
+
+An earlier draft of this tried to infer the answer from the values file, on the
+theory that legacy-only keys prove a pre-3.x release. That was too clever: a
+release using a top-level `existingSecret` sets no `postgresql.auth.password`
+and none of the Deployment-only keys, so it would have been read as new and
+silently migrated. One missed case is one destroyed database, so inference is
+the wrong tool.
+
+The default is therefore `bundled` — the boring answer that changes nothing for
+anyone — and CloudNativePG is opted into explicitly. Every example in the docs
+sets it, so new installs following the documentation get CNPG; a bare
+`helm install` with no values keeps the deprecated engine and says so in NOTES.
+The default flips in a future major, once CNPG is the well-trodden path.
+*/}}
+{{- define "schautrack.postgresql.mode" -}}
+{{- $mode := .Values.postgresql.mode | default "bundled" }}
+{{- if not (has $mode (list "cnpg" "bundled")) }}
+{{- fail (printf "postgresql.mode must be \"cnpg\" or \"bundled\", got %q" $mode) }}
+{{- end }}
+{{- $mode }}
+{{- end }}
+
+{{/*
+True when this release runs the CloudNativePG Cluster.
+*/}}
+{{- define "schautrack.postgresql.isCNPG" -}}
+{{- and .Values.postgresql.enabled (eq (include "schautrack.postgresql.mode" .) "cnpg") | ternary "true" "" }}
+{{- end }}
+
+{{/*
+True when this release runs the deprecated bundled Deployment.
+*/}}
+{{- define "schautrack.postgresql.isBundled" -}}
+{{- and .Values.postgresql.enabled (eq (include "schautrack.postgresql.mode" .) "bundled") | ternary "true" "" }}
+{{- end }}
+
+{{- define "schautrack.postgresql.validate" -}}
+{{- if lt (int (.Values.postgresql.instances | default 1)) 1 }}
+{{- fail "postgresql.instances must be at least 1" }}
 {{- end }}
 {{- end }}
 

--- a/helm/schautrack/templates/_helpers.tpl
+++ b/helm/schautrack/templates/_helpers.tpl
@@ -182,6 +182,29 @@ True when this release runs the deprecated bundled Deployment.
 {{- if lt (int (.Values.postgresql.instances | default 1)) 1 }}
 {{- fail "postgresql.instances must be at least 1" }}
 {{- end }}
+{{- /*
+  Refuse to switch to cnpg while the bundled PVC still exists.
+
+  Flipping postgresql.mode is a one-word values edit and every example shows it,
+  but on its own it is destructive: the PVC leaves the manifest set and Helm
+  deletes it in the same pass that creates an empty Cluster. The database is
+  gone before anything could have copied it out. Documenting that in
+  docs/cloudnativepg.md is not a guard — it only reaches people who read it
+  first, and the person most likely to skip it is the one uncommenting
+  `mode: cnpg` from the README.
+
+  `lookup` returns empty during `helm template`, `--dry-run` and any
+  disconnected render, so this fires only on a real upgrade against a live
+  cluster and does not disturb CI or the byte-identical bundled render.
+
+  scripts/migrate-to-cnpg.sh sets the acknowledgement after it has dumped,
+  verified the dump is restorable, and annotated the PVC to survive.
+*/}}
+{{- if and (include "schautrack.postgresql.isCNPG" .)
+           (not .Values.postgresql.acknowledgeDataMigration)
+           (lookup "v1" "PersistentVolumeClaim" .Release.Namespace (include "schautrack.postgresql.fullname" .)) }}
+{{- fail (printf "\n\npostgresql.mode is \"cnpg\", but the bundled PostgreSQL PVC %q still exists in namespace %q.\n\nThis upgrade would DELETE it, along with your database, and start an empty\nCloudNativePG cluster in its place.\n\nMigrate the data first:\n  scripts/migrate-to-cnpg.sh -n %s -r %s\n\nOr, if the data is already elsewhere and the PVC is genuinely disposable, set\npostgresql.acknowledgeDataMigration=true to proceed.\n\nSee docs/cloudnativepg.md.\n" (include "schautrack.postgresql.fullname" .) .Release.Namespace .Release.Namespace .Release.Name) }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/schautrack/templates/cnpg-cluster.yaml
+++ b/helm/schautrack/templates/cnpg-cluster.yaml
@@ -1,0 +1,137 @@
+{{- if include "schautrack.postgresql.isCNPG" . }}
+{{- include "schautrack.postgresql.validate" . }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "schautrack.postgresql.fullname" . }}
+  labels:
+    {{- include "schautrack.postgresql.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.postgresql.instances }}
+  {{- with .Values.postgresql.imageName }}
+  imageName: {{ . | quote }}
+  {{- end }}
+
+  # The app is the only writer, and it reconnects on its own (the pgx pool
+  # retries, and sse.Listen re-LISTENs with backoff), so an unclean promotion
+  # costs a reconnect rather than data. `unsupervised` lets the operator
+  # complete a switchover without a human in the loop.
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+
+  bootstrap:
+    {{- if .Values.postgresql.bootstrap.importFrom.enabled }}
+    # Migration path off a bundled-mode Deployment: CNPG runs pg_dump |
+    # pg_restore against the old server once, at bootstrap, and never again.
+    # See docs/cloudnativepg.md — this is a one-shot flag, not a steady state.
+    initdb:
+      database: {{ .Values.postgresql.auth.database | quote }}
+      owner: {{ .Values.postgresql.auth.username | quote }}
+      {{- with .Values.postgresql.auth.existingSecret }}
+      secret:
+        name: {{ . | quote }}
+      {{- end }}
+      import:
+        type: microservice
+        databases:
+          - {{ .Values.postgresql.bootstrap.importFrom.database | default .Values.postgresql.auth.database | quote }}
+        source:
+          externalCluster: schautrack-legacy
+    {{- else }}
+    initdb:
+      database: {{ .Values.postgresql.auth.database | quote }}
+      owner: {{ .Values.postgresql.auth.username | quote }}
+      {{- with .Values.postgresql.auth.existingSecret }}
+      secret:
+        name: {{ . | quote }}
+      {{- end }}
+    {{- end }}
+
+  {{- if .Values.postgresql.bootstrap.importFrom.enabled }}
+  externalClusters:
+    - name: schautrack-legacy
+      connectionParameters:
+        host: {{ required "postgresql.bootstrap.importFrom.host is required when importFrom.enabled" .Values.postgresql.bootstrap.importFrom.host | quote }}
+        port: {{ .Values.postgresql.bootstrap.importFrom.port | quote }}
+        user: {{ .Values.postgresql.bootstrap.importFrom.username | default .Values.postgresql.auth.username | quote }}
+        dbname: {{ .Values.postgresql.bootstrap.importFrom.database | default .Values.postgresql.auth.database | quote }}
+        sslmode: {{ .Values.postgresql.bootstrap.importFrom.sslmode | quote }}
+      password:
+        name: {{ required "postgresql.bootstrap.importFrom.passwordSecret.name is required when importFrom.enabled" .Values.postgresql.bootstrap.importFrom.passwordSecret.name | quote }}
+        key: {{ .Values.postgresql.bootstrap.importFrom.passwordSecret.key | quote }}
+  {{- end }}
+
+  storage:
+    size: {{ .Values.postgresql.storage.size | quote }}
+    {{- with .Values.postgresql.storage.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
+
+  {{- with .Values.postgresql.walStorage }}
+  {{- if .enabled }}
+  walStorage:
+    size: {{ .size | quote }}
+    {{- with .storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+
+  {{- with .Values.postgresql.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  postgresql:
+    parameters:
+      {{- /*
+        max_connections has to clear the app's own ceiling: internal/database
+        pins pgxpool MaxConns=20 per replica, and sse.Listen holds ONE more
+        connection outside the pool for the whole process lifetime (a LISTEN
+        occupies its connection permanently). So the floor is
+        replicas * 21 + CNPG's own superuser/streaming slots.
+      */}}
+      max_connections: {{ .Values.postgresql.maxConnections | quote }}
+      {{- with .Values.postgresql.parameters }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+
+  {{- with .Values.postgresql.affinity }}
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- if .Values.postgresql.backup.enabled }}
+  backup:
+    retentionPolicy: {{ .Values.postgresql.backup.retentionPolicy | quote }}
+    barmanObjectStore:
+      destinationPath: {{ required "postgresql.backup.destinationPath is required when backup.enabled" .Values.postgresql.backup.destinationPath | quote }}
+      {{- with .Values.postgresql.backup.endpointURL }}
+      endpointURL: {{ . | quote }}
+      {{- end }}
+      s3Credentials:
+        accessKeyId:
+          name: {{ required "postgresql.backup.s3Credentials.secretName is required when backup.enabled" .Values.postgresql.backup.s3Credentials.secretName | quote }}
+          key: {{ .Values.postgresql.backup.s3Credentials.accessKeyIdKey | quote }}
+        secretAccessKey:
+          name: {{ .Values.postgresql.backup.s3Credentials.secretName | quote }}
+          key: {{ .Values.postgresql.backup.s3Credentials.secretAccessKeyKey | quote }}
+      wal:
+        compression: {{ .Values.postgresql.backup.walCompression | quote }}
+  {{- end }}
+{{- if and .Values.postgresql.backup.enabled .Values.postgresql.backup.schedule }}
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: {{ include "schautrack.postgresql.fullname" . }}
+  labels:
+    {{- include "schautrack.postgresql.labels" . | nindent 4 }}
+spec:
+  # CNPG cron is a 6-field spec (seconds first), not the 5-field Kubernetes one.
+  schedule: {{ .Values.postgresql.backup.schedule | quote }}
+  backupOwnerReference: self
+  cluster:
+    name: {{ include "schautrack.postgresql.fullname" . }}
+{{- end }}
+{{- end }}

--- a/helm/schautrack/templates/cnpg-cluster.yaml
+++ b/helm/schautrack/templates/cnpg-cluster.yaml
@@ -61,6 +61,31 @@ spec:
         key: {{ .Values.postgresql.bootstrap.importFrom.passwordSecret.key | quote }}
   {{- end }}
 
+  {{- if or .Values.postgresql.podAnnotations .Values.postgresql.podLabels }}
+  # Propagated onto the Cluster's Pods, which the operator owns and recreates —
+  # annotating them directly would not survive a failover or a minor-version
+  # upgrade.
+  #
+  # postgresql.podAnnotations is deliberately the same key the bundled engine
+  # uses, so a values file carrying k8up's backupcommand keeps working across
+  # the engine switch instead of silently losing its backup.
+  #
+  # BUT THE COMMAND ITSELF USUALLY HAS TO CHANGE. In a CNPG pod the OS user is
+  # `postgres`, so a backupcommand of `pg_dump -U <app user>` fails peer
+  # authentication over the local socket — the dump errors, and depending on the
+  # backup tool that can still look like a successful run. Use
+  # `pg_dump -U postgres -d <database>`.
+  inheritedMetadata:
+    {{- with .Values.postgresql.podAnnotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.postgresql.podLabels }}
+    labels:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
   storage:
     size: {{ .Values.postgresql.storage.size | quote }}
     {{- with .Values.postgresql.storage.storageClass }}

--- a/helm/schautrack/templates/deployment.yaml
+++ b/helm/schautrack/templates/deployment.yaml
@@ -39,7 +39,12 @@ spec:
           image: busybox:1.36
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          command: ['sh', '-c', 'until nc -z {{ include "schautrack.postgresql.fullname" . }} 5432; do echo waiting for postgres; sleep 2; done']
+          {{- /* The Service name differs by engine, hence the helper: CNPG
+                 publishes nothing at the Cluster's own name, so waiting on
+                 that would hang forever, while the bundled Service *is* the
+                 plain name. Kept as a template comment so the rendered
+                 Deployment stays byte-identical to bundled-mode output. */}}
+          command: ['sh', '-c', 'until nc -z {{ include "schautrack.postgresql.serviceName" . }} 5432; do echo waiting for postgres; sleep 2; done']
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -56,6 +61,27 @@ spec:
                 name: {{ .Values.existingSecret | default (include "schautrack.fullname" .) }}
             - configMapRef:
                 name: {{ include "schautrack.fullname" . }}
+          {{- if include "schautrack.postgresql.isCNPG" . }}
+          env:
+            # Straight from the Secret CloudNativePG generates for the app user.
+            #
+            # `env` wins over `envFrom` on a name collision, which is what lets
+            # this override the DATABASE_URL the chart Secret carries in
+            # external-database mode without the two having to know about
+            # each other.
+            #
+            # The `uri` key resolves to the cluster's -rw Service, and that is
+            # load-bearing rather than incidental: NOTIFY does not replicate, so
+            # a DSN pointing at -ro or -r would leave sse.Listen waiting on a
+            # channel that never fires. Cross-instance SSE would go quiet with
+            # no error anywhere — linked-user views would simply stop updating.
+            # Never substitute a read Service here.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "schautrack.postgresql.appSecretName" . }}
+                  key: uri
+          {{- end }}
           livenessProbe:
             {{- include "schautrack.renderProbe" (dict "block" .Values.livenessProbe "indent" 12 "name" "livenessProbe") }}
           readinessProbe:

--- a/helm/schautrack/templates/k8up-prebackuppod.yaml
+++ b/helm/schautrack/templates/k8up-prebackuppod.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.backup.k8up.enabled }}
+{{- if not .Values.postgresql.enabled }}
+{{- fail "backup.k8up.enabled requires postgresql.enabled: the PreBackupPod dumps the in-chart database. For an external database, back it up wherever it lives." }}
+{{- end }}
+apiVersion: k8up.io/v1
+kind: PreBackupPod
+metadata:
+  name: {{ include "schautrack.fullname" . }}-db-dump
+  labels:
+    {{- include "schautrack.labels" . | nindent 4 }}
+spec:
+  # k8up execs this in the pod below and streams stdout straight into restic.
+  # Nothing is written to a volume, so the dump needs no scratch space and
+  # cannot half-land on disk.
+  #
+  # A LOGICAL dump, deliberately, and not a backup of the PostgreSQL PVC.
+  # Copying a live PostgreSQL data directory with a file-level tool yields a
+  # torn snapshot that may not restore at all — which is exactly why that PVC
+  # carries k8up.io/backup: "false". Excluding it was correct; the mistake was
+  # never adding this alongside, leaving a schedule that reported success while
+  # storing nothing.
+  #
+  # --clean --if-exists so the dump restores over an existing schema (the app
+  # creates its own on first boot), and a plain SQL stream rather than -Fc
+  # because restic stores one object and a plain dump can be restored by psql
+  # anywhere, without matching pg_restore versions.
+  backupCommand: /bin/sh -c 'pg_dump --clean --if-exists --no-owner --no-acl -d "$DATABASE_URL"'
+  fileExtension: .sql
+  pod:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        runAsGroup: 70
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pg-dump
+          # Client-only use, but the image must be at least the server's major
+          # or pg_dump refuses ("server version mismatch"). Track the server.
+          image: {{ .Values.backup.k8up.image | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 70
+            capabilities:
+              drop:
+                - ALL
+          env:
+            # The same DSN the app uses, from the same source, so the two cannot
+            # drift: under CloudNativePG that is the operator-managed Secret
+            # (whose `uri` targets the -rw Service and follows a failover), and
+            # under the bundled engine it is the chart's own Secret.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  {{- if include "schautrack.postgresql.isCNPG" . }}
+                  name: {{ include "schautrack.postgresql.appSecretName" . }}
+                  key: uri
+                  {{- else }}
+                  name: {{ .Values.existingSecret | default (include "schautrack.fullname" .) }}
+                  key: DATABASE_URL
+                  {{- end }}
+          # k8up starts this pod before the backup and stops it after; it only
+          # has to stay alive long enough to be exec'd into.
+          command: ["sleep"]
+          args: ["infinity"]
+          resources:
+            {{- toYaml .Values.backup.k8up.resources | nindent 12 }}
+{{- end }}

--- a/helm/schautrack/templates/postgresql-deployment.yaml
+++ b/helm/schautrack/templates/postgresql-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.postgresql.enabled }}
+{{- if include "schautrack.postgresql.isBundled" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/schautrack/templates/postgresql-pvc.yaml
+++ b/helm/schautrack/templates/postgresql-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.postgresql.enabled .Values.postgresql.persistence.enabled (not .Values.postgresql.persistence.existingClaim) }}
+{{- if and (include "schautrack.postgresql.isBundled" .) .Values.postgresql.persistence.enabled (not .Values.postgresql.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/schautrack/templates/postgresql-service.yaml
+++ b/helm/schautrack/templates/postgresql-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.postgresql.enabled }}
+{{- if include "schautrack.postgresql.isBundled" . }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/schautrack/templates/secret.yaml
+++ b/helm/schautrack/templates/secret.yaml
@@ -7,8 +7,10 @@ metadata:
     {{- include "schautrack.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if not (include "schautrack.postgresql.isCNPG" .) }}
   DATABASE_URL: {{ include "schautrack.databaseUrl" . | quote }}
-  {{- if .Values.postgresql.enabled }}
+  {{- end }}
+  {{- if include "schautrack.postgresql.isBundled" . }}
   POSTGRES_PASSWORD: {{ .Values.postgresql.auth.password | quote }}
   {{- end }}
   {{- if .Values.smtp.user }}

--- a/helm/schautrack/values.schema.json
+++ b/helm/schautrack/values.schema.json
@@ -718,11 +718,15 @@
         },
         "podAnnotations": {
           "type": "object",
-          "description": "mode: bundled only."
+          "description": "Pod annotations. Both modes: on the Deployment pod template under bundled, propagated via CNPG inheritedMetadata under cnpg. A k8up backupcommand here must use -U postgres under cnpg (peer auth)."
         },
         "acknowledgeDataMigration": {
           "type": "boolean",
           "description": "Confirms that switching to cnpg does not move data. The chart refuses to render mode: cnpg while the bundled PVC exists unless this is set."
+        },
+        "podLabels": {
+          "type": "object",
+          "description": "Pod labels. cnpg mode only, via inheritedMetadata."
         }
       }
     },

--- a/helm/schautrack/values.schema.json
+++ b/helm/schautrack/values.schema.json
@@ -191,7 +191,7 @@
           "type": "boolean"
         },
         "sessionSecret": {
-          "description": "REMOVED — accepted and ignored. The app never read SESSION_SECRET: sessions are server-side, keyed by a 32-byte crypto/rand session ID looked up in Postgres, so there is nothing to sign or encrypt. This key is retained ONLY so that existing values files keep validating: `config` sets additionalProperties=false, so deleting it here would fail `helm upgrade` for everyone who set it. Safe to drop from your values. Remove this entry in a future major.",
+          "description": "REMOVED \u2014 accepted and ignored. The app never read SESSION_SECRET: sessions are server-side, keyed by a 32-byte crypto/rand session ID looked up in Postgres, so there is nothing to sign or encrypt. This key is retained ONLY so that existing values files keep validating: `config` sets additionalProperties=false, so deleting it here would fail `helm upgrade` for everyone who set it. Safe to drop from your values. Remove this entry in a future major.",
           "type": [
             "string",
             "integer",
@@ -469,70 +469,62 @@
       "type": "object"
     },
     "postgresql": {
+      "type": "object",
+      "description": "In-chart PostgreSQL. postgresql.mode selects the engine: \"cnpg\" (CloudNativePG Cluster; the supported and documented option) or \"bundled\" (the deprecated single-Pod Deployment, kept working for existing installs). Keys for the non-selected mode are ignored, so both sets are permitted here.",
       "properties": {
-        "auth": {
-          "properties": {
-            "database": {
-              "type": "string"
-            },
-            "password": {
-              "type": [
-                "string",
-                "integer",
-                "boolean",
-                "null"
-              ]
-            },
-            "username": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
         "enabled": {
           "type": "boolean"
         },
-        "image": {
+        "instances": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1 = single instance, no standby. Use 3 for real HA."
+        },
+        "imageName": {
+          "type": "string",
+          "description": "Empty takes the operator's default PostgreSQL image."
+        },
+        "auth": {
+          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "pullPolicy": {
-              "type": "string"
+            "database": {
+              "type": "string",
+              "minLength": 1
             },
-            "repository": {
-              "type": "string"
+            "username": {
+              "type": "string",
+              "minLength": 1
             },
-            "tag": {
+            "existingSecret": {
+              "type": "string",
+              "description": "kubernetes.io/basic-auth Secret to use instead of the operator-generated one. Must also carry a uri key."
+            },
+            "password": {
+              "type": "string",
+              "description": "mode: bundled only. Ignored under CloudNativePG, which generates and owns the credential."
+            }
+          }
+        },
+        "storage": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "size": {
+              "type": "string",
+              "minLength": 1
+            },
+            "storageClass": {
               "type": "string"
             }
-          },
-          "type": "object"
+          }
         },
-        "livenessProbe": {
-          "properties": {},
-          "type": "object"
-        },
-        "persistence": {
+        "walStorage": {
+          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "accessMode": {
-              "type": "string"
-            },
-            "annotations": {
-              "properties": {},
-              "type": "object"
-            },
             "enabled": {
               "type": "boolean"
-            },
-            "existingClaim": {
-              "type": [
-                "string",
-                "integer",
-                "boolean",
-                "null"
-              ]
-            },
-            "labels": {
-              "properties": {},
-              "type": "object"
             },
             "size": {
               "type": "string"
@@ -540,66 +532,190 @@
             "storageClass": {
               "type": "string"
             }
-          },
-          "type": "object"
+          }
         },
-        "podSecurityContext": {
-          "properties": {
-            "fsGroup": {
-              "type": "integer"
-            },
-            "runAsGroup": {
-              "type": "integer"
-            },
-            "runAsNonRoot": {
-              "type": "boolean"
-            },
-            "runAsUser": {
-              "type": "integer"
-            },
-            "seccompProfile": {
-              "properties": {
-                "type": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            }
-          },
-          "type": "object"
+        "maxConnections": {
+          "type": "integer",
+          "minimum": 25,
+          "description": "Floor is replicas*(pgxpool MaxConns 20 + 1 permanent SSE LISTEN) plus CNPG's own slots."
         },
-        "readinessProbe": {
-          "properties": {},
+        "parameters": {
           "type": "object"
         },
         "resources": {
-          "properties": {},
           "type": "object"
         },
-        "securityContext": {
+        "affinity": {
+          "type": "object"
+        },
+        "backup": {
+          "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "allowPrivilegeEscalation": {
+            "enabled": {
               "type": "boolean"
             },
-            "capabilities": {
+            "destinationPath": {
+              "type": "string"
+            },
+            "endpointURL": {
+              "type": "string"
+            },
+            "s3Credentials": {
+              "type": "object",
+              "additionalProperties": false,
               "properties": {
-                "drop": {
-                  "type": "array"
+                "secretName": {
+                  "type": "string"
+                },
+                "accessKeyIdKey": {
+                  "type": "string"
+                },
+                "secretAccessKeyKey": {
+                  "type": "string"
                 }
-              },
+              }
+            },
+            "retentionPolicy": {
+              "type": "string"
+            },
+            "walCompression": {
+              "type": "string",
+              "enum": [
+                "gzip",
+                "bzip2",
+                "snappy"
+              ]
+            },
+            "schedule": {
+              "type": "string",
+              "description": "CNPG cron: SIX fields, seconds first. Empty disables the ScheduledBackup."
+            }
+          }
+        },
+        "bootstrap": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "importFrom": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                },
+                "database": {
+                  "type": "string"
+                },
+                "sslmode": {
+                  "type": "string",
+                  "enum": [
+                    "disable",
+                    "allow",
+                    "prefer",
+                    "require",
+                    "verify-ca",
+                    "verify-full"
+                  ]
+                },
+                "passwordSecret": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "key": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "cnpg",
+            "bundled"
+          ],
+          "description": "Engine selector. Defaults to \"bundled\" so an upgrade never moves an existing release off its data."
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "mode: bundled only.",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            }
+          }
+        },
+        "persistence": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "mode: bundled only. CloudNativePG uses postgresql.storage.",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "existingClaim": {
+              "type": "string"
+            },
+            "size": {
+              "type": "string"
+            },
+            "storageClass": {
+              "type": "string"
+            },
+            "accessMode": {
+              "type": "string"
+            },
+            "annotations": {
               "type": "object"
             },
-            "runAsNonRoot": {
-              "type": "boolean"
-            },
-            "runAsUser": {
-              "type": "integer"
+            "labels": {
+              "type": "object"
             }
-          },
-          "type": "object"
+          }
+        },
+        "podSecurityContext": {
+          "type": "object",
+          "description": "mode: bundled only."
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "mode: bundled only."
+        },
+        "livenessProbe": {
+          "type": "object",
+          "description": "mode: bundled only."
+        },
+        "readinessProbe": {
+          "type": "object",
+          "description": "mode: bundled only."
+        },
+        "podAnnotations": {
+          "type": "object",
+          "description": "mode: bundled only."
         }
-      },
-      "type": "object"
+      }
     },
     "readinessProbe": {
       "properties": {},

--- a/helm/schautrack/values.schema.json
+++ b/helm/schautrack/values.schema.json
@@ -501,8 +501,13 @@
               "description": "kubernetes.io/basic-auth Secret to use instead of the operator-generated one. Must also carry a uri key."
             },
             "password": {
-              "type": "string",
-              "description": "mode: bundled only. Ignored under CloudNativePG, which generates and owns the credential."
+              "type": [
+                "string",
+                "integer",
+                "boolean",
+                "null"
+              ],
+              "description": "mode: bundled only. Ignored under CloudNativePG, which owns the credential."
             }
           }
         },
@@ -714,6 +719,10 @@
         "podAnnotations": {
           "type": "object",
           "description": "mode: bundled only."
+        },
+        "acknowledgeDataMigration": {
+          "type": "boolean",
+          "description": "Confirms that switching to cnpg does not move data. The chart refuses to render mode: cnpg while the bundled PVC exists unless this is set."
         }
       }
     },
@@ -832,6 +841,29 @@
     },
     "tolerations": {
       "type": "array"
+    },
+    "backup": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Backup integration. The in-chart database is dumped logically via a k8up PreBackupPod; it must never be backed up at the volume level.",
+      "properties": {
+        "k8up": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "image": {
+              "type": "string",
+              "description": "Must be >= the server's major version or pg_dump refuses."
+            },
+            "resources": {
+              "type": "object"
+            }
+          }
+        }
+      }
     }
   },
   "title": "schautrack Helm values",

--- a/helm/schautrack/values.yaml
+++ b/helm/schautrack/values.yaml
@@ -254,10 +254,138 @@ ai:
   # Daily request limit per user when using global key (0 = unlimited)
   dailyLimit: 10
 
-# PostgreSQL configuration
+# In-chart PostgreSQL. Two engines, both supported; `mode` picks one.
+#
+#   bundled  - a single PostgreSQL Pod with a PVC. Simple, no operator to
+#              install, nothing else to run. Fine for a single-node homelab or
+#              anywhere the database is backed up by other means. No failover,
+#              no point-in-time recovery.
+#   cnpg     - a CloudNativePG Cluster. Continuous backup to object storage,
+#              PITR, replicas with automatic failover, managed minor-version
+#              upgrades. Requires the CloudNativePG operator in the cluster.
+#
+# Pick `bundled` if you want the fewest moving parts, `cnpg` if you want the
+# database to look after itself. Neither is going away.
+#
+# The default is `bundled` because Helm cannot tell a fresh install from an
+# upgrade: defaulting to cnpg would move every existing release onto an empty
+# Cluster while its data sat in a PVC nothing mounts.
+#
+# Switching an existing install is a data migration, not a values change —
+# see docs/cloudnativepg.md.
 postgresql:
-  # Enable bundled PostgreSQL (set to false to use external database)
+  # Provision an in-chart database at all. false = use externalDatabase.url.
   enabled: true
+
+  # "bundled" or "cnpg".
+  mode: bundled
+
+  # --- mode: cnpg ---------------------------------------------------------
+
+  # 1 is a single instance with no standby: still a real upgrade on the old
+  # Deployment (managed backups, PITR, supervised restarts), but a node loss is
+  # downtime until the volume reattaches. Use 3 for actual high availability;
+  # 2 gives you a standby but no quorum, so prefer 3 if you can afford it.
+  instances: 1
+
+  # Leave empty to take the operator's default PostgreSQL image, which is what
+  # keeps minor-version upgrades on CNPG's tested path.
+  imageName: ""
+
+  auth:
+    database: schautrack
+    username: schautrack
+    # CNPG generates and owns the password; there is no auth.password key.
+    # To bring your own, create a kubernetes.io/basic-auth Secret with
+    # `username` and `password` keys and name it here. The chart then reads
+    # DATABASE_URL from `<name>`; that Secret must also carry a `uri` key.
+    existingSecret: ""
+
+  storage:
+    size: 10Gi
+    # Empty means the cluster default StorageClass.
+    storageClass: ""
+
+  # A separate volume for the write-ahead log. Off by default; worth enabling
+  # when the data volume is on slow or heavily shared storage, because WAL
+  # fsyncs then stop competing with table I/O.
+  walStorage:
+    enabled: false
+    size: 2Gi
+    storageClass: ""
+
+  # Ceiling on server connections.
+  #
+  # The floor is set by the app, not by taste: internal/database pins pgxpool
+  # MaxConns=20 per replica, and sse.Listen holds one MORE connection outside
+  # the pool for the process lifetime, because a LISTEN occupies its connection
+  # permanently. So a 2-replica deployment needs 2*(20+1)=42 before CNPG's own
+  # superuser and streaming-replication slots. 100 leaves headroom to scale the
+  # Deployment to 4 replicas without touching this.
+  maxConnections: 100
+
+  # Extra postgresql.conf parameters, merged after max_connections.
+  parameters: {}
+    # shared_buffers: 256MB
+    # work_mem: 8MB
+
+  resources: {}
+    # limits:
+    #   cpu: 1000m
+    #   memory: 1Gi
+    # requests:
+    #   cpu: 100m
+    #   memory: 256Mi
+
+  affinity: {}
+
+  # Continuous backup to S3-compatible object storage, plus PITR.
+  #
+  # Off by default because it cannot work without credentials, and a backup
+  # that silently is not running is worse than one you know you have not set
+  # up. Turning this on is the main reason to be on CNPG at all.
+  backup:
+    enabled: false
+    # e.g. s3://my-bucket/schautrack
+    destinationPath: ""
+    # Set for non-AWS S3 (MinIO, Garage, R2): e.g. https://minio.example.com
+    endpointURL: ""
+    s3Credentials:
+      secretName: ""
+      accessKeyIdKey: ACCESS_KEY_ID
+      secretAccessKeyKey: ACCESS_SECRET_KEY
+    retentionPolicy: "30d"
+    walCompression: gzip
+    # SIX fields, seconds first — CNPG's cron dialect is not Kubernetes'.
+    # This default is 03:00 daily. Empty disables the ScheduledBackup.
+    schedule: "0 0 3 * * *"
+
+  # One-shot import from a bundled-mode PostgreSQL.
+  #
+  # When enabled, CNPG runs pg_dump | pg_restore against the old server as it
+  # bootstraps, then never looks at it again. It is read ONLY at bootstrap: on
+  # an already-initialised Cluster it does nothing, so leaving it true will not
+  # re-import and will not overwrite live data. Set it back to false once the
+  # migration is done, so a future Cluster rebuild does not point at a server
+  # that no longer exists. See docs/cloudnativepg.md.
+  bootstrap:
+    importFrom:
+      enabled: false
+      # Service name of the old postgres, e.g. schautrack-prod-postgresql
+      host: ""
+      port: 5432
+      # Default to auth.username / auth.database when empty.
+      username: ""
+      database: ""
+      sslmode: prefer
+      # Secret holding the OLD database password.
+      passwordSecret:
+        name: ""
+        key: POSTGRES_PASSWORD
+
+  # --- mode: bundled -----------------------------------------------------
+  # Read only when mode is "bundled". Left at their historical defaults so an
+  # existing release renders exactly as it did before CloudNativePG existed.
   image:
     repository: postgres
     tag: "18-alpine"

--- a/helm/schautrack/values.yaml
+++ b/helm/schautrack/values.yaml
@@ -280,6 +280,15 @@ postgresql:
   # "bundled" or "cnpg".
   mode: bundled
 
+  # Confirms you understand that switching to cnpg does not move your data.
+  #
+  # With mode: cnpg, the chart refuses to render while the bundled PVC still
+  # exists, because that upgrade would delete it and start an empty cluster.
+  # scripts/migrate-to-cnpg.sh sets this itself once the data is safely dumped
+  # and the PVC preserved. Set it by hand only if the PVC is genuinely
+  # disposable.
+  acknowledgeDataMigration: false
+
   # --- mode: cnpg ---------------------------------------------------------
 
   # 1 is a single instance with no standby: still a real upgrade on the old
@@ -464,6 +473,30 @@ postgresql:
     # requests:
     #   cpu: 100m
     #   memory: 256Mi
+
+# Backups.
+#
+# The in-chart database is NOT covered by a volume-level backup, and must not
+# be: copying a live PostgreSQL data directory with a file-level tool produces a
+# torn snapshot that may not restore. If you back this namespace up with k8up,
+# annotate the PostgreSQL PVC k8up.io/backup: "false" and enable the
+# PreBackupPod below instead — it dumps logically and streams straight to
+# restic, so the schedule you already run starts holding something restorable.
+#
+# A schedule that reports success while storing nothing is the failure mode this
+# exists to prevent, and it is silent for as long as nobody tries a restore.
+backup:
+  k8up:
+    # Renders a k8up PreBackupPod. Requires the k8up operator (CRDs) in the
+    # cluster, and a k8up Schedule for this namespace — the Schedule is usually
+    # owned by whatever manages your cluster-wide backups, not by this chart.
+    enabled: false
+    # Must be >= the server's major version or pg_dump refuses.
+    image: postgres:18-alpine
+    resources: {}
+      # limits:
+      #   cpu: 500m
+      #   memory: 256Mi
 
 # External database (used when postgresql.enabled is false)
 externalDatabase:

--- a/internal/config/chart_cnpg_test.go
+++ b/internal/config/chart_cnpg_test.go
@@ -1,0 +1,167 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// chartTemplates is the rendered-template source these assertions read.
+var chartTemplates = filepath.Join("..", "..", "helm", "schautrack", "templates")
+
+func readChartTemplates(t *testing.T) map[string]string {
+	t.Helper()
+	entries, err := os.ReadDir(chartTemplates)
+	if err != nil {
+		t.Fatalf("read chart templates: %v", err)
+	}
+	out := map[string]string{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(chartTemplates, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		out[e.Name()] = string(b)
+	}
+	if len(out) == 0 {
+		t.Fatal("no chart templates found")
+	}
+	return out
+}
+
+// TestChartNeverPointsAtAReadOnlyService is the build-time half of the invariant
+// docs/cloudnativepg.md states in prose: everything that talks to the database
+// uses the CloudNativePG -rw Service.
+//
+// This is worth a test rather than a comment because the failure is invisible.
+// A DSN on -ro or -r reads fine and passes /api/health, so nothing looks wrong —
+// but NOTIFY does not replicate, so the LISTEN in internal/sse attaches to a
+// standby and waits on a channel that never fires. Cross-instance SSE goes dead
+// with no error in any log, and the symptom users report is "linked accounts
+// stopped updating", days later.
+//
+// The match has to survive templating, which is where the first version of
+// this test was useless: it looked for a literal "postgresql-ro" and happily
+// passed on `{{ include "schautrack.postgresql.fullname" . }}-ro`, the only
+// spelling anyone would actually write. So the suffix is matched wherever it
+// lands — after a template action, after a printf verb, or in a literal name —
+// and `-rw` is the sole accepted form.
+func TestChartNeverPointsAtAReadOnlyService(t *testing.T) {
+	// A service-suffix `-ro`/`-r` not followed by the `w` that would make it -rw.
+	readService := regexp.MustCompile(`-r(o\b|\b)`)
+	for name, body := range readChartTemplates(t) {
+		for i, line := range strings.Split(body, "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "#") {
+				continue // prose about -ro is how the invariant gets explained
+			}
+			if m := readService.FindString(line); m != "" {
+				t.Errorf("%s:%d references a CloudNativePG read Service (%q):\n  %s\n"+
+					"NOTIFY does not replicate: a LISTEN on a standby never fires and "+
+					"cross-instance SSE dies silently. Use the -rw Service.",
+					name, i+1, m, strings.TrimSpace(line))
+			}
+		}
+	}
+}
+
+// TestChartUsesTheReadWriteServiceHelper pins the indirection itself. Someone
+// hardcoding "-rw" in one template and not another is how the two drift, and
+// the drift only shows up after a failover moves the primary.
+func TestChartUsesTheReadWriteServiceHelper(t *testing.T) {
+	helpers, err := os.ReadFile(filepath.Join(chartTemplates, "_helpers.tpl"))
+	if err != nil {
+		t.Fatalf("read _helpers.tpl: %v", err)
+	}
+	if !strings.Contains(string(helpers), `define "schautrack.postgresql.rwService"`) {
+		t.Fatal("the schautrack.postgresql.rwService helper is gone; every database " +
+			"reference must resolve through it so they cannot drift apart")
+	}
+
+	for name, body := range readChartTemplates(t) {
+		if name == "cnpg-cluster.yaml" {
+			continue // declares the Cluster; the Services are derived from it
+		}
+		for _, line := range strings.Split(body, "\n") {
+			if !strings.Contains(line, "-rw") {
+				continue
+			}
+			if strings.Contains(line, "rwService") || strings.HasPrefix(strings.TrimSpace(line), "#") {
+				continue
+			}
+			t.Errorf("%s hardcodes a -rw reference:\n  %s\nUse the "+
+				"schautrack.postgresql.rwService helper instead.", name, strings.TrimSpace(line))
+		}
+	}
+}
+
+// TestChartKeepsBothDatabaseEngines pins the promise that the chart offers two
+// databases, not one with a legacy path. Both are supported: bundled for
+// installs that want no operator, CloudNativePG for installs that want backups
+// and failover.
+//
+// It is a test rather than a convention because deleting the bundled templates
+// is a tidy-looking change with an untidy consequence: an existing release keeps
+// its data in a PVC only those templates manage, so a chart that stopped
+// rendering them would leave the volume mounted by nothing and the database
+// would look erased.
+func TestChartKeepsBothDatabaseEngines(t *testing.T) {
+	for _, name := range []string{
+		"postgresql-deployment.yaml",
+		"postgresql-pvc.yaml",
+		"postgresql-service.yaml",
+		"cnpg-cluster.yaml",
+	} {
+		if _, err := os.Stat(filepath.Join(chartTemplates, name)); err != nil {
+			t.Errorf("%s is missing. Both engines must render: CloudNativePG for new "+
+				"installs, the bundled Deployment so existing releases are undisturbed.", name)
+		}
+	}
+}
+
+// TestDatabaseEnginesAreMutuallyExclusive guards the shape that would be worst
+// to get wrong: two servers, one database name, one release. Every engine
+// template must gate on the resolved mode helpers rather than on
+// postgresql.enabled, which is true for both.
+func TestDatabaseEnginesAreMutuallyExclusive(t *testing.T) {
+	want := map[string]string{
+		"postgresql-deployment.yaml": "schautrack.postgresql.isBundled",
+		"postgresql-pvc.yaml":        "schautrack.postgresql.isBundled",
+		"postgresql-service.yaml":    "schautrack.postgresql.isBundled",
+		"cnpg-cluster.yaml":          "schautrack.postgresql.isCNPG",
+	}
+	for name, guard := range want {
+		b, err := os.ReadFile(filepath.Join(chartTemplates, name))
+		if err != nil {
+			t.Errorf("read %s: %v", name, err)
+			continue
+		}
+		head := strings.SplitN(string(b), "\n", 2)[0]
+		if !strings.Contains(head, guard) {
+			t.Errorf("%s does not gate on %s; its first line is:\n  %s\n"+
+				"Gating on postgresql.enabled alone would render both engines at once.",
+				name, guard, head)
+		}
+	}
+}
+
+// TestBundledModeIsTheDefault is the whole compatibility argument in one
+// assertion. Helm cannot distinguish a fresh install from an upgrade, so a
+// default of "cnpg" would move every existing release off the Deployment it is
+// running and strand its PVC. Choosing CloudNativePG is therefore explicit, and
+// changing this default is a major-version decision rather than a tweak.
+func TestBundledModeIsTheDefault(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join(chartTemplates, "..", "values.yaml"))
+	if err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	}
+	if !regexp.MustCompile(`(?m)^  mode: bundled\s*$`).Match(b) {
+		t.Error("postgresql.mode must default to \"bundled\" in values.yaml. " +
+			"Defaulting to cnpg silently migrates every existing release away from " +
+			"its data. Flipping this is a major-version decision.")
+	}
+}

--- a/internal/config/chart_cnpg_test.go
+++ b/internal/config/chart_cnpg_test.go
@@ -19,7 +19,11 @@ func readChartTemplates(t *testing.T) map[string]string {
 	}
 	out := map[string]string{}
 	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+		// .tpl too, not just .yaml. The first version of this helper read only
+		// .yaml, so _helpers.tpl — the one file that actually spells the Service
+		// suffix — was never scanned, and a rwService helper returning "-ro"
+		// passed every test below.
+		if e.IsDir() || !(strings.HasSuffix(e.Name(), ".yaml") || strings.HasSuffix(e.Name(), ".tpl")) {
 			continue
 		}
 		b, err := os.ReadFile(filepath.Join(chartTemplates, e.Name()))
@@ -51,13 +55,20 @@ func readChartTemplates(t *testing.T) map[string]string {
 // spelling anyone would actually write. So the suffix is matched wherever it
 // lands — after a template action, after a printf verb, or in a literal name —
 // and `-rw` is the sole accepted form.
+// templateComment strips {{/* ... */}} blocks. Prose about -ro is how this
+// invariant gets explained, so the explanation must not trip the check.
+var templateComment = regexp.MustCompile(`(?s)\{\{-?\s*/\*.*?\*/\s*-?\}\}`)
+
 func TestChartNeverPointsAtAReadOnlyService(t *testing.T) {
-	// A service-suffix `-ro`/`-r` not followed by the `w` that would make it -rw.
-	readService := regexp.MustCompile(`-r(o\b|\b)`)
+	// A service-suffix `-ro`/`-r`, not the `-r` of a command-line flag: the
+	// suffix is always welded to a name, so require a preceding word character,
+	// `}` (end of a template action) or `%s` (a printf verb). Without that,
+	// prose like "migrate.sh -n %s -r %s" reads as a read Service.
+	readService := regexp.MustCompile(`[\w}]-r(o\b|\b)`)
 	for name, body := range readChartTemplates(t) {
-		for i, line := range strings.Split(body, "\n") {
+		for i, line := range strings.Split(templateComment.ReplaceAllString(body, ""), "\n") {
 			if strings.HasPrefix(strings.TrimSpace(line), "#") {
-				continue // prose about -ro is how the invariant gets explained
+				continue // YAML comments explain it too
 			}
 			if m := readService.FindString(line); m != "" {
 				t.Errorf("%s:%d references a CloudNativePG read Service (%q):\n  %s\n"+
@@ -82,11 +93,21 @@ func TestChartUsesTheReadWriteServiceHelper(t *testing.T) {
 			"reference must resolve through it so they cannot drift apart")
 	}
 
+	// A positive assertion, not just "the define exists": the helper has to
+	// actually emit -rw. Asserting its presence is what let a "-ro" body slip
+	// through unnoticed.
+	if !regexp.MustCompile(`define "schautrack\.postgresql\.rwService"[\s\S]{0,200}?printf "%s-rw"`).MatchString(string(helpers)) {
+		t.Error("schautrack.postgresql.rwService must render a -rw suffix; " +
+			"NOTIFY does not replicate, so any other Service silently kills cross-instance SSE")
+	}
+
 	for name, body := range readChartTemplates(t) {
-		if name == "cnpg-cluster.yaml" {
-			continue // declares the Cluster; the Services are derived from it
+		// _helpers.tpl is where rwService is legitimately defined, and
+		// cnpg-cluster.yaml declares the Cluster the Services derive from.
+		if name == "cnpg-cluster.yaml" || name == "_helpers.tpl" {
+			continue
 		}
-		for _, line := range strings.Split(body, "\n") {
+		for _, line := range strings.Split(templateComment.ReplaceAllString(body, ""), "\n") {
 			if !strings.Contains(line, "-rw") {
 				continue
 			}

--- a/scripts/db-fingerprint.sql
+++ b/scripts/db-fingerprint.sql
@@ -1,0 +1,68 @@
+-- A content fingerprint of a schautrack database, for proving a migration was
+-- lossless.
+--
+-- Row counts alone are not proof: they survive a restore that silently dropped
+-- a column's contents, coerced NULL to '', or truncated numeric precision. So
+-- each table is reduced to an md5 over its ordered, fully-rendered rows, and the
+-- sequence positions are reported alongside — a restore that forgets to advance
+-- sequences looks perfect until the next INSERT collides on a primary key.
+--
+-- Output is stable across dump/restore: ordered by primary key, and no
+-- clock- or OID-dependent values.
+\pset footer off
+\pset format unaligned
+\pset fieldsep '|'
+
+SELECT 'rowcount' AS kind, relname AS name, n_live_tup::text AS value
+FROM pg_stat_user_tables
+ORDER BY relname;
+
+SELECT 'digest' AS kind, 'users' AS name,
+       md5(string_agg(t::text, '|' ORDER BY id))::text AS value
+FROM (SELECT id, email, password_hash, daily_goal, timezone, weight_unit,
+             macros_enabled, macro_goals, totp_enabled, email_verified
+      FROM users) t;
+
+SELECT 'digest', 'calorie_entries',
+       md5(string_agg(t::text, '|' ORDER BY id))
+FROM (SELECT id, user_id, entry_date, amount, entry_name,
+             protein_g, carbs_g, fat_g, fiber_g, sugar_g
+      FROM calorie_entries) t;
+
+SELECT 'digest', 'weight_entries',
+       md5(string_agg(t::text, '|' ORDER BY id))
+FROM (SELECT id, user_id, entry_date, weight, body_fat FROM weight_entries) t;
+
+SELECT 'digest', 'saved_foods',
+       md5(string_agg(t::text, '|' ORDER BY id))
+FROM (SELECT id, user_id, name, emoji, amount, protein_g, use_count FROM saved_foods) t;
+
+SELECT 'digest', 'daily_notes',
+       md5(string_agg(t::text, '|' ORDER BY id))
+FROM (SELECT id, user_id, note_date, content FROM daily_notes) t;
+
+SELECT 'digest', 'account_links',
+       md5(string_agg(t::text, '|' ORDER BY id))
+FROM (SELECT id, requester_id, target_id, status, requester_label, target_label
+      FROM account_links) t;
+
+SELECT 'digest', 'todos',
+       md5(string_agg(t::text, '|' ORDER BY id))
+FROM (SELECT id, user_id, name, schedule, time_of_day, sort_order, archived FROM todos) t;
+
+-- NULL and '' must stay distinguishable.
+SELECT 'nullcheck', 'daily_notes_null_vs_empty',
+       count(*) FILTER (WHERE content IS NULL)::text || '/' ||
+       count(*) FILTER (WHERE content = '')::text
+FROM daily_notes;
+
+-- Sequence positions. last_value must be >= max(id), or the next insert fails.
+SELECT 'sequence', s.relname,
+       (SELECT last_value FROM pg_sequences q
+        WHERE q.schemaname = 'public' AND q.sequencename = s.relname)::text
+FROM pg_class s
+WHERE s.relkind = 'S' AND s.relnamespace = 'public'::regnamespace
+ORDER BY s.relname;
+
+-- Applied data migrations: the app must not try to re-run them post-cutover.
+SELECT 'datamigration', name, 'applied' FROM schema_data_migrations ORDER BY name;

--- a/scripts/db-fingerprint.sql
+++ b/scripts/db-fingerprint.sql
@@ -1,68 +1,60 @@
 -- A content fingerprint of a schautrack database, for proving a migration was
 -- lossless.
 --
--- Row counts alone are not proof: they survive a restore that silently dropped
--- a column's contents, coerced NULL to '', or truncated numeric precision. So
--- each table is reduced to an md5 over its ordered, fully-rendered rows, and the
--- sequence positions are reported alongside — a restore that forgets to advance
--- sequences looks perfect until the next INSERT collides on a primary key.
+-- Row counts alone are not proof: they survive a restore that coerced NULL to
+-- '', truncated numeric precision, or dropped a column's contents. So every
+-- table is reduced to an md5 over its fully-rendered rows.
 --
--- Output is stable across dump/restore: ordered by primary key, and no
--- clock- or OID-dependent values.
+-- THE TABLE LIST COMES FROM THE CATALOG, NOT FROM THIS FILE. An earlier version
+-- hand-listed seven tables and the surrounding script then claimed "every table
+-- digest is identical". The schema has twenty-four: a restore that lost every
+-- passkey, API token, TOTP backup code, invite code, weight goal and admin
+-- setting would have produced a clean diff and a congratulatory message. A
+-- curated list also ages out silently — each new migration adds a table nobody
+-- remembers to add here.
+--
+-- Rows are ordered by their own text representation rather than by a primary
+-- key, so no table needs special knowledge and a table with a non-integer or
+-- composite key is covered like any other.
+--
+-- Output is stable across dump/restore: no clock- or OID-dependent values, and
+-- the timezone is pinned because a timestamptz renders per-session.
+
 \pset footer off
 \pset format unaligned
 \pset fieldsep '|'
+SET TIME ZONE 'UTC';
 
-SELECT 'rowcount' AS kind, relname AS name, n_live_tup::text AS value
-FROM pg_stat_user_tables
-ORDER BY relname;
+-- One digest per user table, generated and then executed by \gexec.
+SELECT format(
+  'SELECT ''digest'' AS kind, %L AS name, '
+  || 'coalesce(md5(string_agg(t::text, ''|'' ORDER BY t::text)), ''<empty>'') AS value '
+  || 'FROM public.%I t',
+  tablename, tablename)
+FROM pg_tables
+WHERE schemaname = 'public'
+ORDER BY tablename
+\gexec
 
-SELECT 'digest' AS kind, 'users' AS name,
-       md5(string_agg(t::text, '|' ORDER BY id))::text AS value
-FROM (SELECT id, email, password_hash, daily_goal, timezone, weight_unit,
-             macros_enabled, macro_goals, totp_enabled, email_verified
-      FROM users) t;
+-- Row counts, exact (not the pg_stat_user_tables estimate, which is only
+-- populated by ANALYZE and would differ on a freshly restored cluster).
+SELECT format(
+  'SELECT ''rowcount'' AS kind, %L AS name, count(*)::text AS value FROM public.%I',
+  tablename, tablename)
+FROM pg_tables
+WHERE schemaname = 'public'
+ORDER BY tablename
+\gexec
 
-SELECT 'digest', 'calorie_entries',
-       md5(string_agg(t::text, '|' ORDER BY id))
-FROM (SELECT id, user_id, entry_date, amount, entry_name,
-             protein_g, carbs_g, fat_g, fiber_g, sugar_g
-      FROM calorie_entries) t;
+-- Sequence positions. A restore that forgot to advance these looks perfect
+-- until the next INSERT collides on a primary key.
+SELECT 'sequence' AS kind, sequencename AS name, coalesce(last_value::text, '<unread>') AS value
+FROM pg_sequences
+WHERE schemaname = 'public'
+ORDER BY sequencename;
 
-SELECT 'digest', 'weight_entries',
-       md5(string_agg(t::text, '|' ORDER BY id))
-FROM (SELECT id, user_id, entry_date, weight, body_fat FROM weight_entries) t;
-
-SELECT 'digest', 'saved_foods',
-       md5(string_agg(t::text, '|' ORDER BY id))
-FROM (SELECT id, user_id, name, emoji, amount, protein_g, use_count FROM saved_foods) t;
-
-SELECT 'digest', 'daily_notes',
-       md5(string_agg(t::text, '|' ORDER BY id))
-FROM (SELECT id, user_id, note_date, content FROM daily_notes) t;
-
-SELECT 'digest', 'account_links',
-       md5(string_agg(t::text, '|' ORDER BY id))
-FROM (SELECT id, requester_id, target_id, status, requester_label, target_label
-      FROM account_links) t;
-
-SELECT 'digest', 'todos',
-       md5(string_agg(t::text, '|' ORDER BY id))
-FROM (SELECT id, user_id, name, schedule, time_of_day, sort_order, archived FROM todos) t;
-
--- NULL and '' must stay distinguishable.
-SELECT 'nullcheck', 'daily_notes_null_vs_empty',
-       count(*) FILTER (WHERE content IS NULL)::text || '/' ||
-       count(*) FILTER (WHERE content = '')::text
-FROM daily_notes;
-
--- Sequence positions. last_value must be >= max(id), or the next insert fails.
-SELECT 'sequence', s.relname,
-       (SELECT last_value FROM pg_sequences q
-        WHERE q.schemaname = 'public' AND q.sequencename = s.relname)::text
-FROM pg_class s
-WHERE s.relkind = 'S' AND s.relnamespace = 'public'::regnamespace
-ORDER BY s.relname;
-
--- Applied data migrations: the app must not try to re-run them post-cutover.
-SELECT 'datamigration', name, 'applied' FROM schema_data_migrations ORDER BY name;
+-- The set of tables itself, so a table that vanished entirely is a diff line
+-- rather than a silently absent digest.
+SELECT 'tablelist' AS kind, 'public' AS name, string_agg(tablename, ',' ORDER BY tablename) AS value
+FROM pg_tables
+WHERE schemaname = 'public';

--- a/scripts/migrate-to-cnpg.sh
+++ b/scripts/migrate-to-cnpg.sh
@@ -59,12 +59,27 @@ FINGERPRINT_SQL="$SCRIPT_DIR/db-fingerprint.sql"
 # is much worse than one that refused to start.
 say "Preflight"
 
-k get deploy "$RELEASE-schautrack" >/dev/null 2>&1 \
-  || die "no Deployment $RELEASE-schautrack in namespace $NS"
+# Discover the object names; do NOT reconstruct them.
+#
+# `schautrack.fullname` collapses to the release name alone when the release
+# already contains the chart name (_helpers.tpl: `if contains $name
+# .Release.Name`). So release `schautrack-staging` produces Deployments named
+# `schautrack-staging` and `schautrack-staging-postgresql`, not
+# `schautrack-staging-schautrack…`. An earlier version of this script pasted
+# "$RELEASE-schautrack" together and could not find a single one of this
+# project's own releases — and `nameOverride`/`fullnameOverride` break the
+# guess in other ways. The labels are the contract; use them.
+APP_DEPLOY="$(k get deploy -l "app.kubernetes.io/instance=$RELEASE,app.kubernetes.io/name=schautrack" \
+  -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)"
+[[ "$(wc -w <<<"$APP_DEPLOY")" == "1" ]] \
+  || die "expected exactly one app Deployment for release '$RELEASE' in $NS, found: ${APP_DEPLOY:-none}"
 
-PG_DEPLOY="$RELEASE-schautrack-postgresql"
-k get deploy "$PG_DEPLOY" >/dev/null 2>&1 \
-  || die "no bundled PostgreSQL Deployment $PG_DEPLOY. Already migrated, or this release is not in bundled mode."
+PG_DEPLOY="$(k get deploy -l "app.kubernetes.io/instance=$RELEASE,app.kubernetes.io/component=database" \
+  -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)"
+[[ "$(wc -w <<<"$PG_DEPLOY")" == "1" ]] \
+  || die "expected exactly one bundled PostgreSQL Deployment for release '$RELEASE' in $NS, found: ${PG_DEPLOY:-none}.
+  Already migrated, or this release is not in bundled mode."
+say "App Deployment: $APP_DEPLOY   PostgreSQL Deployment: $PG_DEPLOY"
 
 kubectl "${KCTX[@]}" get crd clusters.postgresql.cnpg.io >/dev/null 2>&1 \
   || die "the CloudNativePG operator is not installed in this cluster.
@@ -75,7 +90,7 @@ DB_USER="$(h get values "$RELEASE" -n "$NS" -o json 2>/dev/null | python3 -c 'im
 DB_NAME="$(h get values "$RELEASE" -n "$NS" -o json 2>/dev/null | python3 -c 'import json,sys;v=json.load(sys.stdin) or {};print((v.get("postgresql") or {}).get("auth",{}).get("database","schautrack"))' 2>/dev/null || echo schautrack)"
 say "Source database: $DB_NAME (owner $DB_USER)"
 
-REPLICAS="$(k get deploy "$RELEASE-schautrack" -o jsonpath='{.spec.replicas}')"
+REPLICAS="$(k get deploy "$APP_DEPLOY" -o jsonpath='{.spec.replicas}')"
 say "App replicas to restore afterwards: $REPLICAS"
 
 # The chart still ships the bundled engine and still defaults to it, so an
@@ -109,13 +124,13 @@ restore_replicas_on_failure() {
   local code=$?
   [[ $code -eq 0 ]] && return 0
   printf '\n\033[33mNothing has been changed yet — scaling the app back to %s.\033[0m\n' "$REPLICAS" >&2
-  k scale deploy "$RELEASE-schautrack" --replicas="$REPLICAS" >/dev/null 2>&1 || true
+  k scale deploy "$APP_DEPLOY" --replicas="$REPLICAS" >/dev/null 2>&1 || true
 }
-trap restore_replicas_on_failure EXIT
+trap restore_replicas_on_failure EXIT INT TERM
 
 say "Scaling app to 0 (downtime begins)"
-k scale deploy "$RELEASE-schautrack" --replicas=0
-k rollout status deploy "$RELEASE-schautrack" --timeout=120s >/dev/null 2>&1 || true
+k scale deploy "$APP_DEPLOY" --replicas=0
+k rollout status deploy "$APP_DEPLOY" --timeout=120s >/dev/null 2>&1 || true
 for _ in $(seq 1 60); do
   [[ "$(k get pods -l app.kubernetes.io/name=schautrack --no-headers 2>/dev/null | grep -c .)" == "0" ]] && break
   sleep 2
@@ -153,7 +168,13 @@ say "Dump verified: $(du -h "$DUMP" | cut -f1), $(grep -c 'TABLE DATA' "$WORKDIR
 # Do this BEFORE the upgrade. Once Helm has deleted the PVC there is nothing
 # left to annotate, and the only copy of the data is the dump in /tmp.
 say "Annotating the old PVC to survive the upgrade"
-OLD_PVC="$(k get pvc -l app.kubernetes.io/component=database -o name 2>/dev/null | head -1)"
+OLD_PVC="$(k get pvc -l "app.kubernetes.io/instance=$RELEASE,app.kubernetes.io/component=database" -o name 2>/dev/null)"
+# Scoped to the release, and no `head -1`: two matches means the wrong volume
+# gets the keep-annotation while the real one is deleted by the upgrade
+# seconds later, leaving the dump in /tmp as the only copy.
+if [[ "$(wc -w <<<"$OLD_PVC")" -gt 1 ]]; then
+  die "more than one database PVC matches release '$RELEASE': $OLD_PVC"
+fi
 if [[ -n "$OLD_PVC" ]]; then
   k annotate "$OLD_PVC" helm.sh/resource-policy=keep --overwrite >/dev/null
   say "Kept: $OLD_PVC (delete it yourself once you are satisfied)"
@@ -167,11 +188,17 @@ fi
 trap - EXIT
 
 say "Upgrading release to the CloudNativePG chart (app stays at 0 replicas)"
-HELM_ARGS=(upgrade "$RELEASE" "$CHART" -n "$NS" --set replicaCount=0 --wait --timeout 10m)
+# --reuse-values, because -f is optional and nothing requires the supplied file
+# to be the release's COMPLETE values. Without it, a three-line file containing
+# only `postgresql: {mode: cnpg}` passes preflight and then resets baseUrl,
+# ingress, existingSecret, image.tag, SMTP and OIDC to chart defaults — at the
+# exact moment the old Deployment has just been deleted.
+HELM_ARGS=(upgrade "$RELEASE" "$CHART" -n "$NS" --reuse-values --set replicaCount=0
+  --set postgresql.acknowledgeDataMigration=true --wait --timeout 10m)
 [[ -n "$VALUES" ]] && HELM_ARGS+=(-f "$VALUES")
 h "${HELM_ARGS[@]}" || die "helm upgrade failed; the old PVC is still present for rollback"
 
-CLUSTER="$RELEASE-schautrack-postgresql"
+CLUSTER="$PG_DEPLOY"   # the Cluster takes the same fullname the Deployment had
 say "Waiting for the CNPG cluster to be ready"
 for _ in $(seq 1 120); do
   READY="$(k get cluster "$CLUSTER" -o jsonpath='{.status.readyInstances}' 2>/dev/null || echo 0)"
@@ -268,9 +295,16 @@ grep -q 'migration-probe' <<<"$NOTIFY_OUT" \
 say "LISTEN/NOTIFY delivers on the app DSN"
 
 # --- Let traffic back in ---------------------------------------------------
-say "Scaling app back to $REPLICAS (downtime ends)"
-k scale deploy "$RELEASE-schautrack" --replicas="$REPLICAS"
-k rollout status deploy "$RELEASE-schautrack" --timeout=300s || die "app did not become ready"
+# Through Helm, not `kubectl scale`. The upgrade above recorded
+# replicaCount=0 in the release, so scaling with kubectl would leave live state
+# at N and desired state at 0 — and the next upgrade, `--reuse-values`, or an
+# ArgoCD sync would quietly take the app back to zero.
+say "Scaling app back to $REPLICAS through Helm (downtime ends)"
+RESTORE_ARGS=(upgrade "$RELEASE" "$CHART" -n "$NS" --reuse-values --set "replicaCount=$REPLICAS"
+  --set postgresql.acknowledgeDataMigration=true --wait --timeout 10m)
+[[ -n "$VALUES" ]] && RESTORE_ARGS+=(-f "$VALUES")
+h "${RESTORE_ARGS[@]}" || die "could not restore replicaCount through Helm; the data is migrated and intact, but the release still records replicaCount=0"
+k rollout status deploy "$APP_DEPLOY" --timeout=300s || die "app did not become ready"
 
 say "Done."
 cat <<EOF

--- a/scripts/migrate-to-cnpg.sh
+++ b/scripts/migrate-to-cnpg.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Migrate a schautrack release from the bundled PostgreSQL Deployment
+# to a CloudNativePG Cluster.
+#
+#   scripts/migrate-to-cnpg.sh -n <namespace> -r <release> [-c <kube-context>] \
+#     [-C <chart>] [-f <values.yaml>] [--dry-run]
+#
+# WHY A SCRIPT AND NOT A NOTE IN THE README
+#
+# The obvious move — flip `postgresql.mode` to cnpg and run `helm upgrade` —
+# destroys the database. One upgrade deletes the bundled Deployment, Service and
+# PVC and creates an empty Cluster, and Helm does all of it in a single pass,
+# before anything can copy the data out. That
+# is also why CNPG's own `bootstrap.initdb.import` cannot carry this migration
+# on its own: it dumps from a live source over the network, and by the time the
+# Cluster bootstraps, Helm has already deleted the source. (importFrom is still
+# the right tool when the source is a PostgreSQL you keep running yourself —
+# see docs/cloudnativepg.md.)
+#
+# So the order here is deliberate: stop writers, dump, PROVE the dump is
+# usable, only then let Helm near the old objects, restore, and compare a
+# content fingerprint before letting traffic back in.
+#
+# The old PVC is annotated helm.sh/resource-policy=keep before the upgrade, so
+# Helm leaves it behind. It is the rollback: nothing in this script deletes it,
+# and it is yours to remove once you are satisfied.
+set -euo pipefail
+
+NS=""; RELEASE=""; CTX=""; CHART="helm/schautrack"; VALUES=""; DRY_RUN=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n) NS="$2"; shift 2 ;;
+    -r) RELEASE="$2"; shift 2 ;;
+    -c) CTX="$2"; shift 2 ;;
+    -C) CHART="$2"; shift 2 ;;
+    -f) VALUES="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+[[ -n "$NS" && -n "$RELEASE" ]] || { echo "usage: $0 -n <namespace> -r <release> [-c ctx] [-C chart] [-f values] [--dry-run]" >&2; exit 2; }
+
+KCTX=(); [[ -n "$CTX" ]] && KCTX=(--context "$CTX")
+k() { kubectl "${KCTX[@]}" -n "$NS" "$@"; }
+h() { helm ${CTX:+--kube-context "$CTX"} "$@"; }
+say() { printf '\n\033[1m==> %s\033[0m\n' "$*"; }
+die() { printf '\n\033[31mFAILED: %s\033[0m\n' "$*" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d -t schautrack-cnpg-XXXXXX)"
+DUMP="$WORKDIR/schautrack.dump"
+say "Working directory: $WORKDIR (dump and fingerprints are kept here)"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FINGERPRINT_SQL="$SCRIPT_DIR/db-fingerprint.sql"
+[[ -f "$FINGERPRINT_SQL" ]] || die "missing $FINGERPRINT_SQL"
+
+# --- Preflight -------------------------------------------------------------
+# Every check here fails BEFORE anything is modified. A half-migrated release
+# is much worse than one that refused to start.
+say "Preflight"
+
+k get deploy "$RELEASE-schautrack" >/dev/null 2>&1 \
+  || die "no Deployment $RELEASE-schautrack in namespace $NS"
+
+PG_DEPLOY="$RELEASE-schautrack-postgresql"
+k get deploy "$PG_DEPLOY" >/dev/null 2>&1 \
+  || die "no bundled PostgreSQL Deployment $PG_DEPLOY. Already migrated, or this release is not in bundled mode."
+
+kubectl "${KCTX[@]}" get crd clusters.postgresql.cnpg.io >/dev/null 2>&1 \
+  || die "the CloudNativePG operator is not installed in this cluster.
+  Install it first (cluster-wide, once):
+    kubectl apply --server-side -f https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.28/releases/cnpg-1.28.0.yaml"
+
+DB_USER="$(h get values "$RELEASE" -n "$NS" -o json 2>/dev/null | python3 -c 'import json,sys;v=json.load(sys.stdin) or {};print((v.get("postgresql") or {}).get("auth",{}).get("username","schautrack"))' 2>/dev/null || echo schautrack)"
+DB_NAME="$(h get values "$RELEASE" -n "$NS" -o json 2>/dev/null | python3 -c 'import json,sys;v=json.load(sys.stdin) or {};print((v.get("postgresql") or {}).get("auth",{}).get("database","schautrack"))' 2>/dev/null || echo schautrack)"
+say "Source database: $DB_NAME (owner $DB_USER)"
+
+REPLICAS="$(k get deploy "$RELEASE-schautrack" -o jsonpath='{.spec.replicas}')"
+say "App replicas to restore afterwards: $REPLICAS"
+
+# The chart still ships the bundled engine and still defaults to it, so an
+# upgrade that does not say `mode: cnpg` faithfully recreates the Deployment and
+# PVC this script has just dumped and is about to replace. The result would be
+# two servers for one database and a restore into the wrong one. Refuse early,
+# while the only thing that has happened is that we read some values.
+MODE="$(h template "$RELEASE" "$CHART" ${VALUES:+-f "$VALUES"} --set config.baseUrl=http://preflight.invalid 2>/dev/null \
+  | grep -c 'kind: Cluster' || true)"
+if [[ "${MODE:-0}" -lt 1 ]]; then
+  die "the chart does not render a CloudNativePG Cluster with these values.
+  Set postgresql.mode: cnpg in ${VALUES:-your values file} and re-run.
+  Without it the upgrade would rebuild the bundled Deployment on top of the
+  database this script is migrating away from."
+fi
+
+if [[ "$DRY_RUN" == 1 ]]; then
+  say "Dry run: preflight passed, stopping before any change."
+  exit 0
+fi
+
+# --- Stop writers ----------------------------------------------------------
+# Downtime starts here and ends at the final scale-up. Taking the dump from a
+# live database would be consistent (pg_dump is snapshot-based) but the rows
+# written after it would be lost silently at cutover, which is worse.
+# Until Helm has touched anything, a failure is fully recoverable and the only
+# harm done is that the app is down. Put it back up on the way out, so a failed
+# dump costs a blip rather than an outage that waits for someone to notice.
+# Disarmed just before the upgrade, after which staying down is the safe state.
+restore_replicas_on_failure() {
+  local code=$?
+  [[ $code -eq 0 ]] && return 0
+  printf '\n\033[33mNothing has been changed yet — scaling the app back to %s.\033[0m\n' "$REPLICAS" >&2
+  k scale deploy "$RELEASE-schautrack" --replicas="$REPLICAS" >/dev/null 2>&1 || true
+}
+trap restore_replicas_on_failure EXIT
+
+say "Scaling app to 0 (downtime begins)"
+k scale deploy "$RELEASE-schautrack" --replicas=0
+k rollout status deploy "$RELEASE-schautrack" --timeout=120s >/dev/null 2>&1 || true
+for _ in $(seq 1 60); do
+  [[ "$(k get pods -l app.kubernetes.io/name=schautrack --no-headers 2>/dev/null | grep -c .)" == "0" ]] && break
+  sleep 2
+done
+
+# --- Fingerprint + dump the source ----------------------------------------
+say "Fingerprinting the source database"
+k exec -i "deploy/$PG_DEPLOY" -- psql -U "$DB_USER" -d "$DB_NAME" -tA -v ON_ERROR_STOP=1 \
+  < "$FINGERPRINT_SQL" > "$WORKDIR/fingerprint-before.txt" \
+  || die "could not fingerprint the source database"
+grep -c . "$WORKDIR/fingerprint-before.txt" >/dev/null || die "empty fingerprint"
+
+say "Dumping (custom format)"
+k exec "deploy/$PG_DEPLOY" -- pg_dump -U "$DB_USER" -d "$DB_NAME" -Fc --no-owner --no-acl \
+  > "$DUMP" || die "pg_dump failed"
+
+# A dump that exists is not a dump that works. pg_restore --list both proves
+# the file is a valid archive and lets us assert the tables are really in it,
+# which catches a truncated or half-written transfer before it matters.
+#
+# Run inside the pod, not locally: the archive is written by the server's
+# pg_dump, so only a pg_restore of at least that version can read it — and a
+# self-hoster driving this from a laptop has no reason to have PostgreSQL
+# client tools installed at all. The pod always has the matching pair.
+[[ -s "$DUMP" ]] || die "dump is empty"
+k exec -i "deploy/$PG_DEPLOY" -- pg_restore --list > "$WORKDIR/dump-toc.txt" < "$DUMP" 2>/dev/null \
+  || die "dump is not a readable pg_restore archive"
+for t in users calorie_entries weight_entries saved_foods schema_data_migrations; do
+  grep -q "TABLE DATA public $t" "$WORKDIR/dump-toc.txt" \
+    || die "dump has no data for table '$t' — refusing to continue"
+done
+say "Dump verified: $(du -h "$DUMP" | cut -f1), $(grep -c 'TABLE DATA' "$WORKDIR/dump-toc.txt") tables with data"
+
+# --- Preserve the old volume ----------------------------------------------
+# Do this BEFORE the upgrade. Once Helm has deleted the PVC there is nothing
+# left to annotate, and the only copy of the data is the dump in /tmp.
+say "Annotating the old PVC to survive the upgrade"
+OLD_PVC="$(k get pvc -l app.kubernetes.io/component=database -o name 2>/dev/null | head -1)"
+if [[ -n "$OLD_PVC" ]]; then
+  k annotate "$OLD_PVC" helm.sh/resource-policy=keep --overwrite >/dev/null
+  say "Kept: $OLD_PVC (delete it yourself once you are satisfied)"
+else
+  say "WARNING: no database PVC found; the old data may have been ephemeral"
+fi
+
+# --- Upgrade to the CNPG chart, with the app still at zero -----------------
+# From here on, staying down on failure is correct: the old objects are gone
+# and the app must not come up against a half-restored database.
+trap - EXIT
+
+say "Upgrading release to the CloudNativePG chart (app stays at 0 replicas)"
+HELM_ARGS=(upgrade "$RELEASE" "$CHART" -n "$NS" --set replicaCount=0 --wait --timeout 10m)
+[[ -n "$VALUES" ]] && HELM_ARGS+=(-f "$VALUES")
+h "${HELM_ARGS[@]}" || die "helm upgrade failed; the old PVC is still present for rollback"
+
+CLUSTER="$RELEASE-schautrack-postgresql"
+say "Waiting for the CNPG cluster to be ready"
+for _ in $(seq 1 120); do
+  READY="$(k get cluster "$CLUSTER" -o jsonpath='{.status.readyInstances}' 2>/dev/null || echo 0)"
+  [[ "${READY:-0}" -ge 1 ]] && break
+  sleep 5
+done
+[[ "${READY:-0}" -ge 1 ]] || die "CNPG cluster $CLUSTER never became ready"
+
+# --- Restore ---------------------------------------------------------------
+# The app ran its own migrations against an empty database when the Cluster
+# bootstrapped, so the schema already exists. --clean --if-exists makes the
+# restore authoritative over that empty schema instead of colliding with it.
+say "Restoring into the CNPG cluster"
+PRIMARY="$(k get pods -l "cnpg.io/cluster=$CLUSTER,cnpg.io/instanceRole=primary" -o name | head -1)"
+[[ -n "$PRIMARY" ]] || die "could not find the CNPG primary pod"
+
+# --role, not a fix-up afterwards. The dump is --no-owner, so a plain restore
+# as postgres creates every table owned by postgres and the app — which
+# connects as the CNPG app user — gets permission denied on all of them.
+#
+# The obvious repair, REASSIGN OWNED BY postgres TO <app>, does not work: it
+# refuses with "cannot reassign ownership of objects owned by role postgres
+# because they are required by the database system", because it sweeps up
+# catalog objects along with ours. --role makes pg_restore SET ROLE first, so
+# the objects are created correctly owned and there is nothing to repair.
+say "Restoring as role $DB_USER"
+k exec -i "$PRIMARY" -- pg_restore -U postgres -d "$DB_NAME" --role="$DB_USER" \
+  --no-owner --no-acl --clean --if-exists --exit-on-error < "$DUMP" \
+  || die "pg_restore failed. The old PVC is intact; roll back by reinstalling the previous chart."
+
+# Prove the app user really owns what it will have to write to. A restore that
+# silently left tables owned by postgres passes every row-count check and then
+# fails on the first INSERT in production.
+say "Verifying table ownership"
+NOT_OWNED="$(k exec -i "$PRIMARY" -- psql -U postgres -d "$DB_NAME" -tAc \
+  "SELECT count(*) FROM pg_tables WHERE schemaname='public' AND tableowner <> '$DB_USER'" | tr -d '[:space:]')"
+[[ "$NOT_OWNED" == "0" ]] \
+  || die "$NOT_OWNED table(s) in public are not owned by $DB_USER; the app would hit permission denied"
+
+# --- Prove it --------------------------------------------------------------
+# As postgres, over the pod's local socket: inside a CNPG pod the OS user is
+# postgres, so peer auth rejects `-U schautrack` outright. The fingerprint is
+# pure content, so who reads it does not change the answer — and the app user's
+# real access is proven separately below, over TCP, with its actual credentials.
+say "Fingerprinting the migrated database"
+k exec -i "$PRIMARY" -- psql -U postgres -d "$DB_NAME" -tA -v ON_ERROR_STOP=1 \
+  < "$FINGERPRINT_SQL" > "$WORKDIR/fingerprint-after.txt" \
+  || die "could not fingerprint the migrated database"
+
+# Row counts come from pg_stat_user_tables, which is populated by ANALYZE and
+# is an estimate on a freshly restored cluster — comparing those would produce
+# false failures. The digests and sequence values are exact, so they are what
+# the comparison is made of.
+grep -vE '^rowcount\|' "$WORKDIR/fingerprint-before.txt" | sort > "$WORKDIR/before.cmp"
+grep -vE '^rowcount\|' "$WORKDIR/fingerprint-after.txt"  | sort > "$WORKDIR/after.cmp"
+
+if ! diff -u "$WORKDIR/before.cmp" "$WORKDIR/after.cmp" > "$WORKDIR/fingerprint.diff"; then
+  cat "$WORKDIR/fingerprint.diff"
+  die "the migrated database does not match the source.
+  The app is still at 0 replicas and the old PVC is intact — nothing is serving
+  bad data. Inspect $WORKDIR, then roll back to the previous chart revision."
+fi
+say "Fingerprints match: every table digest and sequence position is identical"
+
+# --- Prove the DSN the app will actually use -------------------------------
+# Everything above ran as postgres over a local socket. That is not what the
+# app does: it connects over TCP as the CNPG app user, using the URI from the
+# operator-managed Secret. Test that exact path.
+say "Verifying the application DSN"
+APP_SECRET="$(k get cluster "$CLUSTER" -o jsonpath='{.metadata.name}')-app"
+APP_URI="$(k get secret "$APP_SECRET" -o jsonpath='{.data.uri}' 2>/dev/null | base64 -d)"
+[[ -n "$APP_URI" ]] || die "no uri key in Secret $APP_SECRET — the Deployment reads DATABASE_URL from it"
+
+case "$APP_URI" in
+  *"-rw"*|*"-rw."*) : ;;
+  *) die "the app DSN does not point at the -rw Service.
+  NOTIFY does not replicate, so LISTEN on a read Service never fires and
+  cross-instance SSE would go silently dead. Refusing to finish." ;;
+esac
+
+k exec -i "$PRIMARY" -- psql "$APP_URI" -tAc "SELECT 1" >/dev/null \
+  || die "the application DSN cannot connect or authenticate"
+
+# The invariant this whole migration is most likely to break silently.
+# One session LISTENs and NOTIFYs itself; psql prints the asynchronous
+# notification only if the channel genuinely delivered it.
+say "Verifying LISTEN/NOTIFY on the application DSN"
+NOTIFY_OUT="$(k exec -i "$PRIMARY" -- psql "$APP_URI" -tA -c "LISTEN schautrack_events;" -c "SELECT pg_notify('schautrack_events','migration-probe');" -c "SELECT pg_sleep(0.2);" 2>&1 || true)"
+grep -q 'migration-probe' <<<"$NOTIFY_OUT" \
+  || die "LISTEN/NOTIFY did not deliver on the application DSN.
+  Server-Sent Events across app replicas depend on this channel; without it
+  linked-user views stop updating with no error anywhere.
+  psql said: $NOTIFY_OUT"
+say "LISTEN/NOTIFY delivers on the app DSN"
+
+# --- Let traffic back in ---------------------------------------------------
+say "Scaling app back to $REPLICAS (downtime ends)"
+k scale deploy "$RELEASE-schautrack" --replicas="$REPLICAS"
+k rollout status deploy "$RELEASE-schautrack" --timeout=300s || die "app did not become ready"
+
+say "Done."
+cat <<EOF
+
+  Migrated $RELEASE in $NS to CloudNativePG.
+
+  Evidence:   $WORKDIR
+  Rollback:   the old PVC is still there, annotated helm.sh/resource-policy=keep
+
+  Remaining, once you have watched it for a while:
+    1. delete the old PVC
+    2. set replicaCount back in your values file if you passed it on the CLI
+    3. if you run the sql-exporter, repoint its DSN at $CLUSTER-rw
+EOF

--- a/scripts/seed-migration-fixture.sql
+++ b/scripts/seed-migration-fixture.sql
@@ -1,0 +1,60 @@
+-- Fixture for verifying a CloudNativePG migration moved everything, not just
+-- the rows that are easy to move.
+--
+-- Deliberately exercises what a careless dump/restore loses:
+--   * sequence positions (a reset sequence collides on the next INSERT)
+--   * foreign keys across tables restored in the wrong order
+--   * unicode text, jsonb, numeric precision and timestamptz
+--   * a NULL-vs-empty-string distinction a sloppy round-trip flattens
+BEGIN;
+
+INSERT INTO users (email, password_hash, timezone, daily_goal, weight_unit, macros_enabled, macro_goals)
+VALUES
+  ('migrate-a@test.invalid', '$argon2id$v=19$m=65536,t=1,p=2$fake1', 'Europe/Berlin', 2200, 'kg',
+   '{"protein": true, "carbs": true}'::jsonb, '{"protein": 150}'::jsonb),
+  ('migrate-b@test.invalid', '$argon2id$v=19$m=65536,t=1,p=2$fake2', 'America/New_York', 1800, 'lbs',
+   '{}'::jsonb, '{}'::jsonb),
+  ('migrate-ue@test.invalid', '$argon2id$v=19$m=65536,t=1,p=2$fake3', 'Asia/Tokyo', 2000, 'kg',
+   '{"fiber": true}'::jsonb, '{}'::jsonb);
+
+INSERT INTO calorie_entries (user_id, entry_date, amount, entry_name, protein_g, carbs_g, fat_g)
+SELECT u.id,
+       DATE '2026-08-01' + (n || ' days')::interval,
+       400 + n,
+       'Entry ' || n || ' — ümlaut & emoji 🥑',
+       10 + n, 20 + n, 5 + n
+FROM users u
+CROSS JOIN generate_series(1, 40) AS n
+WHERE u.email LIKE 'migrate-%';
+
+INSERT INTO weight_entries (user_id, entry_date, weight, body_fat)
+SELECT u.id, DATE '2026-08-01' + (n || ' days')::interval, 80.5 - (n * 0.1), 18.25 + (n * 0.01)
+FROM users u CROSS JOIN generate_series(1, 20) AS n
+WHERE u.email LIKE 'migrate-%';
+
+INSERT INTO saved_foods (user_id, name, emoji, amount, protein_g, use_count)
+SELECT u.id, 'Saved ' || n, '🍎', 100 * n, 5 * n, n
+FROM users u CROSS JOIN generate_series(1, 12) AS n
+WHERE u.email LIKE 'migrate-%';
+
+INSERT INTO daily_notes (user_id, note_date, content)
+SELECT u.id, DATE '2026-08-10', 'note with '' quote and ünicode'
+FROM users u WHERE u.email = 'migrate-a@test.invalid';
+
+-- NULL vs empty string: a round-trip that coerces one into the other is a bug.
+INSERT INTO daily_notes (user_id, note_date, content)
+SELECT u.id, DATE '2026-08-11', ''
+FROM users u WHERE u.email = 'migrate-b@test.invalid';
+
+-- Link row, so FK ordering matters on restore.
+INSERT INTO account_links (requester_id, target_id, status, requester_label, target_label)
+SELECT a.id, b.id, 'accepted', 'partner', 'me'
+FROM users a, users b
+WHERE a.email = 'migrate-a@test.invalid' AND b.email = 'migrate-b@test.invalid';
+
+INSERT INTO todos (user_id, name, schedule, time_of_day, sort_order)
+SELECT u.id, 'Todo ' || n, '{"days": [1,2,3,4,5]}'::jsonb, 'morning', n
+FROM users u CROSS JOIN generate_series(1, 5) AS n
+WHERE u.email = 'migrate-a@test.invalid';
+
+COMMIT;


### PR DESCRIPTION
The chart now offers **two** PostgreSQL engines, selected with `postgresql.mode`. Both are supported; nothing is removed and nothing is deprecated.

- **`bundled`** (default) — the existing single Pod with a PVC. No operator, nothing else to run. No failover or PITR.
- **`cnpg`** — a CloudNativePG `Cluster`: continuous backup to object storage, PITR, replicas with automatic failover, managed minor-version upgrades.

## Existing installs are untouched — verified, not asserted

`mode` defaults to `bundled`. That is a safety property, not a preference: Helm cannot tell a fresh install from an upgrade, so a default of `cnpg` would move every existing release onto an empty Cluster while its data sat in a PVC nothing mounts.

Rendering the current chart and this one with the same legacy values, pinned to the same chart version, produces **byte-for-byte identical output** — same PVC, Deployment, Service, Secret, and even the same checksum annotations.

An earlier draft tried to *infer* the engine from the values file. It was discarded: a release using a top-level `existingSecret` sets neither `postgresql.auth.password` nor any Deployment-only key, so it would have been read as new and silently migrated. One missed case is one destroyed database.

## The `-rw` invariant

`NOTIFY` does not replicate. A DSN on `-ro`/`-r` reads fine and passes `/api/health`, but `sse.Listen` attaches to a standby and waits on a channel that never fires — cross-instance SSE dies with no error anywhere.

Found while building this: the `wait-for-postgres` init container waited on the bare Cluster name, which CNPG publishes no Service for. It would have hung forever.

## Migration

Switching an existing install is a data migration, not a values change. `scripts/migrate-to-cnpg.sh` fingerprints the source (md5 per table over ordered rows, plus sequence positions), proves the dump is restorable before deleting anything, restores with `--role` so ownership is right by construction, diffs the fingerprints, and verifies `LISTEN`/`NOTIFY` on the app's real DSN before letting traffic back in.

It refuses to run unless the values actually render a Cluster — upgrading with the mode still on `bundled` would rebuild the Deployment on top of the database it just dumped.

## Verification

End-to-end in k3d against a seeded bundled release (CNPG 1.28): fingerprints identical, `LISTEN`/`NOTIFY` confirmed, app healthy afterwards. Bugs found by *running* it rather than reading it: a local `pg_restore` assumption, replicas left at 0 on early failure, an `env:` block spliced into the middle of `envFrom:`, `REASSIGN OWNED BY postgres` being refused for catalog objects, and peer auth rejecting the app role on the pod's local socket.

Five Go invariant tests, each mutation-checked — the first `-ro` test passed on a real violation and was rewritten.

Also fixes the `chart` job that was red on this PR: `kubeconform -strict` had no CNPG CRD schema. Added the CRD catalog as a second schema location rather than `-ignore-missing-schemas`, which would have silenced it by skipping the one resource the chart newly introduces. Both engines validate, **0 skipped**.

## Not done

Not published to any Helm channel. `schautrack-staging` and `schautrack-prod` are ArgoCD Applications with `prune: true` + `selfHeal: true`; `docs/cloudnativepg.md` has the ArgoCD runbook, since `helm.sh/resource-policy=keep` is a Helm annotation ArgoCD does not honour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhPLVD9yn32Hrag8pPfZbt